### PR TITLE
Parallelize disjoint Go application validation branches

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1425,8 +1425,7 @@ tasks:
   ci:lane:go:application:
     desc: Run sharded application and external-service Go tests
     cmds:
-      - task: test:go:app:shards
-      - task: test:go:external
+      - task --parallel test:go:app:shards test:go:external
 
   ci:lane:frontend:
     desc: Run every bounded frontend shard sequentially on a shared local machine

--- a/internal/platform/architecture/architecture_test.go
+++ b/internal/platform/architecture/architecture_test.go
@@ -3546,8 +3546,7 @@ func TestGitHubHostedCISplitsGoWorkAndWarmsReusableBunCache(t *testing.T) {
 		"ci:lane:go:packages:",
 		"- task: test:go:packages",
 		"ci:lane:go:application:",
-		"- task: test:go:app:shards",
-		"- task: test:go:external",
+		"- task --parallel test:go:app:shards test:go:external",
 	} {
 		if !strings.Contains(taskfile, want) {
 			t.Fatalf("Taskfile missing split Go lane fragment %q", want)

--- a/internal/platform/architecture/ci_contract_test.go
+++ b/internal/platform/architecture/ci_contract_test.go
@@ -276,3 +276,26 @@ func TestContinuousIntegrationHasExplicitPRFullAndNightlyTiers(t *testing.T) {
 		}
 	}
 }
+
+func TestGoApplicationLaneRunsShardsAndExternalInParallel(t *testing.T) {
+	root := repoRoot(t)
+	taskfile, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	if err != nil {
+		t.Fatalf("read Taskfile.yml: %v", err)
+	}
+	application := taskfileTaskBlock(t, string(taskfile), "ci:lane:go:application")
+	const parallelBranches = "- task --parallel test:go:app:shards test:go:external"
+	if strings.Count(application, parallelBranches) != 1 {
+		t.Fatalf("Go application lane must invoke app shards and the serial external branch through one parallel command: missing %q", parallelBranches)
+	}
+	for _, serial := range []string{"- task: test:go:app:shards", "- task: test:go:external"} {
+		if strings.Contains(application, serial) {
+			t.Fatalf("Go application lane retains serial branch %q", serial)
+		}
+	}
+	for _, suppression := range []string{"ignore_error:", "|| true", "set +e"} {
+		if strings.Contains(application, suppression) {
+			t.Fatalf("Go application lane suppresses parallel branch failures with %q", suppression)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Go application validation runs its ordinary application shards before the independent external-service branch, leaving the 2m33s shard envelope on the hosted critical path.

## Root cause

`ci:lane:go:application` invokes `test:go:app:shards` and `test:go:external` as sequential Task commands even though ordinary shards skip both PostgreSQL conformance and the isolated MinIO contract.

## Solution

Run the ordinary shard branch and the external-service branch through one native `task --parallel` command. The external branch remains serial internally: MinIO first, then the unchanged source-inventoried PostgreSQL conformance suite. Native Task failure propagation keeps either branch gate-failing.

## Tests added/updated

- Added an architecture contract requiring the exact two-branch parallel topology and rejecting serial or failure-suppressing forms.
- Updated the hosted Go lane architecture expectation.

## Verification performed

- `go test ./internal/platform/architecture -count=1`
- `task generated:check`
- `task --dry ci:lane:go:application` with Task v3.50.0
- `task ci:lane:go:application` (all ordinary shards, MinIO, and 54-package PostgreSQL inventory passed)
- `git diff --check`

## Remaining limitations

Hosted PR and merge-queue timing must be measured before concluding whether the Go application job ceased to be the critical path. No further CI optimization is included.