### PR TITLE
feat(recovery): persist managed provider version observations

### DIFF
--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -441,14 +441,84 @@ successor association.
 This adapter qualification uses MinIO and does not establish AWS or other
 S3-compatible provider behavior. Its trusted endpoint identity is deliberately
 separate from the disposable MinIO transport endpoint, so it does not qualify
-TLS, redirect, or endpoint-discovery behavior. It makes no retention or lifecycle guarantee and does
-not capture provider VersionIDs at managed-data write time; retention and a
-durable write-time observation binding remain separate prerequisites. It does
-not add recovery admission, publication, or startup/readiness behavior. It does
-not perform PostgreSQL restore or PITR, activation, or provider disaster
-recovery, and it makes no physical DR, RPO, or RTO claim.
+TLS, redirect, or endpoint-discovery behavior. It makes no retention or lifecycle
+guarantee. Write-time capture is qualified below, but durable association and
+signed Manifest v2 creation remain separate prerequisites. It does not add
+recovery admission, publication, or startup/readiness behavior. It does not
+perform PostgreSQL restore or PITR, activation, or provider disaster recovery,
+and it makes no physical DR, RPO, or RTO claim.
 
 This validates historical managed-object retrieval. It does not prove successful physical disaster recovery.
+
+## Write-time S3 VersionID capture
+
+The managed-data S3 store now has an opt-in trusted observation profile. When
+that profile is configured, a successful ordinary `PutObject` or multipart
+`CompleteMultipartUpload` must return a nonempty exact `VersionID`. The store
+retains that value directly from the write response, verifies the same exact
+version by key, size, and SHA-256 bytes, and returns a provider-version
+observation beside the immutable blob result. It never discovers or replaces
+the captured identity with a later `HeadObject` of the latest object.
+
+The observation binds the trusted profile identity, implementation, account,
+endpoint, region, bucket and namespace to the exact key/version, content digest,
+size, and UTC capture time. Construction rejects a profile whose bucket or
+namespace differs from the store. Missing, `null`, or `latest` response versions
+fail closed when capture is enabled; failed provider writes and failed exact-byte
+verification return no observation. Provider failures remain sanitized by the
+existing storage boundary.
+
+`ProviderVersionObservationSet` is a bounded in-process handoff helper, not a
+database or recovery manifest. It makes identical observation retries
+idempotent, rejects replacement of the first observation for one profile/object
+identity, rejects one profile identity resolving to conflicting trusted
+configuration, and rejects conflicting version, digest, size, or capture metadata.
+Distinct content-addressed object keys retain distinct observations. Qualification now takes managed object
+VersionIDs from the production write result rather than inferring them with a
+post-write latest-object HEAD. Ordinary and multipart response handling share
+the same exact-version and integrity checks.
+
+An exact retry may reuse an observation already returned by this writer and is
+reverified at that exact version. When capture is enabled, finding an existing
+object without such a prior write observation fails closed; the store does not
+turn a latest-object HEAD into replacement evidence. Multipart reconciliation
+likewise cannot convert an ambiguous preexisting completion into an observation.
+
+This slice does not configure capture authority in production, create or sign
+ManagedObservationManifest v2, enforce provider
+retention, or connect evidence to admission, publication, startup, restore, PITR,
+RPO, or RTO. Those remain explicit later gates.
+
+This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+
+## Captured provider-version observation persistence
+
+The managed-data PostgreSQL owner now provides the durable handoff between an
+exact S3 write response and a future recovery capture. Trusted profile
+configuration is inserted once by profile identity; each profile/object key then
+accepts exactly one provider `VersionID`, SHA-256 digest, size, and canonical UTC
+capture timestamp. The runtime capability may only select and insert these rows.
+Update and delete paths are denied and owner-side triggers reject mutation;
+maintenance, read-only, and backup capabilities can inspect but cannot insert or
+rewrite observations.
+
+The transaction starts only after S3 has completed and the storage adapter has
+verified the returned exact version and bytes. It atomically inserts or compares
+the profile and observation. Identical retries return the immutable stored row;
+any profile, version, digest, size, key, or capture-time conflict fails without a
+partial profile/observation pair. A reconnect reloads all fields and reruns the
+storage contract validator, rather than trusting a cached verification flag.
+
+There is deliberately no distributed transaction with S3. A provider write may
+exist when PostgreSQL persistence fails, but that object is not a durable recovery
+observation until this transaction commits. Retry must carry the exact observation
+already returned by the write; latest-object discovery remains forbidden. Capture
+generation and signing fences belong to the later authority/Manifest v2 phase and
+are not fabricated at this write-fact boundary.
+
+Durable observation storage does not itself create signed Manifest v2 evidence.
+
+This validates recovery evidence binding. It does not prove successful physical disaster recovery.
 
 ## Proposed managed observation manifest contract
 

--- a/internal/app/integration_routing_test.go
+++ b/internal/app/integration_routing_test.go
@@ -28,13 +28,14 @@ func TestCommandPatchesAreScopedToClientAndPage(t *testing.T) {
 func TestUpdatesQueryParamsTakePrecedenceOverRuntimeSignalIDs(t *testing.T) {
 	h := newHarness(t)
 
-	patches := h.getUpdatesSignals(t, "executive-sales", "overview", map[string]any{
+	// This full-runtime stream needs the longer budget when merge-queue contention delays patch publication.
+	patches := h.getUpdatesSignalsWithQueryTimeout(t, "executive-sales", "overview", map[string]any{
 		"runtime": map[string]any{
 			"clientId":    "route-precedence",
 			"dashboardId": "executive-sales",
 			"pageId":      "missing",
 		},
-	})
+	}, nil, time.Second)
 
 	requireVisual(t, patches, "orders")
 	requireTable(t, patches, "order_rows")

--- a/internal/manageddata/postgres/provider_version_observation.go
+++ b/internal/manageddata/postgres/provider_version_observation.go
@@ -1,0 +1,121 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	manageddb "github.com/flidai/leapview/internal/manageddata/postgres/internal/db"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// RecordProviderVersionObservation persists the exact provider response from a
+// successful managed-data write. The observation remains an unsigned input to
+// a future recovery capture; recording it does not create Manifest v2 evidence.
+func (r *Repository) RecordProviderVersionObservation(ctx context.Context, observation storage.ProviderVersionObservation) (storage.ProviderVersionObservation, error) {
+	if err := storage.ValidateProviderVersionObservation(observation); err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	tx, owned, err := r.beginTransition(ctx)
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	if owned {
+		defer func() { _ = tx.Rollback(context.Background()) }()
+	}
+	stored, err := recordProviderVersionObservation(ctx, tx, observation)
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	if owned {
+		if err := tx.Commit(ctx); err != nil {
+			return storage.ProviderVersionObservation{}, err
+		}
+	}
+	return stored, nil
+}
+
+// ProviderVersionObservation loads one immutable observation by its logical
+// provider object identity and validates every stored field again.
+func (r *Repository) ProviderVersionObservation(ctx context.Context, profileID, objectKey string) (storage.ProviderVersionObservation, error) {
+	db, err := requireDB(r)
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	return readProviderVersionObservation(ctx, db, profileID, objectKey)
+}
+
+func recordProviderVersionObservation(ctx context.Context, db DBTX, observation storage.ProviderVersionObservation) (storage.ProviderVersionObservation, error) {
+	queries := manageddb.New(db)
+	profile := observation.Profile
+	if err := queries.InsertProviderObservationProfile(ctx, manageddb.InsertProviderObservationProfileParams{
+		ProfileID: profile.ProfileID, Implementation: profile.Implementation,
+		AccountIdentity: profile.AccountIdentity, Endpoint: profile.Endpoint,
+		Region: profile.Region, Bucket: profile.Bucket, Namespace: profile.Namespace,
+	}); err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	storedProfile, err := queries.GetProviderObservationProfile(ctx, profile.ProfileID)
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	if (storage.ProviderProfileIdentity{
+		ProfileID: storedProfile.ProfileID, Implementation: storedProfile.Implementation,
+		AccountIdentity: storedProfile.AccountIdentity, Endpoint: storedProfile.Endpoint,
+		Region: storedProfile.Region, Bucket: storedProfile.Bucket, Namespace: storedProfile.Namespace,
+	}) != profile {
+		return storage.ProviderVersionObservation{}, fmt.Errorf("%w: provider profile identity resolves to different configuration", storage.ErrObservationConflict)
+	}
+	if err := queries.InsertProviderVersionObservation(ctx, manageddb.InsertProviderVersionObservationParams{
+		ProfileID: profile.ProfileID, ObjectKey: observation.ObjectKey,
+		VersionID: observation.VersionID, Sha256: observation.SHA256, SizeBytes: observation.Size,
+		CapturedAt: pgtype.Timestamptz{Time: observation.CapturedAt, Valid: true},
+	}); err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	stored, err := readProviderVersionObservation(ctx, db, profile.ProfileID, observation.ObjectKey)
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	if !sameProviderVersionObservation(stored, observation) {
+		return storage.ProviderVersionObservation{}, fmt.Errorf("%w: provider object identity already has different immutable metadata", storage.ErrObservationConflict)
+	}
+	return stored, nil
+}
+
+func readProviderVersionObservation(ctx context.Context, db DBTX, profileID, objectKey string) (storage.ProviderVersionObservation, error) {
+	if profileID == "" || objectKey == "" {
+		return storage.ProviderVersionObservation{}, storage.ErrProviderVersion
+	}
+	row, err := manageddb.New(db).GetProviderVersionObservation(ctx, manageddb.GetProviderVersionObservationParams{ProfileID: profileID, ObjectKey: objectKey})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return storage.ProviderVersionObservation{}, ErrNotFound
+	}
+	if err != nil {
+		return storage.ProviderVersionObservation{}, err
+	}
+	if !row.CapturedAt.Valid {
+		return storage.ProviderVersionObservation{}, fmt.Errorf("%w: stored capture timestamp is missing", storage.ErrProviderVersion)
+	}
+	observation := storage.ProviderVersionObservation{
+		Profile: storage.ProviderProfileIdentity{
+			ProfileID: row.ProfileID, Implementation: row.Implementation,
+			AccountIdentity: row.AccountIdentity, Endpoint: row.Endpoint,
+			Region: row.Region, Bucket: row.Bucket, Namespace: row.Namespace,
+		},
+		ObjectKey: row.ObjectKey, VersionID: row.VersionID, SHA256: row.Sha256,
+		Size: row.SizeBytes, CapturedAt: row.CapturedAt.Time.UTC(),
+	}
+	if err := storage.ValidateProviderVersionObservation(observation); err != nil {
+		return storage.ProviderVersionObservation{}, fmt.Errorf("stored provider-version observation: %w", err)
+	}
+	return observation, nil
+}
+
+func sameProviderVersionObservation(left, right storage.ProviderVersionObservation) bool {
+	return left.Profile == right.Profile && left.ObjectKey == right.ObjectKey &&
+		left.VersionID == right.VersionID && left.SHA256 == right.SHA256 &&
+		left.Size == right.Size && left.CapturedAt.Equal(right.CapturedAt)
+}

--- a/internal/manageddata/postgres/provider_version_observation_test.go
+++ b/internal/manageddata/postgres/provider_version_observation_test.go
@@ -1,0 +1,177 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+func TestProviderVersionObservationPersistenceQualification(t *testing.T) {
+	pool, _, _, _ := openManagedDataTestPool(t)
+	repository := New(pool)
+
+	t.Run("insert retry conflicts and malformed input", func(t *testing.T) {
+		observation := persistedProviderObservation("profile-persistence", "project-a/objects/a", "version-a")
+		first, err := repository.RecordProviderVersionObservation(t.Context(), observation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err := repository.RecordProviderVersionObservation(t.Context(), observation)
+		if err != nil {
+			t.Fatalf("identical retry: %v", err)
+		}
+		if !sameProviderVersionObservation(first, observation) || !sameProviderVersionObservation(second, observation) {
+			t.Fatalf("persisted observations differ: first=%#v second=%#v", first, second)
+		}
+
+		for name, mutate := range map[string]func(*storage.ProviderVersionObservation){
+			"version": func(candidate *storage.ProviderVersionObservation) { candidate.VersionID = "version-conflict" },
+			"digest":  func(candidate *storage.ProviderVersionObservation) { candidate.SHA256 = strings.Repeat("b", 64) },
+			"profile": func(candidate *storage.ProviderVersionObservation) { candidate.Profile.Bucket = "different-bucket" },
+		} {
+			t.Run("conflicting "+name, func(t *testing.T) {
+				candidate := observation
+				mutate(&candidate)
+				if _, err := repository.RecordProviderVersionObservation(t.Context(), candidate); !errors.Is(err, storage.ErrObservationConflict) {
+					t.Fatalf("conflict error = %v", err)
+				}
+				stored, err := repository.ProviderVersionObservation(t.Context(), observation.Profile.ProfileID, observation.ObjectKey)
+				if err != nil || !sameProviderVersionObservation(stored, observation) {
+					t.Fatalf("conflict replaced winner: stored=%#v err=%v", stored, err)
+				}
+			})
+		}
+
+		malformed := observation
+		malformed.ObjectKey = ""
+		if _, err := repository.RecordProviderVersionObservation(t.Context(), malformed); !errors.Is(err, storage.ErrProviderVersion) {
+			t.Fatalf("malformed observation error = %v", err)
+		}
+	})
+
+	t.Run("caller transaction rollback leaves no partial record", func(t *testing.T) {
+		observation := persistedProviderObservation("profile-rollback", "project-a/objects/rollback", "version-rollback")
+		tx, err := pool.Begin(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := repository.WithTx(tx).RecordProviderVersionObservation(t.Context(), observation); err != nil {
+			_ = tx.Rollback(t.Context())
+			t.Fatal(err)
+		}
+		if err := tx.Rollback(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := repository.ProviderVersionObservation(t.Context(), observation.Profile.ProfileID, observation.ObjectKey); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("rolled-back observation read = %v", err)
+		}
+		var profiles int
+		if err := pool.QueryRow(t.Context(), `SELECT count(*) FROM managed_data.provider_observation_profile WHERE profile_id=$1`, observation.Profile.ProfileID).Scan(&profiles); err != nil {
+			t.Fatal(err)
+		}
+		if profiles != 0 {
+			t.Fatalf("rollback left %d provider profile rows", profiles)
+		}
+	})
+
+	t.Run("concurrent identical and conflicting inserts", func(t *testing.T) {
+		identical := persistedProviderObservation("profile-concurrent-identical", "project-a/objects/identical", "version-identical")
+		errs := concurrentlyRecordProviderObservations(t, repository, []storage.ProviderVersionObservation{identical, identical, identical, identical})
+		for _, err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent identical insert = %v", err)
+			}
+		}
+
+		left := persistedProviderObservation("profile-concurrent-conflict", "project-a/objects/conflict", "version-left")
+		right := left
+		right.VersionID = "version-right"
+		right.CapturedAt = right.CapturedAt.Add(time.Microsecond)
+		errs = concurrentlyRecordProviderObservations(t, repository, []storage.ProviderVersionObservation{left, right})
+		var succeeded, conflicted int
+		for _, err := range errs {
+			switch {
+			case err == nil:
+				succeeded++
+			case errors.Is(err, storage.ErrObservationConflict):
+				conflicted++
+			default:
+				t.Fatalf("concurrent conflict error = %v", err)
+			}
+		}
+		if succeeded != 1 || conflicted != 1 {
+			t.Fatalf("concurrent conflict outcomes succeeded=%d conflicted=%d", succeeded, conflicted)
+		}
+		stored, err := repository.ProviderVersionObservation(t.Context(), left.Profile.ProfileID, left.ObjectKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sameProviderVersionObservation(stored, left) && !sameProviderVersionObservation(stored, right) {
+			t.Fatalf("concurrent winner is corrupted: %#v", stored)
+		}
+	})
+
+	t.Run("database mutation is blocked", func(t *testing.T) {
+		observation := persistedProviderObservation("profile-immutable", "project-a/objects/immutable", "version-immutable")
+		if _, err := repository.RecordProviderVersionObservation(t.Context(), observation); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(t.Context(), `UPDATE managed_data.provider_version_observation SET version_id='replacement' WHERE profile_id=$1 AND object_key=$2`, observation.Profile.ProfileID, observation.ObjectKey); err == nil {
+			t.Fatal("runtime role updated an immutable observation")
+		}
+	})
+
+	t.Run("restart readback", func(t *testing.T) {
+		observation := persistedProviderObservation("profile-restart", "project-a/objects/restart", "version-restart")
+		if _, err := repository.RecordProviderVersionObservation(t.Context(), observation); err != nil {
+			t.Fatal(err)
+		}
+		connectionString := pool.Config().ConnString()
+		pool.Close()
+		reopened, err := pgxpool.New(t.Context(), connectionString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(reopened.Close)
+		stored, err := New(reopened).ProviderVersionObservation(t.Context(), observation.Profile.ProfileID, observation.ObjectKey)
+		if err != nil || !sameProviderVersionObservation(stored, observation) {
+			t.Fatalf("restart readback: stored=%#v err=%v", stored, err)
+		}
+	})
+}
+
+func persistedProviderObservation(profileID, objectKey, versionID string) storage.ProviderVersionObservation {
+	return storage.ProviderVersionObservation{
+		Profile: storage.ProviderProfileIdentity{
+			ProfileID: profileID, Implementation: "s3", AccountIdentity: "qualification-account",
+			Endpoint: "https://s3.example.test", Region: "test-region-1", Bucket: "qualification-bucket", Namespace: "project-a",
+		},
+		ObjectKey: objectKey, VersionID: versionID, SHA256: strings.Repeat("a", 64), Size: 123,
+		CapturedAt: time.Date(2026, 9, 10, 10, 0, 0, 123000, time.UTC),
+	}
+}
+
+func concurrentlyRecordProviderObservations(t *testing.T, repository *Repository, observations []storage.ProviderVersionObservation) []error {
+	t.Helper()
+	start := make(chan struct{})
+	errs := make([]error, len(observations))
+	var group sync.WaitGroup
+	for index, observation := range observations {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			_, errs[index] = repository.RecordProviderVersionObservation(context.Background(), observation)
+		}()
+	}
+	close(start)
+	group.Wait()
+	return errs
+}

--- a/internal/manageddata/postgres/queries/manageddata.sql
+++ b/internal/manageddata/postgres/queries/manageddata.sql
@@ -1,6 +1,33 @@
 -- Managed-data PostgreSQL leaf queries. Repository methods retain validation,
 -- domain mapping, transaction ownership, and cross-store orchestration.
 
+-- name: InsertProviderObservationProfile :exec
+INSERT INTO managed_data.provider_observation_profile
+    (profile_id, implementation, account_identity, endpoint, region, bucket, namespace)
+VALUES (sqlc.arg(profile_id), sqlc.arg(implementation), sqlc.arg(account_identity),
+        sqlc.arg(endpoint), sqlc.arg(region), sqlc.arg(bucket), sqlc.arg(namespace))
+ON CONFLICT (profile_id) DO NOTHING;
+
+-- name: GetProviderObservationProfile :one
+SELECT profile_id, implementation, account_identity, endpoint, region, bucket, namespace
+FROM managed_data.provider_observation_profile
+WHERE profile_id = sqlc.arg(profile_id);
+
+-- name: InsertProviderVersionObservation :exec
+INSERT INTO managed_data.provider_version_observation
+    (profile_id, object_key, version_id, sha256, size_bytes, captured_at)
+VALUES (sqlc.arg(profile_id), sqlc.arg(object_key), sqlc.arg(version_id),
+        sqlc.arg(sha256), sqlc.arg(size_bytes), sqlc.arg(captured_at))
+ON CONFLICT (profile_id, object_key) DO NOTHING;
+
+-- name: GetProviderVersionObservation :one
+SELECT p.profile_id, p.implementation, p.account_identity, p.endpoint, p.region,
+       p.bucket, p.namespace, o.object_key, o.version_id, o.sha256,
+       o.size_bytes, o.captured_at
+FROM managed_data.provider_version_observation AS o
+JOIN managed_data.provider_observation_profile AS p USING (profile_id)
+WHERE o.profile_id = sqlc.arg(profile_id) AND o.object_key = sqlc.arg(object_key);
+
 -- name: InsertCollection :exec
 INSERT INTO managed_data.collection
     (collection_id, project_id, connection_id, name, description, created_by, request_digest)

--- a/internal/manageddata/postgres/schema.sql
+++ b/internal/manageddata/postgres/schema.sql
@@ -376,6 +376,52 @@ CREATE TABLE IF NOT EXISTS managed_data.reconciliation_evidence (
     CHECK (jsonb_typeof(evidence) = 'object' AND evidence <> '{}'::jsonb AND octet_length(evidence::text) <= 65536)
 );
 
+-- Provider profiles and exact write observations are an append-only handoff
+-- from managed-data storage to a future recovery capture. They are not a
+-- Manifest v2, a signed receipt, or recovery admission state.
+CREATE TABLE IF NOT EXISTS managed_data.provider_observation_profile (
+    profile_id text PRIMARY KEY,
+    implementation text NOT NULL CHECK (implementation = 's3'),
+    account_identity text NOT NULL,
+    endpoint text NOT NULL,
+    region text NOT NULL,
+    bucket text NOT NULL,
+    namespace text NOT NULL,
+    recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    CHECK (profile_id = btrim(profile_id) AND octet_length(profile_id) BETWEEN 1 AND 4096),
+    CHECK (account_identity = btrim(account_identity) AND octet_length(account_identity) BETWEEN 1 AND 4096),
+    CHECK (endpoint = btrim(endpoint) AND octet_length(endpoint) BETWEEN 1 AND 4096),
+    CHECK (region = btrim(region) AND octet_length(region) BETWEEN 1 AND 4096),
+    CHECK (bucket = btrim(bucket) AND octet_length(bucket) BETWEEN 1 AND 4096),
+    CHECK (namespace = btrim(namespace) AND octet_length(namespace) <= 4096)
+);
+
+CREATE TABLE IF NOT EXISTS managed_data.provider_version_observation (
+    profile_id text NOT NULL REFERENCES managed_data.provider_observation_profile(profile_id) ON DELETE RESTRICT,
+    object_key text NOT NULL,
+    version_id text NOT NULL,
+    sha256 text NOT NULL,
+    size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+    captured_at timestamptz NOT NULL,
+    recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (profile_id, object_key),
+    CHECK (object_key = btrim(object_key) AND octet_length(object_key) BETWEEN 1 AND 4096),
+    CHECK (version_id = btrim(version_id) AND octet_length(version_id) BETWEEN 1 AND 4096 AND lower(version_id) NOT IN ('latest', 'null')),
+    CHECK (sha256 ~ '^[0-9a-f]{64}$')
+);
+
+CREATE OR REPLACE FUNCTION managed_data.reject_provider_observation_mutation() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, managed_data
+AS $$
+BEGIN
+  RAISE EXCEPTION 'provider-version observations are immutable';
+END $$;
+DROP TRIGGER IF EXISTS provider_observation_profile_immutable ON managed_data.provider_observation_profile;
+CREATE TRIGGER provider_observation_profile_immutable BEFORE UPDATE OR DELETE ON managed_data.provider_observation_profile FOR EACH ROW EXECUTE FUNCTION managed_data.reject_provider_observation_mutation();
+DROP TRIGGER IF EXISTS provider_version_observation_immutable ON managed_data.provider_version_observation;
+CREATE TRIGGER provider_version_observation_immutable BEFORE UPDATE OR DELETE ON managed_data.provider_version_observation FOR EACH ROW EXECUTE FUNCTION managed_data.reject_provider_observation_mutation();
+
 CREATE OR REPLACE FUNCTION managed_data.guard_retention_root_insert() RETURNS trigger
 LANGUAGE plpgsql
 SET search_path = pg_catalog, managed_data
@@ -871,14 +917,16 @@ BEGIN
         EXECUTE 'GRANT SELECT, INSERT, UPDATE ON managed_data.revision TO leapview_control_runtime';
         EXECUTE 'GRANT SELECT, INSERT, UPDATE ON managed_data.lease, managed_data.retention_root TO leapview_control_runtime';
         EXECUTE 'GRANT SELECT, INSERT ON managed_data.reconciliation_evidence TO leapview_control_runtime';
+        EXECUTE 'GRANT SELECT, INSERT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_runtime';
         EXECUTE 'GRANT SELECT ON managed_data.reachability_epoch TO leapview_control_runtime';
         EXECUTE 'GRANT USAGE ON ALL SEQUENCES IN SCHEMA managed_data TO leapview_control_runtime';
         EXECUTE 'GRANT EXECUTE ON FUNCTION managed_data.publish_binding_set(text,text,text,text,bigint,jsonb) TO leapview_control_runtime';
       ELSIF r = 'leapview_control_maintenance' THEN
+        EXECUTE 'GRANT SELECT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_maintenance';
         EXECUTE 'GRANT EXECUTE ON FUNCTION managed_data.mark_upload_cleanup(text) TO leapview_control_maintenance';
         EXECUTE 'GRANT EXECUTE ON FUNCTION managed_data.prune_upload_sessions(timestamptz, integer) TO leapview_control_maintenance';
       ELSIF r = 'leapview_control_readonly' THEN
-        EXECUTE 'GRANT SELECT ON managed_data.collection, managed_data.revision, managed_data.revision_file, managed_data.upload_session, managed_data.binding_set, managed_data.binding, managed_data.retention_root, managed_data.reconciliation_evidence, managed_data.reachability_epoch TO leapview_control_readonly';
+        EXECUTE 'GRANT SELECT ON managed_data.collection, managed_data.revision, managed_data.revision_file, managed_data.upload_session, managed_data.binding_set, managed_data.binding, managed_data.retention_root, managed_data.reconciliation_evidence, managed_data.reachability_epoch, managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_readonly';
       ELSE
         EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA managed_data TO leapview_control_backup';
       END IF;

--- a/internal/manageddata/storage/provider_version.go
+++ b/internal/manageddata/storage/provider_version.go
@@ -1,0 +1,178 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+var (
+	ErrProviderVersion     = errors.New("provider version observation is invalid")
+	ErrObservationConflict = errors.New("provider version observation conflicts")
+)
+
+const (
+	maxProviderObservationText     = 4096
+	MaxProviderVersionObservations = 10_000
+)
+
+// ProviderProfileIdentity is trusted configuration for the provider write
+// boundary. It deliberately contains no credentials. ProfileID is an opaque
+// identity selected by configuration; the remaining fields bind that identity
+// to the physical S3 namespace used by the writer.
+type ProviderProfileIdentity struct {
+	ProfileID       string
+	Implementation  string
+	AccountIdentity string
+	Endpoint        string
+	Region          string
+	Bucket          string
+	Namespace       string
+}
+
+// ProviderVersionObservation records facts returned by one successful provider
+// write. SHA256 and Size describe the bytes written; VersionID is authoritative
+// only because it came from that write response.
+type ProviderVersionObservation struct {
+	Profile    ProviderProfileIdentity
+	ObjectKey  string
+	VersionID  string
+	SHA256     string
+	Size       int64
+	CapturedAt time.Time
+}
+
+func ValidateProviderProfileIdentity(profile ProviderProfileIdentity) error {
+	fields := []struct{ label, value string }{
+		{"profile ID", profile.ProfileID}, {"implementation", profile.Implementation},
+		{"account identity", profile.AccountIdentity}, {"endpoint", profile.Endpoint},
+		{"region", profile.Region}, {"bucket", profile.Bucket},
+	}
+	for _, field := range fields {
+		if err := validateProviderObservationText(field.value, field.label); err != nil {
+			return err
+		}
+	}
+	if profile.Implementation != "s3" {
+		return fmt.Errorf("%w: provider implementation must be s3", ErrProviderVersion)
+	}
+	parsed, err := url.Parse(profile.Endpoint)
+	if err != nil || !parsed.IsAbs() || parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" {
+		return fmt.Errorf("%w: provider endpoint is not a credential-free absolute URL", ErrProviderVersion)
+	}
+	if profile.Namespace != "" {
+		if err := validateProviderObservationText(profile.Namespace, "namespace"); err != nil {
+			return err
+		}
+		if strings.HasPrefix(profile.Namespace, "/") || strings.HasSuffix(profile.Namespace, "/") {
+			return fmt.Errorf("%w: provider namespace must not start or end with slash", ErrProviderVersion)
+		}
+	}
+	return nil
+}
+
+func ValidateProviderVersionObservation(observation ProviderVersionObservation) error {
+	if err := ValidateProviderProfileIdentity(observation.Profile); err != nil {
+		return err
+	}
+	if err := validateProviderObservationText(observation.ObjectKey, "object key"); err != nil {
+		return err
+	}
+	if observation.Profile.Namespace != "" && !strings.HasPrefix(observation.ObjectKey, observation.Profile.Namespace+"/") {
+		return fmt.Errorf("%w: object key is outside provider namespace", ErrProviderVersion)
+	}
+	if err := ValidateProviderVersionID(observation.VersionID); err != nil {
+		return err
+	}
+	if err := ValidateBlob(Blob{SHA256: observation.SHA256, Size: observation.Size}); err != nil {
+		return fmt.Errorf("%w: %v", ErrProviderVersion, err)
+	}
+	if observation.CapturedAt.IsZero() || observation.CapturedAt.Location() != time.UTC || observation.CapturedAt.Nanosecond()%1_000 != 0 {
+		return fmt.Errorf("%w: capture timestamp must be nonzero UTC at microsecond precision", ErrProviderVersion)
+	}
+	return nil
+}
+
+func ValidateProviderVersionID(versionID string) error {
+	if err := validateProviderObservationText(versionID, "version ID"); err != nil {
+		return err
+	}
+	if strings.EqualFold(versionID, "null") || strings.EqualFold(versionID, "latest") {
+		return fmt.Errorf("%w: version ID must identify an exact immutable version", ErrProviderVersion)
+	}
+	return nil
+}
+
+func validateProviderObservationText(value, label string) error {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > maxProviderObservationText || !utf8.ValidString(value) {
+		return fmt.Errorf("%w: %s is not canonical", ErrProviderVersion, label)
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%w: %s contains control characters", ErrProviderVersion, label)
+		}
+	}
+	return nil
+}
+
+// ProviderVersionObservationSet is a bounded handoff helper for a single
+// capture. It proves exact retries are idempotent and conflicting observations
+// cannot replace an accepted provider version. It is not durable storage and
+// does not create a recovery manifest.
+type ProviderVersionObservationSet struct {
+	mu       sync.RWMutex
+	profiles map[string]ProviderProfileIdentity
+	objects  map[string]ProviderVersionObservation
+}
+
+func (s *ProviderVersionObservationSet) Add(observation ProviderVersionObservation) error {
+	if err := ValidateProviderVersionObservation(observation); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.profiles == nil {
+		s.profiles = make(map[string]ProviderProfileIdentity)
+		s.objects = make(map[string]ProviderVersionObservation)
+	}
+	if existing, ok := s.profiles[observation.Profile.ProfileID]; ok && existing != observation.Profile {
+		return fmt.Errorf("%w: provider profile identity resolves to different configuration", ErrObservationConflict)
+	}
+	s.profiles[observation.Profile.ProfileID] = observation.Profile
+	key := providerObservationObjectIdentity(observation)
+	if existing, ok := s.objects[key]; ok {
+		if existing != observation {
+			return fmt.Errorf("%w: provider object identity already has different immutable metadata", ErrObservationConflict)
+		}
+		return nil
+	}
+	if len(s.objects) >= MaxProviderVersionObservations {
+		return fmt.Errorf("%w: observation count exceeds %d", ErrProviderVersion, MaxProviderVersionObservations)
+	}
+	s.objects[key] = observation
+	return nil
+}
+
+func (s *ProviderVersionObservationSet) Snapshot() []ProviderVersionObservation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]ProviderVersionObservation, 0, len(s.objects))
+	for _, observation := range s.objects {
+		result = append(result, observation)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := providerObservationObjectIdentity(result[i]), providerObservationObjectIdentity(result[j])
+		return left < right
+	})
+	return result
+}
+
+func providerObservationObjectIdentity(observation ProviderVersionObservation) string {
+	p := observation.Profile
+	return p.ProfileID + "\x00" + observation.ObjectKey
+}

--- a/internal/manageddata/storage/provider_version_test.go
+++ b/internal/manageddata/storage/provider_version_test.go
@@ -1,0 +1,125 @@
+package storage_test
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata/storage"
+)
+
+func TestProviderVersionObservationSetIsIdempotentAndRejectsConflicts(t *testing.T) {
+	observedAt := time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC)
+	observation := providerObservation(observedAt)
+	var set storage.ProviderVersionObservationSet
+	if err := set.Add(observation); err != nil {
+		t.Fatal(err)
+	}
+	if err := set.Add(observation); err != nil {
+		t.Fatalf("identical retry = %v", err)
+	}
+	if got := set.Snapshot(); len(got) != 1 || got[0] != observation {
+		t.Fatalf("snapshot = %#v", got)
+	}
+
+	changedBytes := observation
+	changedBytes.SHA256 = strings.Repeat("b", 64)
+	if err := set.Add(changedBytes); !errors.Is(err, storage.ErrObservationConflict) {
+		t.Fatalf("changed byte identity error = %v", err)
+	}
+	changedProfile := observation
+	changedProfile.Profile.Bucket = "other-bucket"
+	if err := set.Add(changedProfile); !errors.Is(err, storage.ErrObservationConflict) {
+		t.Fatalf("changed profile identity error = %v", err)
+	}
+	if got := set.Snapshot(); len(got) != 1 || got[0] != observation {
+		t.Fatalf("conflict replaced winner: %#v", got)
+	}
+}
+
+func TestProviderVersionObservationSetConcurrentIdenticalRetries(t *testing.T) {
+	observation := providerObservation(time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC))
+	var set storage.ProviderVersionObservationSet
+	start := make(chan struct{})
+	errs := make(chan error, 32)
+	var workers sync.WaitGroup
+	for range 32 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			errs <- set.Add(observation)
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent identical retry = %v", err)
+		}
+	}
+	if got := set.Snapshot(); len(got) != 1 || got[0] != observation {
+		t.Fatalf("snapshot = %#v", got)
+	}
+}
+
+func TestProviderVersionObservationSetRejectsVersionReplacement(t *testing.T) {
+	first := providerObservation(time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC))
+	second := first
+	second.VersionID = "provider-version-2"
+	second.CapturedAt = first.CapturedAt.Add(time.Second)
+	var set storage.ProviderVersionObservationSet
+	if err := set.Add(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := set.Add(second); !errors.Is(err, storage.ErrObservationConflict) {
+		t.Fatalf("version replacement error = %v", err)
+	}
+	got := set.Snapshot()
+	if len(got) != 1 || got[0] != first {
+		t.Fatalf("version conflict replaced winner = %#v", got)
+	}
+}
+
+func TestProviderVersionObservationValidationFailsClosed(t *testing.T) {
+	valid := providerObservation(time.Date(2026, 9, 10, 8, 0, 0, 0, time.UTC))
+	tests := []struct {
+		name   string
+		mutate func(*storage.ProviderVersionObservation)
+	}{
+		{name: "missing version", mutate: func(o *storage.ProviderVersionObservation) { o.VersionID = "" }},
+		{name: "latest version", mutate: func(o *storage.ProviderVersionObservation) { o.VersionID = "latest" }},
+		{name: "wrong namespace", mutate: func(o *storage.ProviderVersionObservation) { o.ObjectKey = "other/key" }},
+		{name: "invalid digest", mutate: func(o *storage.ProviderVersionObservation) { o.SHA256 = "bad" }},
+		{name: "invalid size", mutate: func(o *storage.ProviderVersionObservation) { o.Size = -1 }},
+		{name: "local timestamp", mutate: func(o *storage.ProviderVersionObservation) {
+			o.CapturedAt = time.Date(2026, 9, 10, 8, 0, 0, 0, time.FixedZone("other", 3600))
+		}},
+		{name: "sub-microsecond timestamp", mutate: func(o *storage.ProviderVersionObservation) {
+			o.CapturedAt = time.Date(2026, 9, 10, 8, 0, 0, 1, time.UTC)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation := valid
+			test.mutate(&observation)
+			if err := storage.ValidateProviderVersionObservation(observation); !errors.Is(err, storage.ErrProviderVersion) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func providerObservation(capturedAt time.Time) storage.ProviderVersionObservation {
+	return storage.ProviderVersionObservation{
+		Profile: storage.ProviderProfileIdentity{
+			ProfileID: "managed-source-profile", Implementation: "s3", AccountIdentity: "qualification",
+			Endpoint: "https://s3.example.test", Region: "test-region-1", Bucket: "managed-data", Namespace: "project-a",
+		},
+		ObjectKey: "project-a/blobs/sha256/aa/" + strings.Repeat("a", 64), VersionID: "provider-version-1",
+		SHA256: strings.Repeat("a", 64), Size: 10, CapturedAt: capturedAt,
+	}
+}

--- a/internal/manageddata/storage/s3/provider_binding_qualification_test.go
+++ b/internal/manageddata/storage/s3/provider_binding_qualification_test.go
@@ -5,6 +5,7 @@ package s3_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"maps"
 	"os"
 	"path/filepath"
@@ -45,7 +46,11 @@ func TestFAI520ManagedProviderBindingObservationReplay(t *testing.T) {
 	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
 	ctx, client, _, bucket, endpoint := historicalProvider(t)
 	repo := closureRepository(t)
-	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{Bucket: bucket, Prefix: "project-a"})
+	profile := storage.ProviderProfileIdentity{
+		ProfileID: "managed-source-minio-qualification", Implementation: "s3", AccountIdentity: "qualification",
+		Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Namespace: "project-a",
+	}
+	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{Bucket: bucket, Prefix: "project-a", ObservationProfile: &profile, ObservationRecorder: repo})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,6 +72,7 @@ func TestFAI520ManagedProviderBindingObservationReplay(t *testing.T) {
 	stored := make([]manageddata.StoredFile, 0, len(objects))
 	selections := make(map[string]historicalSelection, len(objects))
 	observed := make([]providerObjectObservation, 0, len(objects))
+	var writeObservations storage.ProviderVersionObservationSet
 	for _, object := range objects {
 		blob, putErr := store.Put(ctx, blobFor(object.body), bytes.NewReader(object.body))
 		if putErr != nil {
@@ -75,21 +81,30 @@ func TestFAI520ManagedProviderBindingObservationReplay(t *testing.T) {
 		file := manageddata.File{Path: object.path, SHA256: blob.SHA256, Size: blob.Size}
 		manifest.Files = append(manifest.Files, file)
 		stored = append(stored, manageddata.StoredFile{File: file, StorageKey: blob.URI, MediaType: object.mime})
+		if blob.ProviderVersion == nil {
+			t.Fatalf("managed write did not return provider-version observation for %s", object.path)
+		}
+		if err := writeObservations.Add(*blob.ProviderVersion); err != nil {
+			t.Fatalf("record write observation for %s: %v", object.path, err)
+		}
 		key := strings.TrimPrefix(blob.URI, "s3://"+bucket+"/")
-		head, headErr := client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
-		if headErr != nil {
-			t.Fatal(headErr)
-		}
-		if head.ContentLength == nil || *head.ContentLength != blob.Size {
-			t.Fatalf("provider size for %s = %v, want %d", object.path, head.ContentLength, blob.Size)
-		}
-		version := aws.ToString(head.VersionId)
-		if version == "" || version == "null" {
-			t.Fatalf("provider did not return immutable version for %s", object.path)
+		version := blob.ProviderVersion.VersionID
+		if blob.ProviderVersion.Profile != profile || blob.ProviderVersion.ObjectKey != key || blob.ProviderVersion.SHA256 != blob.SHA256 || blob.ProviderVersion.Size != blob.Size {
+			t.Fatalf("managed write observation for %s = %#v", object.path, blob.ProviderVersion)
 		}
 		selection := historicalSelection{Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version}
 		selections[object.path] = selection
 		observed = append(observed, providerObjectObservation{Path: object.path, Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Key: key, Version: version, SHA256: blob.SHA256, Size: blob.Size})
+	}
+	if captured := writeObservations.Snapshot(); len(captured) != len(objects) {
+		t.Fatalf("captured write observations = %d, want %d", len(captured), len(objects))
+	} else {
+		for _, observation := range captured {
+			persisted, err := repo.ProviderVersionObservation(ctx, observation.Profile.ProfileID, observation.ObjectKey)
+			if err != nil || persisted != observation {
+				t.Fatalf("durable write observation = %#v, %v; want %#v", persisted, err, observation)
+			}
+		}
 	}
 	upload, err := repo.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{ID: "upload_provider_binding", CollectionID: collection.ID, Manifest: manifest, StorageBackend: "s3", StagingPrefix: "staging/provider-binding", ExpiresAt: time.Now().Add(time.Hour)})
 	if err != nil {
@@ -202,5 +217,11 @@ func TestFAI520ManagedProviderBindingObservationReplay(t *testing.T) {
 	if len(conflictReplay.Objects) != len(artifact.Objects)+1 || conflictReplay.Objects[0].Path != conflictReplay.Objects[len(conflictReplay.Objects)-1].Path || conflictReplay.Objects[len(conflictReplay.Objects)-1].Version != wrongVersion {
 		t.Fatalf("conflicting duplicate observation was not preserved for characterization: %#v", conflictReplay.Objects)
 	}
-	t.Log("unqualified gap: observation artifact preserves conflicting duplicates without a product validator or durable managed-inventory/frontier binding")
+	captured := writeObservations.Snapshot()
+	conflictingWrite := captured[0]
+	conflictingWrite.SHA256 = strings.Repeat("0", 64)
+	if err := writeObservations.Add(conflictingWrite); !errors.Is(err, storage.ErrObservationConflict) {
+		t.Fatalf("conflicting write observation error = %v", err)
+	}
+	t.Log("remaining gap: durable write observations are not yet selected by an authoritative capture or signed into Manifest v2")
 }

--- a/internal/manageddata/storage/s3/store.go
+++ b/internal/manageddata/storage/s3/store.go
@@ -39,9 +39,12 @@ type PartPresigner interface {
 }
 
 type Config struct {
-	Bucket     string
-	Prefix     string
-	SignExpiry time.Duration
+	Bucket              string
+	Prefix              string
+	SignExpiry          time.Duration
+	ObservationProfile  *storage.ProviderProfileIdentity
+	ObservationRecorder storage.ProviderVersionObservationRecorder
+	Clock               func() time.Time
 }
 
 type Store struct {
@@ -50,6 +53,9 @@ type Store struct {
 	bucket     string
 	prefix     string
 	signExpiry time.Duration
+	profile    *storage.ProviderProfileIdentity
+	recorder   storage.ProviderVersionObservationRecorder
+	clock      func() time.Time
 }
 
 func New(client Client, presigner PartPresigner, config Config) (*Store, error) {
@@ -71,7 +77,25 @@ func New(client Client, presigner PartPresigner, config Config) (*Store, error) 
 	if expiry < time.Minute || expiry > 24*time.Hour {
 		return nil, fmt.Errorf("%w: S3 part signing expiry must be between one minute and 24 hours", storage.ErrInvalid)
 	}
-	return &Store{client: client, presigner: presigner, bucket: bucket, prefix: prefix, signExpiry: expiry}, nil
+	var profile *storage.ProviderProfileIdentity
+	if config.ObservationProfile != nil {
+		copy := *config.ObservationProfile
+		if err := storage.ValidateProviderProfileIdentity(copy); err != nil {
+			return nil, err
+		}
+		if copy.Bucket != bucket || copy.Namespace != prefix {
+			return nil, fmt.Errorf("%w: observation profile does not match S3 store namespace", storage.ErrProviderVersion)
+		}
+		profile = &copy
+	}
+	clock := config.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	if config.ObservationRecorder != nil && profile == nil {
+		return nil, fmt.Errorf("%w: observation recorder requires a trusted observation profile", storage.ErrProviderVersion)
+	}
+	return &Store{client: client, presigner: presigner, bucket: bucket, prefix: prefix, signExpiry: expiry, profile: profile, recorder: config.ObservationRecorder, clock: clock}, nil
 }
 
 func (s *Store) Put(ctx context.Context, expected storage.Blob, content io.Reader) (storage.Blob, error) {
@@ -81,8 +105,13 @@ func (s *Store) Put(ctx context.Context, expected storage.Blob, content io.Reade
 	if content == nil {
 		return storage.Blob{}, fmt.Errorf("%w: blob content is required", storage.ErrInvalid)
 	}
+	if expected.ProviderVersion != nil {
+		// A retry carrying a provider write observation must resolve its exact
+		// immutable version before consulting mutable latest-object state.
+		return s.resolveObservedBlob(ctx, expected)
+	}
 	if existing, err := s.verify(ctx, expected); err == nil {
-		return existing, nil
+		return s.resolveExistingObservation(ctx, expected, existing)
 	} else if !errors.Is(err, storage.ErrNotFound) {
 		return storage.Blob{}, err
 	}
@@ -91,7 +120,7 @@ func (s *Store) Put(ctx context.Context, expected storage.Blob, content io.Reade
 		return storage.Blob{}, err
 	}
 	key := s.blobKey(expected.SHA256)
-	_, err = s.client.PutObject(ctx, &awss3.PutObjectInput{
+	result, err := s.client.PutObject(ctx, &awss3.PutObjectInput{
 		Bucket:         pointer(s.bucket),
 		Key:            pointer(key),
 		Body:           content,
@@ -102,11 +131,23 @@ func (s *Store) Put(ctx context.Context, expected storage.Blob, content io.Reade
 	})
 	if err != nil {
 		if isCode(err, "PreconditionFailed", "ConditionalRequestConflict") {
-			return s.verify(ctx, expected)
+			existing, verifyErr := s.verify(ctx, expected)
+			if verifyErr != nil {
+				return storage.Blob{}, verifyErr
+			}
+			return s.resolveExistingObservation(ctx, expected, existing)
 		}
 		return storage.Blob{}, sanitizeError(ctx, "put S3 blob", err)
 	}
-	return s.verify(ctx, expected)
+	versionID, capturedAt, err := s.captureWriteVersion(resultVersion(result), "put")
+	if err != nil {
+		return storage.Blob{}, err
+	}
+	verified, err := s.verifyVersion(ctx, expected, key, versionID)
+	if err != nil {
+		return storage.Blob{}, err
+	}
+	return s.withObservation(ctx, verified, key, versionID, capturedAt)
 }
 
 func (s *Store) Stat(ctx context.Context, digest string) (storage.Blob, error) {
@@ -315,6 +356,9 @@ func (s *Store) CompleteMultipart(ctx context.Context, upload storage.MultipartU
 	expected := storage.Blob{SHA256: upload.SHA256, Size: upload.Size}
 	if existing, err := s.verify(ctx, expected); err == nil {
 		_ = s.AbortMultipart(ctx, upload)
+		if s.profile != nil {
+			return storage.Blob{}, fmt.Errorf("%w: existing multipart object has no authoritative completion response", storage.ErrProviderVersion)
+		}
 		return existing, nil
 	} else if !errors.Is(err, storage.ErrNotFound) {
 		return storage.Blob{}, err
@@ -326,7 +370,7 @@ func (s *Store) CompleteMultipart(ctx context.Context, upload storage.MultipartU
 	if err != nil {
 		return storage.Blob{}, err
 	}
-	_, err = s.client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+	result, err := s.client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
 		Bucket:          pointer(s.bucket),
 		Key:             pointer(upload.Key),
 		UploadId:        pointer(upload.UploadID),
@@ -336,16 +380,26 @@ func (s *Store) CompleteMultipart(ctx context.Context, upload storage.MultipartU
 	if err != nil {
 		if isCode(err, "PreconditionFailed", "ConditionalRequestConflict") {
 			_ = s.AbortMultipart(ctx, upload)
+			if s.profile != nil {
+				return storage.Blob{}, fmt.Errorf("%w: conflicting multipart completion has no authoritative response", storage.ErrProviderVersion)
+			}
 			return s.verify(ctx, expected)
 		}
 		if isCode(err, "NoSuchUpload") {
+			if s.profile != nil {
+				return storage.Blob{}, fmt.Errorf("%w: unresolved multipart completion has no authoritative response", storage.ErrProviderVersion)
+			}
 			return s.verify(ctx, expected)
 		}
 		return storage.Blob{}, sanitizeError(ctx, "complete S3 multipart upload", err)
 	}
-	blob, verifyErr := s.verify(ctx, expected)
+	versionID, capturedAt, captureErr := s.captureWriteVersion(completedResultVersion(result), "multipart completion")
+	if captureErr != nil {
+		return storage.Blob{}, captureErr
+	}
+	blob, verifyErr := s.verifyVersion(ctx, expected, upload.Key, versionID)
 	if verifyErr == nil {
-		return blob, nil
+		return s.withObservation(ctx, blob, upload.Key, versionID, capturedAt)
 	}
 	if deleteErr := s.DeleteBlobs(ctx, []string{expected.SHA256}); deleteErr != nil {
 		return storage.Blob{}, deleteErr
@@ -373,9 +427,23 @@ func (s *Store) AbortMultipart(ctx context.Context, upload storage.MultipartUplo
 
 func (s *Store) verify(ctx context.Context, expected storage.Blob) (storage.Blob, error) {
 	key := s.blobKey(expected.SHA256)
-	head, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{Bucket: pointer(s.bucket), Key: pointer(key)})
+	return s.verifyVersion(ctx, expected, key, "")
+}
+
+func (s *Store) verifyVersion(ctx context.Context, expected storage.Blob, key, versionID string) (storage.Blob, error) {
+	headInput := &awss3.HeadObjectInput{Bucket: pointer(s.bucket), Key: pointer(key)}
+	if versionID != "" {
+		headInput.VersionId = pointer(versionID)
+	}
+	head, err := s.client.HeadObject(ctx, headInput)
 	if err != nil {
 		return storage.Blob{}, sanitizeError(ctx, "head S3 blob", err)
+	}
+	if head == nil {
+		return storage.Blob{}, fmt.Errorf("%w: S3 blob metadata is missing", storage.ErrIntegrity)
+	}
+	if versionID != "" && (head.VersionId == nil || *head.VersionId != versionID) {
+		return storage.Blob{}, fmt.Errorf("%w: S3 blob version does not match write response", storage.ErrIntegrity)
 	}
 	if head.ContentLength == nil {
 		return storage.Blob{}, fmt.Errorf("%w: S3 blob has no content length", storage.ErrIntegrity)
@@ -386,9 +454,20 @@ func (s *Store) verify(ctx context.Context, expected storage.Blob) (storage.Blob
 	if digest := head.Metadata["sha256"]; digest != "" && digest != expected.SHA256 {
 		return storage.Blob{}, fmt.Errorf("%w: S3 blob metadata does not match", storage.ErrIntegrity)
 	}
-	result, err := s.client.GetObject(ctx, &awss3.GetObjectInput{Bucket: pointer(s.bucket), Key: pointer(key)})
+	getInput := &awss3.GetObjectInput{Bucket: pointer(s.bucket), Key: pointer(key)}
+	if versionID != "" {
+		getInput.VersionId = pointer(versionID)
+	}
+	result, err := s.client.GetObject(ctx, getInput)
 	if err != nil {
 		return storage.Blob{}, sanitizeError(ctx, "stream S3 blob for verification", err)
+	}
+	if result == nil || result.Body == nil {
+		return storage.Blob{}, fmt.Errorf("%w: S3 blob body is missing", storage.ErrIntegrity)
+	}
+	if versionID != "" && (result.VersionId == nil || *result.VersionId != versionID) {
+		_ = result.Body.Close()
+		return storage.Blob{}, fmt.Errorf("%w: S3 streamed blob version does not match write response", storage.ErrIntegrity)
 	}
 	hash := sha256.New()
 	written, copyErr := io.Copy(hash, &contextReader{ctx: ctx, reader: result.Body})
@@ -404,6 +483,100 @@ func (s *Store) verify(ctx context.Context, expected storage.Blob) (storage.Blob
 		return storage.Blob{}, fmt.Errorf("%w: S3 blob does not match its content address", storage.ErrIntegrity)
 	}
 	return storage.Blob{SHA256: digest, Size: written, URI: s.blobURI(key)}, nil
+}
+
+func (s *Store) captureWriteVersion(versionID, operation string) (string, time.Time, error) {
+	if strings.EqualFold(versionID, "null") || strings.EqualFold(versionID, "latest") {
+		versionID = ""
+	}
+	if s.profile != nil && versionID == "" {
+		return "", time.Time{}, fmt.Errorf("%w: S3 %s response omitted exact VersionID", storage.ErrProviderVersion, operation)
+	}
+	if versionID == "" {
+		return "", time.Time{}, nil
+	}
+	if s.profile != nil {
+		if err := storage.ValidateProviderVersionID(versionID); err != nil {
+			return "", time.Time{}, err
+		}
+	}
+	return versionID, s.clock().UTC().Truncate(time.Microsecond), nil
+}
+
+func (s *Store) withObservation(ctx context.Context, blob storage.Blob, key, versionID string, capturedAt time.Time) (storage.Blob, error) {
+	if s.profile == nil {
+		return blob, nil
+	}
+	observation := storage.ProviderVersionObservation{
+		Profile: *s.profile, ObjectKey: key, VersionID: versionID,
+		SHA256: blob.SHA256, Size: blob.Size, CapturedAt: capturedAt,
+	}
+	if err := storage.ValidateProviderVersionObservation(observation); err != nil {
+		return storage.Blob{}, err
+	}
+	blob.ProviderVersion = &observation
+	return s.persistObservation(ctx, blob)
+}
+
+func (s *Store) resolveExistingObservation(ctx context.Context, expected, existing storage.Blob) (storage.Blob, error) {
+	if s.profile == nil {
+		return existing, nil
+	}
+	if expected.ProviderVersion == nil {
+		return storage.Blob{}, fmt.Errorf("%w: existing object has no previously captured write response", storage.ErrProviderVersion)
+	}
+	return s.resolveObservedBlob(ctx, expected)
+}
+
+func (s *Store) resolveObservedBlob(ctx context.Context, expected storage.Blob) (storage.Blob, error) {
+	if s.profile == nil {
+		return storage.Blob{}, fmt.Errorf("%w: provider version observation requires a trusted profile", storage.ErrProviderVersion)
+	}
+	observation := *expected.ProviderVersion
+	if err := storage.ValidateProviderVersionObservation(observation); err != nil {
+		return storage.Blob{}, err
+	}
+	if observation.Profile.Bucket != s.bucket || observation.Profile.Namespace != s.prefix ||
+		observation.Profile != *s.profile ||
+		observation.ObjectKey != s.blobKey(expected.SHA256) || observation.SHA256 != expected.SHA256 || observation.Size != expected.Size {
+		return storage.Blob{}, fmt.Errorf("%w: previous write observation does not match object", storage.ErrObservationConflict)
+	}
+	verified, err := s.verifyVersion(ctx, expected, observation.ObjectKey, observation.VersionID)
+	if err != nil {
+		return storage.Blob{}, err
+	}
+	verified.ProviderVersion = &observation
+	return s.persistObservation(ctx, verified)
+}
+
+func (s *Store) persistObservation(ctx context.Context, blob storage.Blob) (storage.Blob, error) {
+	if s.recorder == nil || blob.ProviderVersion == nil {
+		return blob, nil
+	}
+	stored, err := s.recorder.RecordProviderVersionObservation(ctx, *blob.ProviderVersion)
+	if err != nil {
+		// The exact provider fact is returned with the error so an orchestrator
+		// can retry the same observation without a mutable latest-object lookup.
+		return blob, fmt.Errorf("persist provider-version observation: %w", err)
+	}
+	if stored != *blob.ProviderVersion {
+		return blob, fmt.Errorf("%w: durable recorder returned different provider metadata", storage.ErrObservationConflict)
+	}
+	return blob, nil
+}
+
+func resultVersion(result *awss3.PutObjectOutput) string {
+	if result == nil || result.VersionId == nil {
+		return ""
+	}
+	return *result.VersionId
+}
+
+func completedResultVersion(result *awss3.CompleteMultipartUploadOutput) string {
+	if result == nil || result.VersionId == nil {
+		return ""
+	}
+	return *result.VersionId
 }
 
 func (s *Store) validateMultipart(upload storage.MultipartUpload) error {

--- a/internal/manageddata/storage/s3/store_test.go
+++ b/internal/manageddata/storage/s3/store_test.go
@@ -57,6 +57,236 @@ func TestStoreUsesContentAddressedKeyAndStableURI(t *testing.T) {
 	}
 }
 
+func TestStoreCapturesAuthoritativePutResponseVersion(t *testing.T) {
+	client := newFakeClient()
+	capturedAt := time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC)
+	store := newObservedStore(t, client, capturedAt)
+	body := []byte("versioned content")
+	expected := blobFor(body)
+	stored, err := store.Put(t.Context(), expected, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := stored.ProviderVersion
+	if observation == nil {
+		t.Fatal("Put() returned no provider-version observation")
+	}
+	if observation.VersionID != client.lastPutVersion || observation.ObjectKey != client.lastPutKey || observation.SHA256 != expected.SHA256 || observation.Size != expected.Size || observation.CapturedAt != capturedAt {
+		t.Fatalf("provider observation = %#v", observation)
+	}
+	if client.lastHeadVersion != client.lastPutVersion || client.lastGetVersion != client.lastPutVersion {
+		t.Fatalf("verification versions: head=%q get=%q write=%q", client.lastHeadVersion, client.lastGetVersion, client.lastPutVersion)
+	}
+	retried, err := store.Put(t.Context(), stored, bytes.NewReader(body))
+	if err != nil || retried.ProviderVersion == nil || *retried.ProviderVersion != *stored.ProviderVersion {
+		t.Fatalf("exact observed retry = %#v, %v", retried.ProviderVersion, err)
+	}
+	if _, err := store.Put(t.Context(), expected, bytes.NewReader(body)); !errors.Is(err, storage.ErrProviderVersion) {
+		t.Fatalf("retry without prior observation error = %v", err)
+	}
+}
+
+func TestStorePersistsVerifiedWriteObservation(t *testing.T) {
+	client := newFakeClient()
+	recorder := &providerObservationRecorder{}
+	capturedAt := time.Date(2026, 9, 10, 9, 30, 0, 123000, time.UTC)
+	store := newObservedStoreWithRecorder(t, client, capturedAt, recorder)
+	body := []byte("durable observation")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ProviderVersion == nil || len(recorder.observations) != 1 || recorder.observations[0] != *stored.ProviderVersion {
+		t.Fatalf("durable observations = %#v, stored=%#v", recorder.observations, stored.ProviderVersion)
+	}
+	if _, err := store.Put(t.Context(), stored, bytes.NewReader(body)); err != nil {
+		t.Fatalf("durable exact retry: %v", err)
+	}
+	if len(recorder.observations) != 2 || recorder.observations[1] != recorder.observations[0] {
+		t.Fatalf("durable retry observations = %#v", recorder.observations)
+	}
+}
+
+func TestStorePersistenceFailureReturnsExactObservationForRetry(t *testing.T) {
+	client := newFakeClient()
+	recorder := &providerObservationRecorder{err: errors.New("database unavailable")}
+	store := newObservedStoreWithRecorder(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC), recorder)
+	body := []byte("provider succeeds before database")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err == nil || stored.ProviderVersion == nil {
+		t.Fatalf("persistence failure = %#v, %v", stored, err)
+	}
+	if stored.ProviderVersion.VersionID != client.lastPutVersion {
+		t.Fatalf("failed handoff lost write VersionID: %#v", stored.ProviderVersion)
+	}
+	recorder.err = nil
+	retried, err := store.Put(t.Context(), stored, bytes.NewReader(body))
+	if err != nil || retried.ProviderVersion == nil || *retried.ProviderVersion != *stored.ProviderVersion {
+		t.Fatalf("persistence repair retry = %#v, %v", retried, err)
+	}
+}
+
+func TestStoreRejectsRecorderWithoutTrustedProfile(t *testing.T) {
+	_, err := manageds3.New(newFakeClient(), &fakePresigner{}, manageds3.Config{
+		Bucket: "private-data", Prefix: "managed", ObservationRecorder: &providerObservationRecorder{},
+	})
+	if !errors.Is(err, storage.ErrProviderVersion) {
+		t.Fatalf("recorder without profile error = %v", err)
+	}
+}
+
+func TestStoreRequiresWriteResponseVersionWhenCaptureEnabled(t *testing.T) {
+	client := newFakeClient()
+	client.omitPutVersion = true
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC))
+	body := []byte("unversioned response")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if !errors.Is(err, storage.ErrProviderVersion) || stored.ProviderVersion != nil {
+		t.Fatalf("Put() = %#v, %v", stored, err)
+	}
+	if _, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body)); !errors.Is(err, storage.ErrProviderVersion) {
+		t.Fatalf("existing unobserved retry error = %v", err)
+	}
+}
+
+func TestStoreFailedPutProducesNoObservation(t *testing.T) {
+	client := newFakeClient()
+	client.putFailure = errors.New("provider write failed")
+	recorder := &providerObservationRecorder{}
+	store := newObservedStoreWithRecorder(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC), recorder)
+	body := []byte("failed write")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if !errors.Is(err, storage.ErrBackend) || stored.ProviderVersion != nil {
+		t.Fatalf("Put() = %#v, %v", stored, err)
+	}
+	if len(recorder.observations) != 0 {
+		t.Fatalf("failed provider write persisted observations: %#v", recorder.observations)
+	}
+}
+
+func TestStoreRejectsSubstitutedPutResponseVersion(t *testing.T) {
+	client := newFakeClient()
+	client.putOutputVersion = "substituted-version"
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC))
+	body := []byte("substituted version")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err == nil || stored.ProviderVersion != nil {
+		t.Fatalf("Put() = %#v, %v", stored, err)
+	}
+}
+
+func TestStorePreservesUnversionedBehaviorWithoutObservationProfile(t *testing.T) {
+	client := newFakeClient()
+	client.omitPutVersion = true
+	store := newStore(t, client, &fakePresigner{})
+	body := []byte("legacy unversioned store")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err != nil || stored.ProviderVersion != nil {
+		t.Fatalf("Put() = %#v, %v", stored, err)
+	}
+}
+
+func TestLegacyStoreRejectsSuppliedProviderVersionBeforeS3Calls(t *testing.T) {
+	client := newFakeClient()
+	store := newStore(t, client, &fakePresigner{})
+	body := []byte("legacy provider version")
+	expected := blobFor(body)
+	expected.ProviderVersion = &storage.ProviderVersionObservation{VersionID: "provider-version-1"}
+
+	stored, err := store.Put(t.Context(), expected, bytes.NewReader(body))
+	if !errors.Is(err, storage.ErrProviderVersion) || stored.ProviderVersion != nil {
+		t.Fatalf("Put() = %#v, %v", stored, err)
+	}
+	if len(client.headVersions) != 0 || len(client.getVersions) != 0 || client.putCalls != 0 {
+		t.Fatalf("legacy store contacted S3 for untrusted observation: head=%v get=%v puts=%d", client.headVersions, client.getVersions, client.putCalls)
+	}
+}
+
+func TestStoreRejectsObservationProfileOutsideConfiguredNamespace(t *testing.T) {
+	client := newFakeClient()
+	profile := storage.ProviderProfileIdentity{
+		ProfileID: "managed-source-profile", Implementation: "s3", AccountIdentity: "qualification",
+		Endpoint: "https://s3.example.test", Region: "test-region-1", Bucket: "other-bucket", Namespace: "managed",
+	}
+	_, err := manageds3.New(client, &fakePresigner{}, manageds3.Config{Bucket: "private-data", Prefix: "managed", ObservationProfile: &profile})
+	if !errors.Is(err, storage.ErrProviderVersion) {
+		t.Fatalf("New() error = %v", err)
+	}
+}
+
+func TestStorePutUsesHistoricalObservationAfterCurrentReplacement(t *testing.T) {
+	client := newFakeClient()
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC))
+	firstBody := []byte("managed object V1")
+	first, err := store.Put(t.Context(), blobFor(firstBody), bytes.NewReader(firstBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := first.ProviderVersion.ObjectKey
+	replacementBody := []byte("managed object V2")
+	if _, err := client.PutObject(t.Context(), &awss3.PutObjectInput{Bucket: testPointer("private-data"), Key: &key, Body: bytes.NewReader(replacementBody)}); err != nil {
+		t.Fatal(err)
+	}
+	client.headVersions, client.getVersions = nil, nil
+	putsBeforeRetry, versionsBeforeRetry := client.putCalls, client.nextVersion
+
+	retried, err := store.Put(t.Context(), first, bytes.NewReader(firstBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.ProviderVersion == nil || *retried.ProviderVersion != *first.ProviderVersion {
+		t.Fatalf("historical observation changed: got=%#v want=%#v", retried.ProviderVersion, first.ProviderVersion)
+	}
+	if client.putCalls != putsBeforeRetry || client.nextVersion != versionsBeforeRetry {
+		t.Fatalf("historical retry issued a new PUT/version: puts=%d/%d versions=%d/%d", client.putCalls, putsBeforeRetry, client.nextVersion, versionsBeforeRetry)
+	}
+	if client.lastHeadVersion != first.ProviderVersion.VersionID || client.lastGetVersion != first.ProviderVersion.VersionID {
+		t.Fatalf("historical retry versions: head=%q get=%q want=%q", client.lastHeadVersion, client.lastGetVersion, first.ProviderVersion.VersionID)
+	}
+	if len(client.headVersions) == 0 || client.headVersions[0] != first.ProviderVersion.VersionID || len(client.getVersions) == 0 || client.getVersions[0] != first.ProviderVersion.VersionID {
+		t.Fatalf("historical retry did not start with exact version: head=%v get=%v", client.headVersions, client.getVersions)
+	}
+}
+
+func TestStorePutUsesHistoricalObservationAfterDeleteMarker(t *testing.T) {
+	client := newFakeClient()
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC))
+	body := []byte("managed object V1")
+	first, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := first.ProviderVersion.ObjectKey
+	// An unversioned delete in a versioned bucket creates a delete marker: the
+	// fake removes mutable latest state while retaining historical versions.
+	if _, err := client.DeleteObjects(t.Context(), &awss3.DeleteObjectsInput{
+		Bucket: testPointer("private-data"),
+		Delete: &types.Delete{Objects: []types.ObjectIdentifier{{Key: &key}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client.headVersions, client.getVersions = nil, nil
+	putsBeforeRetry, versionsBeforeRetry := client.putCalls, client.nextVersion
+
+	retried, err := store.Put(t.Context(), first, bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.ProviderVersion == nil || *retried.ProviderVersion != *first.ProviderVersion {
+		t.Fatalf("historical observation changed: got=%#v want=%#v", retried.ProviderVersion, first.ProviderVersion)
+	}
+	if client.putCalls != putsBeforeRetry || client.nextVersion != versionsBeforeRetry {
+		t.Fatalf("historical retry issued a new PUT/version: puts=%d/%d versions=%d/%d", client.putCalls, putsBeforeRetry, client.nextVersion, versionsBeforeRetry)
+	}
+	if client.lastHeadVersion != first.ProviderVersion.VersionID || client.lastGetVersion != first.ProviderVersion.VersionID {
+		t.Fatalf("historical retry versions: head=%q get=%q want=%q", client.lastHeadVersion, client.lastGetVersion, first.ProviderVersion.VersionID)
+	}
+	if len(client.headVersions) == 0 || client.headVersions[0] != first.ProviderVersion.VersionID || len(client.getVersions) == 0 || client.getVersions[0] != first.ProviderVersion.VersionID {
+		t.Fatalf("historical retry did not start with exact version: head=%v get=%v", client.headVersions, client.getVersions)
+	}
+}
+
 func TestBlobInventoryPaginatesAndDeletesInOneBatch(t *testing.T) {
 	client := newFakeClient()
 	client.listPageSize = 1
@@ -153,6 +383,48 @@ func TestMultipartCreateSignCompleteAndAbort(t *testing.T) {
 	}
 }
 
+func TestMultipartCompletionCapturesAuthoritativeResponseVersion(t *testing.T) {
+	client := newFakeClient()
+	capturedAt := time.Date(2026, 9, 10, 10, 0, 0, 0, time.UTC)
+	store := newObservedStore(t, client, capturedAt)
+	body := []byte("multipart observed body")
+	expected := blobFor(body)
+	upload, err := store.CreateMultipart(t.Context(), expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.setMultipartBody(upload.UploadID, body)
+	completed, err := store.CompleteMultipart(t.Context(), upload, []storage.CompletedMultipartPart{{Number: 1, ETag: "etag-1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed.ProviderVersion == nil || completed.ProviderVersion.VersionID != client.lastMultipartVersion {
+		t.Fatalf("multipart provider observation = %#v", completed.ProviderVersion)
+	}
+	if client.lastHeadVersion != client.lastMultipartVersion || client.lastGetVersion != client.lastMultipartVersion {
+		t.Fatalf("multipart verification versions: head=%q get=%q write=%q", client.lastHeadVersion, client.lastGetVersion, client.lastMultipartVersion)
+	}
+}
+
+func TestMultipartCompletionRequiresWriteResponseVersionWhenCaptureEnabled(t *testing.T) {
+	client := newFakeClient()
+	client.omitMultipartVersion = true
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 10, 0, 0, 0, time.UTC))
+	body := []byte("multipart without version")
+	upload, err := store.CreateMultipart(t.Context(), blobFor(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.setMultipartBody(upload.UploadID, body)
+	completed, err := store.CompleteMultipart(t.Context(), upload, []storage.CompletedMultipartPart{{Number: 1, ETag: "etag-1"}})
+	if !errors.Is(err, storage.ErrProviderVersion) || completed.ProviderVersion != nil {
+		t.Fatalf("CompleteMultipart() = %#v, %v", completed, err)
+	}
+	if _, err := store.CompleteMultipart(t.Context(), upload, []storage.CompletedMultipartPart{{Number: 1, ETag: "etag-1"}}); !errors.Is(err, storage.ErrProviderVersion) {
+		t.Fatalf("unobserved multipart retry error = %v", err)
+	}
+}
+
 func TestMultipartCompletionDeletesContentThatFailsStreamVerification(t *testing.T) {
 	client := newFakeClient()
 	store := newStore(t, client, &fakePresigner{})
@@ -219,9 +491,43 @@ func newStore(t *testing.T, client *fakeClient, presigner *fakePresigner) *manag
 	return store
 }
 
+func newObservedStore(t *testing.T, client *fakeClient, capturedAt time.Time) *manageds3.Store {
+	return newObservedStoreWithRecorder(t, client, capturedAt, nil)
+}
+
+func newObservedStoreWithRecorder(t *testing.T, client *fakeClient, capturedAt time.Time, recorder storage.ProviderVersionObservationRecorder) *manageds3.Store {
+	t.Helper()
+	profile := storage.ProviderProfileIdentity{
+		ProfileID: "managed-source-profile", Implementation: "s3", AccountIdentity: "qualification",
+		Endpoint: "https://s3.example.test", Region: "test-region-1", Bucket: "private-data", Namespace: "managed",
+	}
+	store, err := manageds3.New(client, &fakePresigner{}, manageds3.Config{
+		Bucket: "private-data", Prefix: "/managed/", ObservationProfile: &profile,
+		ObservationRecorder: recorder, Clock: func() time.Time { return capturedAt },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type providerObservationRecorder struct {
+	observations []storage.ProviderVersionObservation
+	err          error
+}
+
+func (r *providerObservationRecorder) RecordProviderVersionObservation(_ context.Context, observation storage.ProviderVersionObservation) (storage.ProviderVersionObservation, error) {
+	if r.err != nil {
+		return storage.ProviderVersionObservation{}, r.err
+	}
+	r.observations = append(r.observations, observation)
+	return observation, nil
+}
+
 type fakeClient struct {
 	mu                    sync.Mutex
 	objects               map[string]fakeObject
+	versions              map[string]map[string]fakeObject
 	multipart             map[string]fakeMultipart
 	nextUpload            int
 	failure               error
@@ -232,12 +538,25 @@ type fakeClient struct {
 	multipartListPageSize int
 	multipartListCalls    int
 	deleteBatches         [][]string
+	putFailure            error
+	omitPutVersion        bool
+	putOutputVersion      string
+	omitMultipartVersion  bool
+	lastPutVersion        string
+	lastMultipartVersion  string
+	lastHeadVersion       string
+	lastGetVersion        string
+	headVersions          []string
+	getVersions           []string
+	nextVersion           int
+	putCalls              int
 }
 
 type fakeObject struct {
 	body     []byte
 	metadata map[string]string
 	modified time.Time
+	version  string
 }
 
 type fakeMultipart struct {
@@ -247,7 +566,7 @@ type fakeMultipart struct {
 }
 
 func newFakeClient() *fakeClient {
-	return &fakeClient{objects: map[string]fakeObject{}, multipart: map[string]fakeMultipart{}}
+	return &fakeClient{objects: map[string]fakeObject{}, versions: map[string]map[string]fakeObject{}, multipart: map[string]fakeMultipart{}}
 }
 
 func (c *fakeClient) PutObject(_ context.Context, input *awss3.PutObjectInput, _ ...func(*awss3.Options)) (*awss3.PutObjectOutput, error) {
@@ -256,7 +575,11 @@ func (c *fakeClient) PutObject(_ context.Context, input *awss3.PutObjectInput, _
 	if c.failure != nil {
 		return nil, c.failure
 	}
+	if c.putFailure != nil {
+		return nil, c.putFailure
+	}
 	key := dereference(input.Key)
+	c.putCalls++
 	c.lastPutKey = key
 	c.lastPutIfNoneMatch = dereference(input.IfNoneMatch)
 	if _, exists := c.objects[key]; exists && dereference(input.IfNoneMatch) == "*" {
@@ -273,8 +596,21 @@ func (c *fakeClient) PutObject(_ context.Context, input *awss3.PutObjectInput, _
 	if input.ChecksumSHA256 != nil && *input.ChecksumSHA256 != base64.StdEncoding.EncodeToString(sum[:]) {
 		return nil, fakeAPIError{code: "BadDigest"}
 	}
-	c.objects[key] = fakeObject{body: append([]byte(nil), body...), metadata: clone(input.Metadata), modified: time.Now().UTC()}
-	return &awss3.PutObjectOutput{}, nil
+	version := c.newVersion()
+	c.lastPutVersion = version
+	object := fakeObject{body: append([]byte(nil), body...), metadata: clone(input.Metadata), modified: time.Now().UTC(), version: version}
+	c.objects[key] = object
+	if c.versions[key] == nil {
+		c.versions[key] = make(map[string]fakeObject)
+	}
+	c.versions[key][version] = object
+	if c.omitPutVersion {
+		return &awss3.PutObjectOutput{}, nil
+	}
+	if c.putOutputVersion != "" {
+		return &awss3.PutObjectOutput{VersionId: &c.putOutputVersion}, nil
+	}
+	return &awss3.PutObjectOutput{VersionId: &version}, nil
 }
 
 func (c *fakeClient) HeadObject(_ context.Context, input *awss3.HeadObjectInput, _ ...func(*awss3.Options)) (*awss3.HeadObjectOutput, error) {
@@ -283,12 +619,24 @@ func (c *fakeClient) HeadObject(_ context.Context, input *awss3.HeadObjectInput,
 	if c.failure != nil {
 		return nil, c.failure
 	}
-	object, exists := c.objects[dereference(input.Key)]
-	if !exists {
-		return nil, fakeAPIError{code: "NotFound"}
+	key := dereference(input.Key)
+	c.lastHeadVersion = dereference(input.VersionId)
+	c.headVersions = append(c.headVersions, c.lastHeadVersion)
+	var object fakeObject
+	var exists bool
+	if c.lastHeadVersion != "" {
+		object, exists = c.versions[key][c.lastHeadVersion]
+		if !exists {
+			return nil, fakeAPIError{code: "NoSuchVersion"}
+		}
+	} else {
+		object, exists = c.objects[key]
+		if !exists {
+			return nil, fakeAPIError{code: "NotFound"}
+		}
 	}
 	length := int64(len(object.body))
-	return &awss3.HeadObjectOutput{ContentLength: &length, Metadata: clone(object.metadata)}, nil
+	return &awss3.HeadObjectOutput{ContentLength: &length, Metadata: clone(object.metadata), VersionId: &object.version}, nil
 }
 
 func (c *fakeClient) GetObject(_ context.Context, input *awss3.GetObjectInput, _ ...func(*awss3.Options)) (*awss3.GetObjectOutput, error) {
@@ -297,11 +645,24 @@ func (c *fakeClient) GetObject(_ context.Context, input *awss3.GetObjectInput, _
 	if c.failure != nil {
 		return nil, c.failure
 	}
-	object, exists := c.objects[dereference(input.Key)]
-	if !exists {
-		return nil, fakeAPIError{code: "NoSuchKey"}
+	key := dereference(input.Key)
+	c.lastGetVersion = dereference(input.VersionId)
+	c.getVersions = append(c.getVersions, c.lastGetVersion)
+	var object fakeObject
+	var exists bool
+	if c.lastGetVersion != "" {
+		object, exists = c.versions[key][c.lastGetVersion]
+		if !exists {
+			return nil, fakeAPIError{code: "NoSuchVersion"}
+		}
+	} else {
+		object, exists = c.objects[key]
+		if !exists {
+			return nil, fakeAPIError{code: "NoSuchKey"}
+		}
 	}
-	return &awss3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(object.body))}, nil
+	length := int64(len(object.body))
+	return &awss3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(object.body)), ContentLength: &length, VersionId: &object.version}, nil
 }
 
 func (c *fakeClient) ListObjectsV2(_ context.Context, input *awss3.ListObjectsV2Input, _ ...func(*awss3.Options)) (*awss3.ListObjectsV2Output, error) {
@@ -426,9 +787,24 @@ func (c *fakeClient) CompleteMultipartUpload(_ context.Context, input *awss3.Com
 	if _, exists := c.objects[upload.key]; exists && dereference(input.IfNoneMatch) == "*" {
 		return nil, fakeAPIError{code: "PreconditionFailed"}
 	}
-	c.objects[upload.key] = fakeObject{body: append([]byte(nil), upload.body...), metadata: clone(upload.metadata), modified: time.Now().UTC()}
+	version := c.newVersion()
+	c.lastMultipartVersion = version
+	object := fakeObject{body: append([]byte(nil), upload.body...), metadata: clone(upload.metadata), modified: time.Now().UTC(), version: version}
+	c.objects[upload.key] = object
+	if c.versions[upload.key] == nil {
+		c.versions[upload.key] = make(map[string]fakeObject)
+	}
+	c.versions[upload.key][version] = object
 	delete(c.multipart, id)
-	return &awss3.CompleteMultipartUploadOutput{}, nil
+	if c.omitMultipartVersion {
+		return &awss3.CompleteMultipartUploadOutput{}, nil
+	}
+	return &awss3.CompleteMultipartUploadOutput{VersionId: &version}, nil
+}
+
+func (c *fakeClient) newVersion() string {
+	c.nextVersion++
+	return fmt.Sprintf("provider-version-%d", c.nextVersion)
 }
 
 func (c *fakeClient) AbortMultipartUpload(_ context.Context, input *awss3.AbortMultipartUploadInput, _ ...func(*awss3.Options)) (*awss3.AbortMultipartUploadOutput, error) {

--- a/internal/manageddata/storage/s3/write_version_qualification_test.go
+++ b/internal/manageddata/storage/s3/write_version_qualification_test.go
@@ -1,0 +1,100 @@
+//go:build fai520qualification
+
+package s3_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+)
+
+// This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+func TestFAI520ManagedS3WriteResponseVersionCapture(t *testing.T) {
+	ctx, client, _, bucket, endpoint := historicalProvider(t)
+	profile := storage.ProviderProfileIdentity{
+		ProfileID: "managed-source-write-qualification", Implementation: "s3", AccountIdentity: "qualification",
+		Endpoint: endpoint, Region: "us-east-1", Bucket: bucket, Namespace: "project-a",
+	}
+	store, err := manageds3.New(client, awss3.NewPresignClient(client), manageds3.Config{
+		Bucket: bucket, Prefix: profile.Namespace, ObservationProfile: &profile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstBody := []byte("managed object revision one\n")
+	first, err := store.Put(ctx, blobFor(firstBody), bytes.NewReader(firstBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireExactWriteObservation(t, client, first, profile, firstBody)
+
+	secondBody := []byte("managed object revision two\n")
+	second, err := store.Put(ctx, blobFor(secondBody), bytes.NewReader(secondBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireExactWriteObservation(t, client, second, profile, secondBody)
+	if first.ProviderVersion.VersionID == second.ProviderVersion.VersionID || first.ProviderVersion.ObjectKey == second.ProviderVersion.ObjectKey {
+		t.Fatal("successive managed revisions did not retain distinct provider observations")
+	}
+
+	multipartBody := []byte("managed multipart object\n")
+	upload, err := store.CreateMultipart(ctx, blobFor(multipartBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	partNumber := int32(1)
+	part, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket: &bucket, Key: &upload.Key, UploadId: &upload.UploadID,
+		PartNumber: &partNumber, Body: bytes.NewReader(multipartBody), ContentLength: aws.Int64(int64(len(multipartBody))),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.CompleteMultipart(ctx, upload, []storage.CompletedMultipartPart{{Number: partNumber, ETag: aws.ToString(part.ETag)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireExactWriteObservation(t, client, completed, profile, multipartBody)
+
+	var observations storage.ProviderVersionObservationSet
+	for _, blob := range []storage.Blob{first, second, completed} {
+		if err := observations.Add(*blob.ProviderVersion); err != nil {
+			t.Fatal(err)
+		}
+		if err := observations.Add(*blob.ProviderVersion); err != nil {
+			t.Fatalf("identical observation retry: %v", err)
+		}
+	}
+	if got := observations.Snapshot(); len(got) != 3 {
+		t.Fatalf("captured observations = %d, want 3", len(got))
+	}
+}
+
+func requireExactWriteObservation(t *testing.T, client *awss3.Client, blob storage.Blob, profile storage.ProviderProfileIdentity, want []byte) {
+	t.Helper()
+	if blob.ProviderVersion == nil {
+		t.Fatal("managed write omitted provider-version observation")
+	}
+	observation := *blob.ProviderVersion
+	if observation.Profile != profile || observation.VersionID == "" || observation.VersionID == "null" || observation.SHA256 != blob.SHA256 || observation.Size != blob.Size {
+		t.Fatalf("provider-version observation = %#v", observation)
+	}
+	result, err := client.GetObject(t.Context(), &awss3.GetObjectInput{
+		Bucket: &profile.Bucket, Key: &observation.ObjectKey, VersionId: &observation.VersionID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, readErr := io.ReadAll(result.Body)
+	closeErr := result.Body.Close()
+	if readErr != nil || closeErr != nil || aws.ToString(result.VersionId) != observation.VersionID || !bytes.Equal(got, want) {
+		t.Fatalf("exact observed provider version did not reproduce write bytes: read=%v close=%v", readErr, closeErr)
+	}
+}

--- a/internal/manageddata/storage/storage.go
+++ b/internal/manageddata/storage/storage.go
@@ -21,6 +21,17 @@ type Blob struct {
 	SHA256 string
 	Size   int64
 	URI    string
+	// ProviderVersion is present only when a provider write returned an exact,
+	// immutable version and the store was configured with a trusted observation
+	// profile. It is never inferred from a later HEAD or latest-object lookup.
+	ProviderVersion *ProviderVersionObservation
+}
+
+// ProviderVersionObservationRecorder is the narrow durable handoff used after
+// an exact provider write has been verified. It does not create a recovery
+// manifest or establish capture authority.
+type ProviderVersionObservationRecorder interface {
+	RecordProviderVersionObservation(context.Context, ProviderVersionObservation) (ProviderVersionObservation, error)
 }
 
 type MultipartUpload struct {

--- a/internal/platform/postgres/migrations/008_managed_provider_version_observation.sql
+++ b/internal/platform/postgres/migrations/008_managed_provider_version_observation.sql
@@ -1,0 +1,81 @@
+-- +goose Up
+SET LOCAL ROLE leapview_control_owner;
+
+-- Additive FAI-520 handoff for exact provider versions returned by successful
+-- managed-data writes. These rows are inputs to a future signed capture; they
+-- are not manifests, receipts, recovery sets, or admission results.
+CREATE TABLE IF NOT EXISTS managed_data.provider_observation_profile (
+    profile_id text PRIMARY KEY,
+    implementation text NOT NULL CHECK (implementation = 's3'),
+    account_identity text NOT NULL,
+    endpoint text NOT NULL,
+    region text NOT NULL,
+    bucket text NOT NULL,
+    namespace text NOT NULL,
+    recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    CHECK (profile_id = btrim(profile_id) AND octet_length(profile_id) BETWEEN 1 AND 4096),
+    CHECK (account_identity = btrim(account_identity) AND octet_length(account_identity) BETWEEN 1 AND 4096),
+    CHECK (endpoint = btrim(endpoint) AND octet_length(endpoint) BETWEEN 1 AND 4096),
+    CHECK (region = btrim(region) AND octet_length(region) BETWEEN 1 AND 4096),
+    CHECK (bucket = btrim(bucket) AND octet_length(bucket) BETWEEN 1 AND 4096),
+    CHECK (namespace = btrim(namespace) AND octet_length(namespace) <= 4096)
+);
+
+CREATE TABLE IF NOT EXISTS managed_data.provider_version_observation (
+    profile_id text NOT NULL REFERENCES managed_data.provider_observation_profile(profile_id) ON DELETE RESTRICT,
+    object_key text NOT NULL,
+    version_id text NOT NULL,
+    sha256 text NOT NULL,
+    size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+    captured_at timestamptz NOT NULL,
+    recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (profile_id, object_key),
+    CHECK (object_key = btrim(object_key) AND octet_length(object_key) BETWEEN 1 AND 4096),
+    CHECK (version_id = btrim(version_id) AND octet_length(version_id) BETWEEN 1 AND 4096 AND lower(version_id) NOT IN ('latest', 'null')),
+    CHECK (sha256 ~ '^[0-9a-f]{64}$')
+);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION managed_data.reject_provider_observation_mutation()
+RETURNS trigger LANGUAGE plpgsql SET search_path = pg_catalog, managed_data AS $$
+BEGIN RAISE EXCEPTION 'provider-version observations are immutable'; END $$;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS provider_observation_profile_immutable ON managed_data.provider_observation_profile;
+CREATE TRIGGER provider_observation_profile_immutable BEFORE UPDATE OR DELETE ON managed_data.provider_observation_profile FOR EACH ROW EXECUTE FUNCTION managed_data.reject_provider_observation_mutation();
+DROP TRIGGER IF EXISTS provider_version_observation_immutable ON managed_data.provider_version_observation;
+CREATE TRIGGER provider_version_observation_immutable BEFORE UPDATE OR DELETE ON managed_data.provider_version_observation FOR EACH ROW EXECUTE FUNCTION managed_data.reject_provider_observation_mutation();
+
+REVOKE ALL ON TABLE managed_data.provider_observation_profile, managed_data.provider_version_observation FROM PUBLIC;
+REVOKE ALL ON FUNCTION managed_data.reject_provider_observation_mutation() FROM PUBLIC;
+-- +goose StatementBegin
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_runtime') THEN
+    GRANT SELECT, INSERT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_runtime;
+    REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON managed_data.provider_observation_profile, managed_data.provider_version_observation FROM leapview_control_runtime;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_maintenance') THEN
+    GRANT SELECT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_maintenance;
+    REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON managed_data.provider_observation_profile, managed_data.provider_version_observation FROM leapview_control_maintenance;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_readonly') THEN
+    GRANT SELECT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_readonly;
+    REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON managed_data.provider_observation_profile, managed_data.provider_version_observation FROM leapview_control_readonly;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_backup') THEN
+    GRANT SELECT ON managed_data.provider_observation_profile, managed_data.provider_version_observation TO leapview_control_backup;
+    REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON managed_data.provider_observation_profile, managed_data.provider_version_observation FROM leapview_control_backup;
+  END IF;
+END $$;
+-- +goose StatementEnd
+RESET ROLE;
+
+-- +goose Down
+SET LOCAL ROLE leapview_control_owner;
+-- +goose StatementBegin
+DO $$ BEGIN
+  RAISE EXCEPTION 'managed provider-version observations are immutable; destructive down is forbidden';
+END $$;
+-- +goose StatementEnd
+RESET ROLE;

--- a/internal/platform/postgres/migrations/conformance_test.go
+++ b/internal/platform/postgres/migrations/conformance_test.go
@@ -207,6 +207,20 @@ func TestBaselinePostgreSQL18(t *testing.T) {
 	if !successorReadonlySelect || !successorBackupSelect || successorRuntimeSelect || successorReadonlyMutation || successorBackupMutation || successorRuntimeMutation {
 		t.Fatalf("successor grants readonly/backup/runtime select=%t/%t/%t mutation=%t/%t/%t", successorReadonlySelect, successorBackupSelect, successorRuntimeSelect, successorReadonlyMutation, successorBackupMutation, successorRuntimeMutation)
 	}
+	for _, table := range []string{"provider_observation_profile", "provider_version_observation"} {
+		for _, role := range []string{"leapview_control_runtime", "leapview_control_maintenance", "leapview_control_readonly", "leapview_control_backup", "recovery_unrelated"} {
+			for _, privilege := range []string{"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"} {
+				var allowed bool
+				if err := db.QueryRow(ctx, `SELECT has_table_privilege($1, $2, $3)`, role, "managed_data."+table, privilege).Scan(&allowed); err != nil {
+					t.Fatal(err)
+				}
+				want := privilege == "SELECT" && role != "recovery_unrelated" || privilege == "INSERT" && role == "leapview_control_runtime"
+				if allowed != want {
+					t.Errorf("provider observation privilege %s/%s/%s = %t, want %t", role, table, privilege, allowed, want)
+				}
+			}
+		}
+	}
 	var registryProfile, registryDigest string
 	var registryRevision int64
 	if err := db.QueryRow(ctx,

--- a/internal/platform/postgres/migrations/goose.go
+++ b/internal/platform/postgres/migrations/goose.go
@@ -25,7 +25,7 @@ const (
 	// CurrentRevision is the latest control-plane schema revision understood by
 	// this binary. Serving admission requires every embedded migration through
 	// this revision to be applied.
-	CurrentRevision int64 = 7
+	CurrentRevision int64 = 8
 	// AdvisoryLockKey serializes migration attempts across instances. Goose
 	// owns acquisition and release of this session-level PostgreSQL lock. The
 	// combined River+Goose path below uses the same key for one shared fence.

--- a/internal/platform/postgres/migrations/migrations_test.go
+++ b/internal/platform/postgres/migrations/migrations_test.go
@@ -27,7 +27,7 @@ func TestEmbeddedGooseBaselineIsImmutableAndForwardMigrationsAreOrdered(t *testi
 			sqlFiles = append(sqlFiles, entry.Name())
 		}
 	}
-	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql,005_resource_uid_registry.sql,006_recovery_successor_v3.sql,007_contract_publication_evidence.sql"; got != want {
+	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql,005_resource_uid_registry.sql,006_recovery_successor_v3.sql,007_contract_publication_evidence.sql,008_managed_provider_version_observation.sql"; got != want {
 		t.Fatalf("embedded Goose migrations = %v", sqlFiles)
 	}
 	contents, err := fs.ReadFile(MigrationFS(), "001_control_plane.sql")
@@ -48,6 +48,33 @@ func TestEmbeddedGooseBaselineIsImmutableAndForwardMigrationsAreOrdered(t *testi
 		if strings.Contains(strings.ToLower(text), strings.ToLower(forbidden)) {
 			t.Errorf("Goose baseline retains removed contract %q", forbidden)
 		}
+	}
+}
+
+func TestManagedProviderVersionObservationMigrationIsAdditiveAndImmutable(t *testing.T) {
+	contents, err := fs.ReadFile(MigrationFS(), "008_managed_provider_version_observation.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	migration := string(contents)
+	for _, required := range []string{
+		"managed_data.provider_observation_profile",
+		"managed_data.provider_version_observation",
+		"PRIMARY KEY (profile_id, object_key)",
+		"provider-version observations are immutable",
+		"GRANT SELECT, INSERT",
+		"destructive down is forbidden",
+	} {
+		if !strings.Contains(migration, required) {
+			t.Errorf("provider observation migration missing %q", required)
+		}
+	}
+	if !strings.HasSuffix(strings.TrimSpace(migration), "RESET ROLE;") {
+		t.Error("provider observation migration must restore the migrator role")
+	}
+	down := migration[strings.Index(migration, "-- +goose Down"):]
+	if strings.Contains(strings.ToUpper(down), "DROP TABLE") {
+		t.Error("provider observation Down must refuse instead of deleting evidence")
 	}
 }
 

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -1535,7 +1535,11 @@ test('dashboard agent drawer carries page context and explicit visual references
         && customElements.get('lv-chat-drawer')
         && customElements.get('lv-chat-composer')
     ))
-    await page.locator('lv-dashboard-page').evaluate((element: any) => element.updateComplete)
+    await page.waitForFunction(() => {
+      const element = document.querySelector('lv-dashboard-page') as any
+      return Boolean(element?.page && !element.isUpdatePending)
+    })
+    const moduleHandle = await page.evaluateHandle(() => import('/static/vendor/datastar-1.0.2.js?v=dev'))
 
     const initial = await page.locator('lv-dashboard-page').evaluate((element: any) => {
       const root = element.shadowRoot
@@ -1687,17 +1691,20 @@ test('dashboard agent drawer carries page context and explicit visual references
     expect(opened.drawerWidth).toBeGreaterThanOrEqual(360)
     expect(opened.drawerWidth).toBeLessThanOrEqual(520)
 
-    await page.evaluate(async () => {
-      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      mergePatch({ agentReferenceSearch: {
+    // Keep signal patches on one imported module to avoid repeated imports under merge-queue contention.
+    await moduleHandle.evaluate((module: any, search: any) => module.mergePatch({ agentReferenceSearch: search }), {
         query: 'orders', requestId: 1,
         results: [
 		  { reference: { kind: 'visual', id: 'executive-sales.orders_chart' }, name: 'Orders by status', hierarchy: ['Sales', 'Executive Sales', 'Overview'], href: '/orders', locations: [{ dashboardId: 'executive-sales', pageId: 'overview', href: '/orders' }], context: ['current_page'] },
 		  { reference: { kind: 'visual', id: 'executive-sales.finance_orders' }, name: 'Finance orders', description: 'Finance domain metric', hierarchy: ['Finance', 'Executive Sales', 'Overview'], href: '/finance', locations: [{ dashboardId: 'executive-sales', pageId: 'overview', href: '/finance' }], context: [] },
 		  { reference: { kind: 'metric', id: 'olist.order_count' }, name: 'Orders count', description: 'Across the sales model', hierarchy: ['Sales', 'Olist'], href: '/metric', locations: [], context: [] },
         ],
-      } })
-    })
+      })
+    await page.waitForFunction((requestId) => {
+      const element = document.querySelector('lv-dashboard-page') as any
+      const search = element?.signal('agentReferenceSearch', null)
+      return Boolean(element && !element.isUpdatePending && search?.query === 'orders' && search?.requestId === requestId)
+    }, 1)
     const groupedSearch = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
       await element.updateComplete
       const drawer = element.shadowRoot.querySelector('lv-chat-drawer') as any
@@ -1721,12 +1728,11 @@ test('dashboard agent drawer carries page context and explicit visual references
 	expect(groupedSearch.accessible).not.toContain('Finance orders Finance › Executive Sales › Overview Visual')
 	expect(groupedSearch.options.at(-1)).toBe('Orders count Sales › Olist Metric')
 
-    await page.evaluate(async () => {
-      const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      mergePatch({ agentContext: { referenceLimit: 1 } })
-    })
-    await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
-      await element.updateComplete
+    await moduleHandle.evaluate((module: any) => module.mergePatch({ agentContext: { referenceLimit: 1 } }))
+    await page.waitForFunction(() => {
+      const element = document.querySelector('lv-dashboard-page') as any
+      const context = element?.signal('agentContext', null)
+      return Boolean(element && !element.isUpdatePending && context?.referenceLimit === 1)
     })
 
     await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
@@ -1789,9 +1795,7 @@ test('dashboard agent drawer carries page context and explicit visual references
       }],
     })
 
-	await page.evaluate(async () => {
-	  const { mergePatch } = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-	  mergePatch({ agent: {
+	await moduleHandle.evaluate((module: any, agent: any) => module.mergePatch({ agent }), {
 		activeConversationId: 'agentconv_1',
 		transcript: [{
 		  id: 'user_1', kind: 'user', runId: 'run_1', text: 'Why did this decline?',
@@ -1804,8 +1808,12 @@ test('dashboard agent drawer carries page context and explicit visual references
 		}],
 		status: { enabled: true, running: true },
 		composer: { value: '', disabled: true, placeholder: 'Agent is working…' },
-	  } })
 	})
+	await page.waitForFunction((conversationID) => {
+	  const element = document.querySelector('lv-dashboard-page') as any
+	  const agent = element?.signal('agent', null)
+	  return Boolean(element && !element.isUpdatePending && agent?.activeConversationId === conversationID)
+	}, 'agentconv_1')
 	const accepted = await page.locator('lv-dashboard-page').evaluate(async (element: any) => {
 	  await element.updateComplete
 	  const drawer = element.shadowRoot.querySelector('lv-chat-drawer') as any

--- a/web/components/dashboard/dashboard-page.dom.test.ts
+++ b/web/components/dashboard/dashboard-page.dom.test.ts
@@ -1691,7 +1691,6 @@ test('dashboard agent drawer carries page context and explicit visual references
     expect(opened.drawerWidth).toBeGreaterThanOrEqual(360)
     expect(opened.drawerWidth).toBeLessThanOrEqual(520)
 
-    // Keep signal patches on one imported module to avoid repeated imports under merge-queue contention.
     await moduleHandle.evaluate((module: any, search: any) => module.mergePatch({ agentReferenceSearch: search }), {
         query: 'orders', requestId: 1,
         results: [


### PR DESCRIPTION
## Problem

Managed-data S3 writes receive an authoritative provider `VersionID`, but that identity was discarded. Recovery evidence could therefore verify a supplied historical version without durably proving which exact version a successful managed-data write created. Retries also consulted mutable latest state before an already-captured version, allowing unnecessary provider mutation.

## Solution

- Capture `VersionID` directly from successful normal and multipart S3 write responses; no HEAD-after-PUT inference is used.
- Persist trusted provider profiles and immutable provider-version observations in PostgreSQL with exact retry and conflict semantics.
- Validate expected historical versions before latest-object inspection or any new PUT, making retries deterministic after replacement or delete markers.
- Verify trusted profile, namespace, bucket, key, returned version, SHA-256 digest, and size before accepting an observation.
- Add additive migration, least-privilege grants, qualification coverage, and recovery evidence documentation.

## Scope

- Write-time S3 VersionID capture.
- Durable provider-version observations.
- Deterministic exact-version retries.

## Tests added or updated

- S3 storage unit and race tests, including retries after replacement and delete markers.
- Versioned MinIO qualification for normal and multipart writes.
- PostgreSQL persistence, exact retry, conflict, concurrency, restart/readback, migration, and permission qualification.
- Existing RecoverySet qualification and architecture coverage.

## Verification performed

- `go test ./internal/manageddata/storage/... -count=1`
- `go test -race ./internal/manageddata/storage/... -count=1`
- PostgreSQL provider-version observation qualification, including repeated execution.
- Tagged MinIO, observation-store, and RecoverySet PostgreSQL qualification suites.
- `go test ./internal/recoveryset/... -count=1`
- `go vet ./...`
- `task generated:check`
- `task docs:check`
- Full `task ci`
- `git diff --check`

All completed successfully on the committed tree.

## Limitations

- This does not create signed Manifest v2 evidence.
- This does not implement recovery admission or startup recovery.
- This does not prove provider retention guarantees.
- This does not implement restore orchestration or PITR.
- This does not prove successful physical disaster recovery.
