### PR TITLE
feat(recovery): capture and sign manifest v2 evidence

### DIFF
--- a/.github/workflows/recovery-evidence-qualification.yml
+++ b/.github/workflows/recovery-evidence-qualification.yml
@@ -37,6 +37,7 @@ jobs:
         run: >-
           go test -race -tags='duckdb_arrow fai520qualification'
           ./internal/manageddata/storage/s3
+          ./internal/recoveryset/capture
           ./internal/recoveryset/postgres
           ./internal/recoveryset/s3reader
           ./internal/recoveryset/observationstore

--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -1891,3 +1891,88 @@ remain required before production enablement. Admission, publication, startup,
 physical restore, PITR and RPO/RTO measurement are outside this foundation.
 
 This validates recovery evidence binding. It does not prove successful physical disaster recovery.
+
+## Manifest v2 capture and signing qualification
+
+This bounded qualification composes durable provider observations, a complete
+managed closure, a source anchor, the canonical ManagedObservationManifest v2,
+a detached signer receipt, and the existing RecoverySet v3 persistence path.
+It qualifies evidence assembly and verification only; it does not change the
+existing admission, publication, startup, restore, or recovery contracts.
+
+### Evidence flow
+
+Durable managed-data observations begin with a successful S3 write response.
+The exact nonempty VersionID, profile identity, object key, size, SHA-256, and
+UTC capture time are persisted in the managed-data PostgreSQL owner. Capture
+reads the authoritative revision projection and resolves each file through an
+explicit provider-profile binding. It then reads the stored observation and
+replays that exact provider version, checking profile/account/endpoint/region/
+bucket/prefix, returned VersionID, size, and fetched-byte digest. Latest-object
+lookup, ETags, and post-write discovery cannot supply evidence.
+
+The qualification source is intentionally instance-global: it captures every
+ready managed revision in the control database under a PostgreSQL lock. An
+independent policy resolver must authorize that complete provider-free
+revision membership, its closure digest, the recovery-set identity, provider
+profiles, authority registry, trust generation, worker fence, and deadline.
+This prevents the capture worker from selecting its own scope or trust roots.
+
+The verified revision/path membership is sorted into the provider-free managed
+closure and its domain-separated digest. The capture service combines that
+digest and the independently configured provider-profile digest with the
+normalized existing recovery frontier to build and hash the source anchor.
+The anchor digest is necessarily bound after PostgreSQL supplies the capture
+restore point and WAL position; the resolver authorizes membership before that
+capture rather than attempting to predict those source-owned values.
+Manifest v2 then emits strict canonical bytes containing the set and anchor
+identities, capture interval, closure, complete revision/file membership, and
+the exact provider observations. Its capture record commits to the receipt
+core digest. The final manifest digest is computed only after that core is
+fixed; a detached signer receives the domain-separated receipt payload and
+returns the Ed25519 signature. A trusted clock supplies verification time, and
+the service re-resolves the independently owned policy immediately before
+signing; a changed/revoked generation, fence, deadline, scope, profile, or key
+fails closed. The authority registry checks authority/key identity, algorithm,
+validity interval, revocation, and allowed provider-profile digest before the
+evidence graph is accepted. Private keys remain behind the signer callback and
+are not stored in capture results or recovery evidence.
+
+The existing RecoverySet v3 persistence adapter fetches every canonical
+payload by its configured exact-version locator, repeats canonical, domain,
+profile, closure, anchor, manifest, receipt, and authority checks, and then
+atomically stores the immutable evidence graph and prepared set association in
+PostgreSQL. The transaction performs no provider I/O. A separate connection
+can read back the same exact payloads and reverify them under independently
+resolved trust.
+
+This slice follows the current `CreateSet3` bundle, where the capture core is
+embedded in the detached receipt and committed by its domain digest. It does
+not add the separately located capture-core transport entry described by the
+frozen transport design; that representation must be reconciled explicitly
+before production evidence upload is enabled.
+
+### Deterministic and failure behavior
+
+Identical already-captured source facts and construction inputs produce
+identical canonical documents and frontier commitment; collection ordering is
+normalized without mutating the source. Exact retries of those saved documents
+through `CreateSet3` are idempotent. A fresh PostgreSQL capture creates a new
+restore point and must use a new set/capture identity; it is not a retry.
+Missing observations,
+incomplete closure, profile or namespace substitution, wrong or unavailable
+versions, size/digest mismatches, stale capture boundaries, malformed
+canonical bytes, invalid or revoked authority, signer errors, and signature or
+binding mismatches fail closed with bounded categories. No latest fallback,
+partial success, conflicting replacement, or dangling RecoverySet v3
+association is accepted.
+
+### Limitations
+
+This qualification does not establish provider retention, restart durability of
+the source system, PostgreSQL restore or PITR, physical provider recovery,
+production signer/key deployment, or RPO/RTO. It also does not grant admission,
+startup, publication, or activation authority. Standalone capture-core payload
+transport remains unresolved as noted above. Signed evidence does not prove physical disaster recovery.
+
+This validates recovery evidence binding. It does not prove successful physical disaster recovery.

--- a/internal/manageddata/observation_capture.go
+++ b/internal/manageddata/observation_capture.go
@@ -1,6 +1,21 @@
 package manageddata
 
-import "context"
+import (
+	"context"
+
+	"github.com/flidai/leapview/internal/manageddata/storage"
+)
+
+// ProviderVersionObservation is the managed-data owner's immutable provider
+// fact. The alias keeps recovery composition on the managed-data contract
+// boundary instead of importing its storage adapter package directly.
+type ProviderVersionObservation = storage.ProviderVersionObservation
+
+// ValidateProviderVersionObservation preserves the single validation owner
+// for provider facts exposed through this contract boundary.
+func ValidateProviderVersionObservation(observation ProviderVersionObservation) error {
+	return storage.ValidateProviderVersionObservation(observation)
+}
 
 // CapturedProjection is the trusted source-side result of a managed-data
 // capture. It contains only facts obtained from the managed-data authority;
@@ -16,6 +31,8 @@ type CapturedProjection struct {
 }
 
 type CapturedProjectionRevision struct {
+	ProjectID      string
+	CollectionID   string
 	RevisionID     string
 	ManifestDigest string
 	Files          []CapturedProjectionFile

--- a/internal/manageddata/postgres/observation_capture.go
+++ b/internal/manageddata/postgres/observation_capture.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flidai/leapview/internal/manageddata"
 	manageddb "github.com/flidai/leapview/internal/manageddata/postgres/internal/db"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	"github.com/flidai/leapview/pkg/strictjson"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -252,6 +253,14 @@ func captureProviderObservationInventory(ctx context.Context, queries *manageddb
 }
 
 func captureProviderObservationRevision(ctx context.Context, queries *manageddb.Queries, row manageddb.ListProviderObservationRevisionsRow) (capturedProjectionRevision, int, error) {
+	projectID, err := projectgraph.NewResourceID(row.ProjectID)
+	if err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q has invalid project identity: %v", ErrInvalid, row.RevisionID, err)
+	}
+	collectionID, err := projectgraph.NewResourceID(row.CollectionID)
+	if err != nil {
+		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q has invalid collection identity: %v", ErrInvalid, row.RevisionID, err)
+	}
 	if _, err := manageddata.ParseRevisionID(row.RevisionID); err != nil {
 		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: revision %q has invalid identity: %v", ErrInvalid, row.RevisionID, err)
 	}
@@ -310,7 +319,7 @@ func captureProviderObservationRevision(ctx context.Context, queries *manageddb.
 	if len(observed) != len(manifestByPath) {
 		return capturedProjectionRevision{}, 0, fmt.Errorf("%w: ready revision %q contains duplicate or missing file paths", ErrInvalid, row.RevisionID)
 	}
-	return capturedProjectionRevision{RevisionID: row.RevisionID, ManifestDigest: row.Digest, Files: observed}, len(observed), nil
+	return capturedProjectionRevision{ProjectID: projectID.String(), CollectionID: collectionID.String(), RevisionID: row.RevisionID, ManifestDigest: row.Digest, Files: observed}, len(observed), nil
 }
 
 func providerObservationRevisionBytes(revision capturedProjectionRevision) int {
@@ -318,7 +327,7 @@ func providerObservationRevisionBytes(revision capturedProjectionRevision) int {
 	// rounded up. Six bytes per source byte covers JSON \u00XX escaping, so
 	// this guard rejects before accumulating beyond the bounded source
 	// document even when source keys contain escapable characters.
-	n := 6*(len(revision.RevisionID)+len(revision.ManifestDigest)) + 128
+	n := 6*(len(revision.ProjectID)+len(revision.CollectionID)+len(revision.RevisionID)+len(revision.ManifestDigest)) + 128
 	for _, file := range revision.Files {
 		n += 6*(len(file.Path)+len(file.SHA256)+len(file.StorageKey)) + 128
 	}

--- a/internal/manageddata/postgres/observation_capture_test.go
+++ b/internal/manageddata/postgres/observation_capture_test.go
@@ -1,0 +1,17 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderObservationRevisionBoundIncludesOwnershipIdentity(t *testing.T) {
+	base := capturedProjectionRevision{ProjectID: "project", CollectionID: "collection", RevisionID: "revision", ManifestDigest: "sha256:" + strings.Repeat("a", 64)}
+	expanded := base
+	expanded.ProjectID += strings.Repeat("p", 128)
+	expanded.CollectionID += strings.Repeat("c", 128)
+
+	if got, want := providerObservationRevisionBytes(expanded)-providerObservationRevisionBytes(base), 6*(128+128); got != want {
+		t.Fatalf("ownership identity byte bound increase = %d, want %d", got, want)
+	}
+}

--- a/internal/manageddata/postgres/queries/observation_capture.sql
+++ b/internal/manageddata/postgres/queries/observation_capture.sql
@@ -18,11 +18,13 @@ WHERE singleton = true;
 SELECT current_setting('fsync')::text AS fsync;
 
 -- name: ListProviderObservationRevisions :many
-SELECT revision_id, digest, manifest::text AS manifest, file_count, size_bytes
-FROM managed_data.revision
-WHERE status = 'ready'
-  AND revision_id > sqlc.arg(after_revision_id)
-ORDER BY revision_id
+SELECT c.project_id, c.collection_id,
+       r.revision_id, r.digest, r.manifest::text AS manifest, r.file_count, r.size_bytes
+FROM managed_data.revision AS r
+JOIN managed_data.collection AS c ON c.collection_id = r.collection_id
+WHERE r.status = 'ready'
+  AND r.revision_id > sqlc.arg(after_revision_id)
+ORDER BY r.revision_id
 LIMIT sqlc.arg(page_size);
 
 -- name: ListProviderObservationRevisionFiles :many

--- a/internal/manageddata/storage/s3/store.go
+++ b/internal/manageddata/storage/s3/store.go
@@ -485,6 +485,27 @@ func (s *Store) verifyVersion(ctx context.Context, expected storage.Blob, key, v
 	return storage.Blob{SHA256: digest, Size: written, URI: s.blobURI(key)}, nil
 }
 
+// VerifyExact replays one durable write-time observation through this store's
+// trusted S3 client and profile. It always supplies the captured VersionID to
+// both provider calls and verifies the returned version, size, and SHA-256
+// bytes. The observation cannot select credentials, endpoint, or bucket.
+func (s *Store) VerifyExact(ctx context.Context, observation storage.ProviderVersionObservation) error {
+	if s == nil || s.profile == nil {
+		return fmt.Errorf("%w: exact provider verification requires a trusted profile", storage.ErrProviderVersion)
+	}
+	if err := storage.ValidateProviderVersionObservation(observation); err != nil {
+		return err
+	}
+	if observation.Profile != *s.profile || observation.Profile.Bucket != s.bucket || observation.Profile.Namespace != s.prefix {
+		return fmt.Errorf("%w: provider observation does not match trusted S3 profile", storage.ErrObservationConflict)
+	}
+	if observation.ObjectKey != s.blobKey(observation.SHA256) {
+		return fmt.Errorf("%w: provider observation key does not match its content identity", storage.ErrObservationConflict)
+	}
+	_, err := s.verifyVersion(ctx, storage.Blob{SHA256: observation.SHA256, Size: observation.Size}, observation.ObjectKey, observation.VersionID)
+	return err
+}
+
 func (s *Store) captureWriteVersion(versionID, operation string) (string, time.Time, error) {
 	if strings.EqualFold(versionID, "null") || strings.EqualFold(versionID, "latest") {
 		versionID = ""

--- a/internal/manageddata/storage/s3/store_test.go
+++ b/internal/manageddata/storage/s3/store_test.go
@@ -86,6 +86,25 @@ func TestStoreCapturesAuthoritativePutResponseVersion(t *testing.T) {
 	}
 }
 
+func TestStoreVerifyExactRejectsProfileSubstitutionBeforeProviderIO(t *testing.T) {
+	client := newFakeClient()
+	store := newObservedStore(t, client, time.Date(2026, 9, 10, 9, 30, 0, 0, time.UTC))
+	body := []byte("versioned content")
+	stored, err := store.Put(t.Context(), blobFor(body), bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.headVersions, client.getVersions = nil, nil
+	observation := *stored.ProviderVersion
+	observation.Profile.AccountIdentity = "substituted-account"
+	if err := store.VerifyExact(t.Context(), observation); !errors.Is(err, storage.ErrObservationConflict) {
+		t.Fatalf("profile substitution error = %v, want observation conflict", err)
+	}
+	if len(client.headVersions) != 0 || len(client.getVersions) != 0 {
+		t.Fatalf("profile substitution contacted provider: head=%v get=%v", client.headVersions, client.getVersions)
+	}
+}
+
 func TestStorePersistsVerifiedWriteObservation(t *testing.T) {
 	client := newFakeClient()
 	recorder := &providerObservationRecorder{}

--- a/internal/manageddata/storage/s3/write_version_qualification_test.go
+++ b/internal/manageddata/storage/s3/write_version_qualification_test.go
@@ -11,7 +11,10 @@ import (
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/flidai/leapview/internal/manageddata/storage"
 	manageds3 "github.com/flidai/leapview/internal/manageddata/storage/s3"
+	"github.com/flidai/leapview/internal/recoveryset/capture"
 )
+
+var _ capture.ObservationVerifier = (*manageds3.Store)(nil)
 
 // This validates recovery evidence binding. It does not prove successful physical disaster recovery.
 func TestFAI520ManagedS3WriteResponseVersionCapture(t *testing.T) {
@@ -32,14 +35,14 @@ func TestFAI520ManagedS3WriteResponseVersionCapture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	requireExactWriteObservation(t, client, first, profile, firstBody)
+	requireExactWriteObservation(t, store, client, first, profile, firstBody)
 
 	secondBody := []byte("managed object revision two\n")
 	second, err := store.Put(ctx, blobFor(secondBody), bytes.NewReader(secondBody))
 	if err != nil {
 		t.Fatal(err)
 	}
-	requireExactWriteObservation(t, client, second, profile, secondBody)
+	requireExactWriteObservation(t, store, client, second, profile, secondBody)
 	if first.ProviderVersion.VersionID == second.ProviderVersion.VersionID || first.ProviderVersion.ObjectKey == second.ProviderVersion.ObjectKey {
 		t.Fatal("successive managed revisions did not retain distinct provider observations")
 	}
@@ -61,7 +64,7 @@ func TestFAI520ManagedS3WriteResponseVersionCapture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	requireExactWriteObservation(t, client, completed, profile, multipartBody)
+	requireExactWriteObservation(t, store, client, completed, profile, multipartBody)
 
 	var observations storage.ProviderVersionObservationSet
 	for _, blob := range []storage.Blob{first, second, completed} {
@@ -77,7 +80,7 @@ func TestFAI520ManagedS3WriteResponseVersionCapture(t *testing.T) {
 	}
 }
 
-func requireExactWriteObservation(t *testing.T, client *awss3.Client, blob storage.Blob, profile storage.ProviderProfileIdentity, want []byte) {
+func requireExactWriteObservation(t *testing.T, store *manageds3.Store, client *awss3.Client, blob storage.Blob, profile storage.ProviderProfileIdentity, want []byte) {
 	t.Helper()
 	if blob.ProviderVersion == nil {
 		t.Fatal("managed write omitted provider-version observation")
@@ -85,6 +88,9 @@ func requireExactWriteObservation(t *testing.T, client *awss3.Client, blob stora
 	observation := *blob.ProviderVersion
 	if observation.Profile != profile || observation.VersionID == "" || observation.VersionID == "null" || observation.SHA256 != blob.SHA256 || observation.Size != blob.Size {
 		t.Fatalf("provider-version observation = %#v", observation)
+	}
+	if err := store.VerifyExact(t.Context(), observation); err != nil {
+		t.Fatalf("production exact-version verifier: %v", err)
 	}
 	result, err := client.GetObject(t.Context(), &awss3.GetObjectInput{
 		Bucket: &profile.Bucket, Key: &observation.ObjectKey, VersionId: &observation.VersionID,

--- a/internal/recoveryset/capture/service.go
+++ b/internal/recoveryset/capture/service.go
@@ -1,0 +1,780 @@
+// Package capture assembles successor recovery evidence from independently
+// owned managed-data and trust inputs. It has no admission, publication,
+// startup, restore, or key-persistence behavior.
+package capture
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/recoveryset/successor"
+	"golang.org/x/text/unicode/norm"
+)
+
+var (
+	ErrInvalid    = errors.New("successor capture input is invalid")
+	ErrIncomplete = errors.New("successor capture evidence is incomplete")
+	ErrConflict   = errors.New("successor capture evidence conflicts")
+	ErrSigning    = errors.New("successor capture signing failed")
+)
+
+const canonicalTimeLayout = "2006-01-02T15:04:05.000000Z"
+
+// ObservationReader resolves only immutable facts already captured from a
+// successful provider write. It must never synthesize a version from latest.
+type ObservationReader interface {
+	ProviderVersionObservation(context.Context, string, string) (manageddata.ProviderVersionObservation, error)
+}
+
+// ObservationVerifier replays the exact provider version and verifies its
+// bytes, size, and digest through trusted provider configuration. Its errors
+// must not contain credentials or provider response bodies.
+type ObservationVerifier interface {
+	VerifyExact(context.Context, manageddata.ProviderVersionObservation) error
+}
+
+type ObservationVerifierFunc func(context.Context, manageddata.ProviderVersionObservation) error
+
+func (f ObservationVerifierFunc) VerifyExact(ctx context.Context, observation manageddata.ProviderVersionObservation) error {
+	return f(ctx, observation)
+}
+
+// Clock is the trusted clock selected by the owner of the capture worker. It
+// is deliberately not part of Request: a worker cannot choose the evidence's
+// verification time.
+type Clock interface {
+	Now() time.Time
+}
+
+type ClockFunc func() time.Time
+
+func (f ClockFunc) Now() time.Time { return f() }
+
+// TrustedClock is an explicit name for the same injected clock boundary.
+type TrustedClock = Clock
+type TrustedClockFunc = ClockFunc
+
+// TrustGeneration identifies the authoritative policy snapshot. A capture
+// worker may present an assignment, but it cannot make that assignment
+// authoritative; Resolve must return the same tuple.
+type TrustGeneration struct {
+	IncarnationID string `json:"incarnation_id"`
+	Revision      int64  `json:"revision"`
+	PolicyDigest  string `json:"policy_digest"`
+}
+
+// TrustAssignment is the immutable worker lease context used for one capture.
+// WorkerFence is an owner-issued fence epoch, not a value that the worker can
+// advance locally.
+type TrustAssignment struct {
+	Generation  TrustGeneration
+	WorkerFence int64
+	Deadline    time.Time
+}
+
+// SigningRequest is the only input provided to a signer. Payload and all
+// nested slices are copied before the call; implementations never receive a
+// pointer into mutable capture state or any private key material.
+type SigningRequest struct {
+	Payload     []byte
+	AuthorityID string
+	KeyID       string
+	Authority   successor.AuthorityKey
+	Generation  TrustGeneration
+	WorkerFence int64
+	Deadline    time.Time
+}
+
+// Signer delegates receipt signing to an authority boundary. Implementations
+// receive the frozen domain-separated receipt payload and its trust context;
+// private keys never enter a CaptureResult or any recovery evidence document.
+type Signer interface {
+	Sign(context.Context, SigningRequest) ([]byte, error)
+}
+
+type SignerFunc func(context.Context, SigningRequest) ([]byte, error)
+
+func (f SignerFunc) Sign(ctx context.Context, request SigningRequest) ([]byte, error) {
+	return f(ctx, request)
+}
+
+// ProfileBinding selects the durable managed-data profile that corresponds to
+// one independently trusted successor namespace. The profile ID is lookup
+// metadata only and is not added to the frozen Manifest v2 wire format.
+type ProfileBinding struct {
+	ProjectID            string
+	CollectionID         string
+	Prefix               string
+	ObservationProfileID string
+}
+
+// TrustPolicy is returned by an independently owned policy/scope boundary.
+// None of these fields are accepted from Request. The service freezes a deep
+// copy before it reads observations or emits evidence.
+type TrustPolicy struct {
+	Profiles        successor.ProviderProfileSet
+	Authorities     successor.AuthorityRegistry
+	ProfileBindings []ProfileBinding
+	ExpectedScope   successor.ExpectedScope
+	Assignment      TrustAssignment
+}
+
+// PolicyScopeResolver is the independent authority for provider profiles,
+// authority keys, expected membership scope, and the current worker fence.
+type PolicyScopeResolver interface {
+	Resolve(context.Context, Request) (TrustPolicy, error)
+}
+
+type PolicyScopeResolverFunc func(context.Context, Request) (TrustPolicy, error)
+
+func (f PolicyScopeResolverFunc) Resolve(ctx context.Context, request Request) (TrustPolicy, error) {
+	return f(ctx, request)
+}
+
+type Request struct {
+	Base        recoveryset.RecoverySet
+	CaptureID   string
+	AuthorityID string
+	KeyID       string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Assignment  TrustAssignment
+}
+
+// Documents are the exact canonical payloads intended for the existing
+// exact-version evidence upload and RecoverySet v3 persistence path.
+type Documents struct {
+	Set         []byte
+	Manifest    []byte
+	Anchor      []byte
+	Profiles    []byte
+	Receipt     []byte
+	Authorities []byte
+}
+
+type Result struct {
+	Set       successor.RecoverySet3
+	Evidence  successor.Evidence
+	Documents Documents
+}
+
+type Service struct {
+	source       manageddata.ProjectionCaptureSource
+	observations ObservationReader
+	verifier     ObservationVerifier
+	signer       Signer
+	resolver     PolicyScopeResolver
+	clock        Clock
+}
+
+func New(source manageddata.ProjectionCaptureSource, observations ObservationReader, verifier ObservationVerifier, signer Signer, resolver PolicyScopeResolver, clock Clock) (*Service, error) {
+	if source == nil || observations == nil || verifier == nil || signer == nil || resolver == nil || clock == nil {
+		return nil, fmt.Errorf("%w: source, observation reader, exact verifier, signer, trust resolver, and clock are required", ErrInvalid)
+	}
+	return &Service{source: source, observations: observations, verifier: verifier, signer: signer, resolver: resolver, clock: clock}, nil
+}
+
+// Capture constructs and verifies a complete successor evidence graph. The
+// caller remains responsible for uploading these canonical documents and for
+// invoking the existing RecoverySet v3 persistence path with exact locators.
+func (s *Service) Capture(ctx context.Context, request Request) (Result, error) {
+	if ctx == nil {
+		return Result{}, fmt.Errorf("%w: context is required", ErrInvalid)
+	}
+	if err := validateRequest(request); err != nil {
+		return Result{}, err
+	}
+	policy, err := s.resolve(ctx, request)
+	if err != nil {
+		return Result{}, err
+	}
+	verificationTime, err := s.trustedNow(policy.Assignment.Deadline)
+	if err != nil {
+		return Result{}, err
+	}
+	if verificationTime.Before(request.CompletedAt) {
+		return Result{}, fmt.Errorf("%w: trusted verification clock predates capture completion", ErrConflict)
+	}
+	captureCtx, cancel := context.WithDeadline(ctx, policy.Assignment.Deadline)
+	defer cancel()
+	projection, err := s.source.CaptureManagedProjection(captureCtx)
+	if err != nil {
+		return Result{}, &sourceFailure{cause: err}
+	}
+	revisions, err := s.joinObservations(captureCtx, projection, request, policy)
+	if err != nil {
+		return Result{}, err
+	}
+	return s.build(captureCtx, request, projection, revisions, policy, verificationTime)
+}
+
+func validateRequest(request Request) error {
+	if request.Base.SchemaVersion != recoveryset.SchemaVersion {
+		return fmt.Errorf("%w: base recovery set must use the existing v1 owner contract", ErrInvalid)
+	}
+	if request.Base.ManagedEvidence != nil {
+		return fmt.Errorf("%w: legacy managed evidence cannot be reinterpreted as successor evidence", ErrInvalid)
+	}
+	if request.Base.Status != recoveryset.StatusPrepared || request.Base.PublishedValidationAttemptID != "" {
+		return fmt.Errorf("%w: base recovery set must be prepared and unpublished", ErrInvalid)
+	}
+	if _, err := request.Base.Normalize(); err != nil {
+		return fmt.Errorf("%w: base recovery set: %v", ErrInvalid, err)
+	}
+	if !canonicalID(request.CaptureID) || !canonicalID(request.AuthorityID) || !canonicalID(request.KeyID) {
+		return fmt.Errorf("%w: capture and authority identities are required", ErrInvalid)
+	}
+	if !canonicalCaptureTime(request.StartedAt) || !canonicalCaptureTime(request.CompletedAt) || request.CompletedAt.Before(request.StartedAt) {
+		return fmt.Errorf("%w: capture chronology must use nonzero UTC microsecond timestamps", ErrInvalid)
+	}
+	if err := validateAssignment(request.Assignment); err != nil {
+		return err
+	}
+	if !request.CompletedAt.Before(request.Assignment.Deadline) {
+		return fmt.Errorf("%w: capture completion must precede assignment deadline", ErrConflict)
+	}
+	return nil
+}
+
+func canonicalCaptureTime(value time.Time) bool {
+	return !value.IsZero() && value.Location() == time.UTC && value.Nanosecond()%1_000 == 0
+}
+
+func canonicalID(value string) bool {
+	if value == "" || value != strings.TrimSpace(value) || len(value) > successor.MaxTextBytes || !utf8.ValidString(value) || norm.NFC.String(value) != value {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || r == utf8.RuneError {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalPrefix(value string) bool {
+	if value == "" {
+		return true
+	}
+	if !canonicalID(value) || strings.HasPrefix(value, "/") || strings.HasSuffix(value, "/") || strings.Contains(value, "\\") {
+		return false
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalUUID(value string) bool {
+	if len(value) != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-' {
+		return false
+	}
+	for i, r := range value {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			continue
+		}
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalDigest(value string) bool {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	for _, r := range value[len("sha256:"):] {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateGeneration(generation TrustGeneration) error {
+	if !canonicalUUID(generation.IncarnationID) || generation.Revision <= 0 || !canonicalDigest(generation.PolicyDigest) {
+		return fmt.Errorf("%w: trust generation is malformed", ErrInvalid)
+	}
+	return nil
+}
+
+func validateAssignment(assignment TrustAssignment) error {
+	if err := validateGeneration(assignment.Generation); err != nil {
+		return err
+	}
+	if assignment.WorkerFence <= 0 {
+		return fmt.Errorf("%w: worker fence must be positive", ErrInvalid)
+	}
+	if !canonicalCaptureTime(assignment.Deadline) {
+		return fmt.Errorf("%w: assignment deadline must use a UTC microsecond timestamp", ErrInvalid)
+	}
+	return nil
+}
+
+func (s *Service) resolve(ctx context.Context, request Request) (TrustPolicy, error) {
+	policy, err := s.resolver.Resolve(ctx, request)
+	if err != nil {
+		return TrustPolicy{}, &policyResolutionFailure{cause: err}
+	}
+	frozen, err := freezePolicy(policy)
+	if err != nil {
+		return TrustPolicy{}, err
+	}
+	if !sameAssignment(frozen.Assignment, request.Assignment) {
+		return TrustPolicy{}, fmt.Errorf("%w: request assignment is stale", ErrConflict)
+	}
+	if frozen.ExpectedScope.SetID != request.Base.ID {
+		return TrustPolicy{}, fmt.Errorf("%w: expected scope is assigned to a different recovery set", ErrConflict)
+	}
+	return frozen, nil
+}
+
+func (s *Service) trustedNow(deadline time.Time) (time.Time, error) {
+	now := s.clock.Now()
+	if !canonicalCaptureTime(now) {
+		return time.Time{}, fmt.Errorf("%w: trusted verification clock must use a UTC microsecond timestamp", ErrInvalid)
+	}
+	if !now.Before(deadline) {
+		return time.Time{}, fmt.Errorf("%w: capture assignment deadline has expired", ErrConflict)
+	}
+	return now, nil
+}
+
+func freezePolicy(policy TrustPolicy) (TrustPolicy, error) {
+	if err := policy.Profiles.Validate(); err != nil {
+		return TrustPolicy{}, fmt.Errorf("%w: provider profiles are not independently trusted", ErrInvalid)
+	}
+	if err := policy.Authorities.Validate(); err != nil {
+		return TrustPolicy{}, fmt.Errorf("%w: authority registry is not independently trusted", ErrInvalid)
+	}
+	if err := validateAssignment(policy.Assignment); err != nil {
+		return TrustPolicy{}, err
+	}
+	if err := validateScope(policy.ExpectedScope); err != nil {
+		return TrustPolicy{}, err
+	}
+	bindings := make([]ProfileBinding, len(policy.ProfileBindings))
+	copy(bindings, policy.ProfileBindings)
+	sort.Slice(bindings, func(i, j int) bool {
+		left, right := bindings[i], bindings[j]
+		if left.ProjectID != right.ProjectID {
+			return left.ProjectID < right.ProjectID
+		}
+		if left.CollectionID != right.CollectionID {
+			return left.CollectionID < right.CollectionID
+		}
+		if left.Prefix != right.Prefix {
+			return left.Prefix < right.Prefix
+		}
+		return left.ObservationProfileID < right.ObservationProfileID
+	})
+	seen := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		if !canonicalID(binding.ProjectID) || !canonicalID(binding.CollectionID) || !canonicalID(binding.ObservationProfileID) || !canonicalPrefix(binding.Prefix) || strings.HasSuffix(binding.Prefix, "/") {
+			return TrustPolicy{}, fmt.Errorf("%w: provider profile binding is malformed", ErrInvalid)
+		}
+		key := binding.ProjectID + "\x00" + binding.CollectionID + "\x00" + binding.Prefix
+		if _, duplicate := seen[key]; duplicate {
+			return TrustPolicy{}, fmt.Errorf("%w: duplicate provider profile binding", ErrConflict)
+		}
+		seen[key] = struct{}{}
+	}
+	profiles, err := policy.Profiles.Normalize()
+	if err != nil {
+		return TrustPolicy{}, fmt.Errorf("%w: provider profiles: %v", ErrInvalid, err)
+	}
+	authorities, err := policy.Authorities.Normalize()
+	if err != nil {
+		return TrustPolicy{}, fmt.Errorf("%w: authority registry: %v", ErrInvalid, err)
+	}
+	scope := cloneScope(policy.ExpectedScope)
+	return TrustPolicy{Profiles: profiles, Authorities: authorities, ProfileBindings: bindings, ExpectedScope: scope, Assignment: policy.Assignment}, nil
+}
+
+func validateScope(scope successor.ExpectedScope) error {
+	// The policy boundary selects the recovery-set identity and complete
+	// provider-free managed membership before PostgreSQL capture. It cannot
+	// pre-authorize the source-anchor digest because that digest includes the
+	// restore point and WAL position created by the capture transaction. The
+	// service binds that value after capture and before signing.
+	if !canonicalUUID(scope.SetID) || scope.SourceFrontierAnchorDigest != "" || !canonicalDigest(scope.ManagedClosureDigest) || scope.Revisions == nil {
+		return fmt.Errorf("%w: expected scope is malformed or incomplete", ErrInvalid)
+	}
+	closure, err := successor.ClosureDigest(scope.Revisions)
+	if err != nil || closure != scope.ManagedClosureDigest {
+		return fmt.Errorf("%w: expected scope closure is not canonical", ErrConflict)
+	}
+	for _, revision := range scope.Revisions {
+		for _, file := range revision.Files {
+			if file.Provider != (successor.ProviderIdentity{}) {
+				return fmt.Errorf("%w: expected scope must be provider-free", ErrInvalid)
+			}
+		}
+	}
+	return nil
+}
+
+func cloneScope(scope successor.ExpectedScope) successor.ExpectedScope {
+	copy := scope
+	copy.Revisions = make([]successor.Revision, len(scope.Revisions))
+	for i, revision := range scope.Revisions {
+		copy.Revisions[i] = successor.Revision{ProjectID: revision.ProjectID, CollectionID: revision.CollectionID, RevisionID: revision.RevisionID, RevisionManifestDigest: revision.RevisionManifestDigest, Files: make([]successor.File, len(revision.Files))}
+		for j, file := range revision.Files {
+			copy.Revisions[i].Files[j] = successor.File{Path: file.Path, SHA256: file.SHA256, Size: file.Size}
+		}
+		sort.Slice(copy.Revisions[i].Files, func(a, b int) bool { return copy.Revisions[i].Files[a].Path < copy.Revisions[i].Files[b].Path })
+	}
+	sort.Slice(copy.Revisions, func(i, j int) bool {
+		left, right := copy.Revisions[i], copy.Revisions[j]
+		if left.ProjectID != right.ProjectID {
+			return left.ProjectID < right.ProjectID
+		}
+		if left.CollectionID != right.CollectionID {
+			return left.CollectionID < right.CollectionID
+		}
+		return left.RevisionID < right.RevisionID
+	})
+	return copy
+}
+
+func samePolicy(left, right TrustPolicy) bool {
+	return reflect.DeepEqual(left.Profiles, right.Profiles) && reflect.DeepEqual(left.Authorities, right.Authorities) && reflect.DeepEqual(left.ProfileBindings, right.ProfileBindings) && reflect.DeepEqual(left.ExpectedScope, right.ExpectedScope) && sameAssignment(left.Assignment, right.Assignment)
+}
+
+func sameAssignment(left, right TrustAssignment) bool {
+	return left.Generation == right.Generation && left.WorkerFence == right.WorkerFence && left.Deadline.Equal(right.Deadline)
+}
+
+func (s *Service) joinObservations(ctx context.Context, projection manageddata.CapturedProjection, request Request, policy TrustPolicy) ([]successor.Revision, error) {
+	revisions := make([]successor.Revision, 0, len(projection.Revisions))
+	for _, captured := range projection.Revisions {
+		revision := successor.Revision{
+			ProjectID: captured.ProjectID, CollectionID: captured.CollectionID,
+			RevisionID: captured.RevisionID, RevisionManifestDigest: captured.ManifestDigest,
+			Files: make([]successor.File, 0, len(captured.Files)),
+		}
+		for _, file := range captured.Files {
+			profile, prefix, profileID, objectKey, err := selectProfile(policy, revision.ProjectID, revision.CollectionID, file.StorageKey)
+			if err != nil {
+				return nil, err
+			}
+			observed, err := s.observations.ProviderVersionObservation(ctx, profileID, objectKey)
+			if err != nil {
+				return nil, &observationFailure{cause: err}
+			}
+			if err := validateObservation(observed, profileID, profile, prefix, objectKey, file, request.StartedAt); err != nil {
+				return nil, fmt.Errorf("revision %q path %q: %w", revision.RevisionID, file.Path, err)
+			}
+			if err := s.verifier.VerifyExact(ctx, observed); err != nil {
+				return nil, &verificationFailure{cause: err}
+			}
+			revision.Files = append(revision.Files, successor.File{
+				Path: file.Path, SHA256: file.SHA256, Size: file.Size,
+				Provider: successor.ProviderIdentity{
+					Implementation: observed.Profile.Implementation, AccountIdentity: observed.Profile.AccountIdentity,
+					Endpoint: observed.Profile.Endpoint, Region: observed.Profile.Region, Bucket: observed.Profile.Bucket,
+					Prefix: prefix, Key: observed.ObjectKey, VersionID: observed.VersionID,
+				},
+			})
+		}
+		revisions = append(revisions, revision)
+	}
+	return revisions, nil
+}
+
+func selectProfile(policy TrustPolicy, projectID, collectionID, storageKey string) (successor.ProviderProfile, string, string, string, error) {
+	u, err := url.Parse(storageKey)
+	if err != nil || u.Scheme != "s3" || u.User != nil || u.Host == "" || u.RawQuery != "" || u.Fragment != "" || u.RawPath != "" || !strings.HasPrefix(u.Path, "/") {
+		return successor.ProviderProfile{}, "", "", "", fmt.Errorf("%w: managed storage key is not a canonical S3 URI", ErrConflict)
+	}
+	objectKey := strings.TrimPrefix(u.Path, "/")
+	if objectKey == "" || (&url.URL{Scheme: "s3", Host: u.Host, Path: "/" + objectKey}).String() != storageKey {
+		return successor.ProviderProfile{}, "", "", "", fmt.Errorf("%w: managed storage key is ambiguous", ErrConflict)
+	}
+	var selected successor.ProviderProfile
+	var selectedPrefix, profileID string
+	matches := 0
+	for _, binding := range policy.ProfileBindings {
+		if binding.ProjectID != projectID || binding.CollectionID != collectionID {
+			continue
+		}
+		for _, profile := range policy.Profiles.Profiles {
+			if profile.Bucket != u.Host {
+				continue
+			}
+			for _, namespace := range profile.Namespaces {
+				if namespace.ProjectID == projectID && namespace.CollectionID == collectionID && namespace.Prefix == binding.Prefix && (namespace.Prefix == "" || strings.HasPrefix(objectKey, namespace.Prefix+"/")) {
+					selected, selectedPrefix, profileID = profile, namespace.Prefix, binding.ObservationProfileID
+					matches++
+				}
+			}
+		}
+	}
+	if matches != 1 {
+		return successor.ProviderProfile{}, "", "", "", fmt.Errorf("%w: managed object has %d trusted provider profile matches", ErrConflict, matches)
+	}
+	return selected, selectedPrefix, profileID, objectKey, nil
+}
+
+func validateObservation(observed manageddata.ProviderVersionObservation, profileID string, profile successor.ProviderProfile, prefix, objectKey string, file manageddata.CapturedProjectionFile, startedAt time.Time) error {
+	if err := manageddata.ValidateProviderVersionObservation(observed); err != nil {
+		return fmt.Errorf("%w: stored provider observation is invalid", ErrConflict)
+	}
+	if observed.Profile.ProfileID != profileID || observed.Profile.Implementation != profile.Implementation || observed.Profile.AccountIdentity != profile.AccountIdentity || observed.Profile.Endpoint != profile.Endpoint || observed.Profile.Region != profile.Region || observed.Profile.Bucket != profile.Bucket || observed.Profile.Namespace != prefix {
+		return fmt.Errorf("%w: provider profile identity differs from trusted configuration", ErrConflict)
+	}
+	if observed.ObjectKey != objectKey || observed.SHA256 != file.SHA256 || observed.Size != file.Size {
+		return fmt.Errorf("%w: provider observation does not match managed closure", ErrConflict)
+	}
+	if observed.CapturedAt.After(startedAt) {
+		return fmt.Errorf("%w: provider observation is newer than the selected capture boundary", ErrConflict)
+	}
+	return nil
+}
+
+func (s *Service) build(ctx context.Context, request Request, projection manageddata.CapturedProjection, revisions []successor.Revision, policy TrustPolicy, verificationTime time.Time) (Result, error) {
+	base := request.Base
+	control := recoveryset.ClusterRecoveryPoint{
+		DatabaseRole: recoveryset.DatabaseControl, ClusterIdentity: "postgres:" + projection.SystemIdentity,
+		DatabaseIdentity: projection.DatabaseIdentity,
+		RecoveryIdentity: fmt.Sprintf("postgres:%s:%d:%s:%s", projection.SystemIdentity, projection.Timeline, projection.LSN, projection.RestorePointName),
+	}
+	points := make([]recoveryset.ClusterRecoveryPoint, 0, len(base.ClusterPoints))
+	for _, point := range base.ClusterPoints {
+		if point.DatabaseRole == recoveryset.DatabaseControl {
+			continue
+		}
+		points = append(points, point)
+	}
+	points = append(points, control)
+	base.ClusterPoints = points
+	base.SchemaVersion = recoveryset.SchemaVersion
+	base.FrontierDigest = ""
+	normalizedBase, err := base.Normalize()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: base recovery frontier: %v", ErrInvalid, err)
+	}
+	closureDigest, err := successor.ClosureDigest(revisions)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: managed closure: %v", ErrConflict, err)
+	}
+	profileDigest, err := policy.Profiles.Digest()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: provider profiles: %v", ErrInvalid, err)
+	}
+	roots := make([]successor.ObjectRoot, len(normalizedBase.ObjectRoots))
+	for i, root := range normalizedBase.ObjectRoots {
+		roots[i] = successor.ObjectRoot{Kind: root.Kind, URI: root.URI, VersionID: root.VersionID, Digest: root.Digest, ProviderRecoveryFrontier: root.ProviderRecoveryFrontier}
+	}
+	anchor := successor.SourceAnchor{
+		AnchorVersion: successor.SourceAnchorVersion, SetID: normalizedBase.ID, ClusterPoints: normalizedBase.ClusterPoints,
+		Delivery: normalizedBase.Delivery, Serving: normalizedBase.Serving, Catalog: normalizedBase.Catalog,
+		ObjectRoots: roots, Compatibility: normalizedBase.Compatibility,
+		ManagedClosureDigest: closureDigest, ProviderProfileDigest: profileDigest,
+	}
+	anchorDigest, err := anchor.Digest()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: source anchor: %v", ErrInvalid, err)
+	}
+	started, completed := request.StartedAt.Format(canonicalTimeLayout), request.CompletedAt.Format(canonicalTimeLayout)
+	manifest := successor.ManagedManifest2{
+		ManifestVersion: successor.ManagedManifestVersion, SetID: normalizedBase.ID,
+		SourceFrontierAnchorDigest: anchorDigest, ManagedClosureDigest: closureDigest, Revisions: revisions,
+		Capture: successor.Capture{AuthorityID: request.AuthorityID, CaptureID: request.CaptureID, StartedAt: started, CompletedAt: completed, ReceiptDigest: "sha256:" + strings.Repeat("0", 64)},
+	}
+	projectionDigest, err := manifest.ObservationProjectionDigest()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: observation projection: %v", ErrConflict, err)
+	}
+	memberships, objects, err := manifest.ObservationCounts()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: observation counts: %v", ErrConflict, err)
+	}
+	core := successor.ReceiptCore{
+		CoreVersion: successor.ReceiptCoreVersion, AuthorityID: request.AuthorityID, KeyID: request.KeyID,
+		CaptureID: request.CaptureID, SetID: normalizedBase.ID, StartedAt: started, CompletedAt: completed,
+		SourceFrontierAnchorDigest: anchorDigest, ManagedClosureDigest: closureDigest, ProviderProfileDigest: profileDigest,
+		ObservationProjectionDigest: projectionDigest, MembershipCount: memberships, ObjectCount: objects, Result: "verified",
+	}
+	manifest.Capture.ReceiptDigest, err = core.Digest()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: receipt core: %v", ErrInvalid, err)
+	}
+	manifestDigest, err := manifest.Digest()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: manifest: %v", ErrConflict, err)
+	}
+	// Check the complete provider-free scope before invoking the signer. The
+	// independently resolved revisions, closure, set, and source anchor must
+	// already agree with this frozen manifest; signing cannot authorize a
+	// divergent capture.
+	expectedScope := cloneScope(policy.ExpectedScope)
+	expectedScope.SourceFrontierAnchorDigest = anchorDigest
+	if err := policy.Profiles.ValidateManifest(manifest, expectedScope); err != nil {
+		return Result{}, fmt.Errorf("%w: independent expected scope differs from captured manifest", ErrConflict)
+	}
+	receipt := successor.SignedReceipt{ReceiptVersion: successor.ReceiptVersion, Core: core, ManifestDigest: manifestDigest}
+	key, err := validateSigningAuthority(policy, request, profileDigest)
+	if err != nil {
+		return Result{}, err
+	}
+	signedPayload, err := receipt.SignedBytes()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: receipt payload: %v", ErrInvalid, err)
+	}
+	// Re-resolve at the last possible point before signing. The first frozen
+	// policy remains the source of evidence; the second snapshot only confirms
+	// that its authority, scope, generation, fence, and deadline are unchanged.
+	latest, err := s.resolve(ctx, request)
+	if err != nil {
+		return Result{}, err
+	}
+	if !samePolicy(policy, latest) {
+		return Result{}, fmt.Errorf("%w: trust policy changed before signing", ErrConflict)
+	}
+	verificationTime, err = s.trustedNow(latest.Assignment.Deadline)
+	if err != nil {
+		return Result{}, err
+	}
+	if verificationTime.Before(request.CompletedAt) {
+		return Result{}, fmt.Errorf("%w: trusted verification clock predates capture completion", ErrConflict)
+	}
+	signingRequest := SigningRequest{
+		Payload: append([]byte(nil), signedPayload...), AuthorityID: request.AuthorityID, KeyID: request.KeyID,
+		Authority: cloneAuthorityKey(key), Generation: latest.Assignment.Generation,
+		WorkerFence: latest.Assignment.WorkerFence, Deadline: latest.Assignment.Deadline,
+	}
+	signature, err := s.signer.Sign(ctx, signingRequest)
+	if err != nil {
+		return Result{}, &signingFailure{cause: err}
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return Result{}, fmt.Errorf("%w: signer returned invalid Ed25519 signature length", ErrSigning)
+	}
+	receipt.Signature = base64.StdEncoding.EncodeToString(signature)
+	set := successor.RecoverySet3{
+		ID: normalizedBase.ID, SchemaVersion: successor.RecoverySetVersion, ClusterPoints: normalizedBase.ClusterPoints,
+		Delivery: normalizedBase.Delivery, Serving: normalizedBase.Serving, Catalog: normalizedBase.Catalog,
+		ObjectRoots: roots, Compatibility: normalizedBase.Compatibility,
+		SourceFrontierAnchorDigest: anchorDigest, ManagedObservationManifestVersion: successor.ManagedManifestVersion,
+		ManagedObservationManifestDigest: manifestDigest, FenceEpoch: normalizedBase.FenceEpoch,
+		AuditIdentity: normalizedBase.AuditIdentity, Status: normalizedBase.Status,
+		CreatedBy: normalizedBase.CreatedBy, CreatedAt: normalizedBase.CreatedAt.Format(canonicalTimeLayout),
+	}
+	set.FrontierDigest, err = set.Commitment()
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: recovery frontier commitment: %v", ErrInvalid, err)
+	}
+	evidence := successor.Evidence{
+		Anchor: anchor, Manifest: manifest, Receipt: receipt, Profiles: policy.Profiles, Authorities: policy.Authorities,
+		ExpectedScope:    expectedScope,
+		VerificationTime: verificationTime,
+	}
+	if err := set.ValidateEvidence(evidence); err != nil {
+		return Result{}, fmt.Errorf("%w: complete evidence graph: %v", ErrInvalid, err)
+	}
+	documents, err := canonicalDocuments(set, evidence)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Set: set, Evidence: evidence, Documents: documents}, nil
+}
+
+func validateSigningAuthority(policy TrustPolicy, request Request, profileDigest string) (successor.AuthorityKey, error) {
+	key, err := policy.Authorities.Lookup(request.AuthorityID, request.KeyID)
+	if err != nil {
+		return successor.AuthorityKey{}, fmt.Errorf("%w: signing authority is unavailable", ErrInvalid)
+	}
+	if err := key.Validate(); err != nil {
+		return successor.AuthorityKey{}, fmt.Errorf("%w: signing authority is invalid", ErrInvalid)
+	}
+	if key.Revoked {
+		return successor.AuthorityKey{}, fmt.Errorf("%w: signing authority is revoked", ErrInvalid)
+	}
+	notBefore, errBefore := time.Parse(canonicalTimeLayout, key.NotBefore)
+	notAfter, errAfter := time.Parse(canonicalTimeLayout, key.NotAfter)
+	if errBefore != nil || errAfter != nil || request.StartedAt.Before(notBefore) || request.CompletedAt.Before(notBefore) || !request.StartedAt.Before(notAfter) || !request.CompletedAt.Before(notAfter) {
+		return successor.AuthorityKey{}, fmt.Errorf("%w: capture is outside signing authority validity", ErrInvalid)
+	}
+	for _, allowed := range key.ProviderProfileDigests {
+		if allowed == profileDigest {
+			return cloneAuthorityKey(key), nil
+		}
+	}
+	return successor.AuthorityKey{}, fmt.Errorf("%w: signing authority does not allow the selected provider profile", ErrInvalid)
+}
+
+func cloneAuthorityKey(key successor.AuthorityKey) successor.AuthorityKey {
+	key.ProviderProfileDigests = append([]string(nil), key.ProviderProfileDigests...)
+	return key
+}
+
+func canonicalDocuments(set successor.RecoverySet3, evidence successor.Evidence) (Documents, error) {
+	var documents Documents
+	encoders := []struct {
+		name string
+		dst  *[]byte
+		fn   func() ([]byte, error)
+	}{
+		{"set", &documents.Set, set.CanonicalJSON}, {"manifest", &documents.Manifest, evidence.Manifest.CanonicalJSON},
+		{"anchor", &documents.Anchor, evidence.Anchor.CanonicalJSON}, {"profiles", &documents.Profiles, evidence.Profiles.CanonicalJSON},
+		{"receipt", &documents.Receipt, evidence.Receipt.CanonicalJSON}, {"authorities", &documents.Authorities, evidence.Authorities.CanonicalJSON},
+	}
+	for _, encoder := range encoders {
+		raw, err := encoder.fn()
+		if err != nil {
+			return Documents{}, fmt.Errorf("%w: canonical %s: %v", ErrInvalid, encoder.name, err)
+		}
+		*encoder.dst = raw
+	}
+	return documents, nil
+}
+
+type signingFailure struct{ cause error }
+
+func (e *signingFailure) Error() string   { return "successor capture signing failed" }
+func (e *signingFailure) Unwrap() []error { return []error{ErrSigning, e.cause} }
+
+type verificationFailure struct{ cause error }
+
+func (e *verificationFailure) Error() string {
+	return "successor capture exact provider-version verification failed"
+}
+func (e *verificationFailure) Unwrap() []error { return []error{ErrIncomplete, e.cause} }
+
+// observationFailure intentionally has a static diagnostic. Provider
+// adapters may include credentials, object contents, or remote response text
+// in their errors; callers still retain errors.Is/As access to the typed cause.
+type observationFailure struct{ cause error }
+
+func (e *observationFailure) Error() string {
+	return "successor capture provider observation lookup failed"
+}
+func (e *observationFailure) Unwrap() []error { return []error{ErrIncomplete, e.cause} }
+
+type policyResolutionFailure struct{ cause error }
+
+func (e *policyResolutionFailure) Error() string {
+	return "successor capture trust policy resolution failed"
+}
+func (e *policyResolutionFailure) Unwrap() []error { return []error{ErrInvalid, e.cause} }
+
+type sourceFailure struct{ cause error }
+
+func (e *sourceFailure) Error() string   { return "successor capture managed projection failed" }
+func (e *sourceFailure) Unwrap() []error { return []error{ErrIncomplete, e.cause} }

--- a/internal/recoveryset/capture/service_test.go
+++ b/internal/recoveryset/capture/service_test.go
@@ -1,0 +1,428 @@
+package capture
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/recoveryset/successor"
+)
+
+func TestFAI520CaptureCanonicalizesSameFixedCapturedEvidence(t *testing.T) {
+	service, request, _ := captureFixture(t)
+	first, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, pair := range map[string][2][]byte{
+		"set": {first.Documents.Set, second.Documents.Set}, "manifest": {first.Documents.Manifest, second.Documents.Manifest},
+		"anchor": {first.Documents.Anchor, second.Documents.Anchor}, "profiles": {first.Documents.Profiles, second.Documents.Profiles},
+		"receipt": {first.Documents.Receipt, second.Documents.Receipt}, "authorities": {first.Documents.Authorities, second.Documents.Authorities},
+	} {
+		if !bytes.Equal(pair[0], pair[1]) {
+			t.Fatalf("%s bytes changed for the same fixed captured evidence", name)
+		}
+	}
+	if err := first.Set.ValidateEvidence(first.Evidence); err != nil {
+		t.Fatalf("complete evidence graph: %v", err)
+	}
+	if first.Evidence.Manifest.Revisions[0].Files[0].Provider.VersionID != "version-a" {
+		t.Fatalf("manifest provider version = %q", first.Evidence.Manifest.Revisions[0].Files[0].Provider.VersionID)
+	}
+	if first.Evidence.Anchor.ClusterPoints[0].DatabaseRole != recoveryset.DatabaseControl || first.Evidence.Anchor.ClusterPoints[0].RecoveryIdentity != "postgres:777777:1:0/ABC:provider_observation_capture" {
+		t.Fatalf("source anchor did not bind captured PostgreSQL point: %#v", first.Evidence.Anchor.ClusterPoints)
+	}
+	if bytes.Contains(first.Documents.Receipt, []byte("PRIVATE")) {
+		t.Fatal("receipt persisted private key material")
+	}
+}
+
+func TestFAI520CaptureContentMutationChangesManifestAndFrontierDigests(t *testing.T) {
+	service, request, source := captureFixture(t)
+	first, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := sha256.Sum256([]byte("different bytes"))
+	changedHash := hex.EncodeToString(changed[:])
+	file := &source.projection.Revisions[0].Files[0]
+	file.SHA256, file.Size = changedHash, int64(len("different bytes"))
+	source.projection.Revisions[0].ManifestDigest = manageddata.Manifest{Files: []manageddata.File{{Path: file.Path, SHA256: file.SHA256, Size: file.Size}}}.RevisionID()
+	reader := service.observations.(*memoryObservationReader)
+	observation := reader.values[observationKey("profile-a", "managed/data.csv")]
+	observation.SHA256, observation.Size = file.SHA256, file.Size
+	reader.values[observationKey("profile-a", "managed/data.csv")] = observation
+	service.verifier.(*memoryObservationVerifier).expected = observation
+	second, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Set.ManagedObservationManifestDigest == second.Set.ManagedObservationManifestDigest || first.Set.FrontierDigest == second.Set.FrontierDigest {
+		t.Fatal("changed managed content preserved manifest or frontier identity")
+	}
+}
+
+func TestFAI520CaptureNormalizesClosureOrderWithoutMutatingSource(t *testing.T) {
+	service, request, source := captureFixture(t)
+	second := source.projection.Revisions[0]
+	second.RevisionID = "revision-b"
+	second.Files = append([]manageddata.CapturedProjectionFile(nil), second.Files...)
+	second.Files[0].Path = "z.csv"
+	second.ManifestDigest = manageddata.Manifest{Files: []manageddata.File{{Path: "z.csv", SHA256: second.Files[0].SHA256, Size: second.Files[0].Size}}}.RevisionID()
+	source.projection.Revisions = append(source.projection.Revisions, second)
+	request.Base.ID = "22222222-2222-4222-8222-222222222222"
+	request.CaptureID = "capture-b"
+
+	ordered, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.projection.Revisions[0], source.projection.Revisions[1] = source.projection.Revisions[1], source.projection.Revisions[0]
+	reordered, err := service.Capture(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(ordered.Documents.Manifest, reordered.Documents.Manifest) || ordered.Set.FrontierDigest != reordered.Set.FrontierDigest {
+		t.Fatal("reordered closure changed canonical evidence")
+	}
+}
+
+func TestFAI520CaptureRejectsIncompleteOrConflictingObservations(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*captureFixtureState)
+		want   error
+	}{
+		{name: "missing observation", want: ErrIncomplete, mutate: func(state *captureFixtureState) { state.reader.values = nil }},
+		{name: "wrong exact version", want: ErrIncomplete, mutate: func(state *captureFixtureState) { state.observation.VersionID = "version-b" }},
+		{name: "digest mismatch", want: ErrConflict, mutate: func(state *captureFixtureState) { state.observation.SHA256 = strings.Repeat("b", 64) }},
+		{name: "closure mismatch", want: ErrConflict, mutate: func(state *captureFixtureState) {
+			scope := fixtureExpectedScope(state.resolver.base, state.resolver.source.projection, state.resolver.profiles)
+			scope.ManagedClosureDigest = digestOf("other")
+			state.resolver.scopeOverride = &scope
+		}},
+		{name: "stale capture boundary", want: ErrConflict, mutate: func(state *captureFixtureState) {
+			state.observation.CapturedAt = state.request.StartedAt.Add(time.Microsecond)
+		}},
+		{name: "profile substitution", want: ErrConflict, mutate: func(state *captureFixtureState) { state.observation.Profile.AccountIdentity = "other-account" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, request, source := captureFixture(t)
+			state := captureFixtureState{request: request, source: source, reader: service.observations.(*memoryObservationReader), resolver: service.resolver.(*memoryTrustResolver)}
+			state.observation = state.reader.values[observationKey("profile-a", "managed/data.csv")]
+			tc.mutate(&state)
+			if state.reader.values != nil {
+				state.reader.values[observationKey("profile-a", "managed/data.csv")] = state.observation
+			}
+			_, err := service.Capture(t.Context(), state.request)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want category %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestFAI520CaptureRejectsAuthorityAndSignatureFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Request, *Service)
+	}{
+		{name: "unknown authority", mutate: func(request *Request, _ *Service) { request.AuthorityID = "unknown-authority" }},
+		{name: "revoked authority", mutate: func(_ *Request, service *Service) {
+			service.resolver.(*memoryTrustResolver).policy.Authorities.Keys[0].Revoked = true
+		}},
+		{name: "stale authority validity", mutate: func(_ *Request, service *Service) {
+			service.resolver.(*memoryTrustResolver).policy.Authorities.Keys[0].NotAfter = "2026-09-10T00:00:30.000000Z"
+		}},
+		{name: "signature mismatch", mutate: func(_ *Request, service *Service) {
+			service.signer = SignerFunc(func(context.Context, SigningRequest) ([]byte, error) { return make([]byte, ed25519.SignatureSize), nil })
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service, request, _ := captureFixture(t)
+			tc.mutate(&request, service)
+			if _, err := service.Capture(t.Context(), request); !errors.Is(err, ErrInvalid) {
+				t.Fatalf("error = %v, want invalid evidence", err)
+			}
+		})
+	}
+}
+
+func TestFAI520CaptureRejectsStaleGenerationAndWorkerFence(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*memoryTrustResolver)
+	}{
+		{name: "generation", mutate: func(resolver *memoryTrustResolver) { resolver.policy.Assignment.Generation.Revision++ }},
+		{name: "worker fence", mutate: func(resolver *memoryTrustResolver) { resolver.policy.Assignment.WorkerFence++ }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service, request, _ := captureFixture(t)
+			resolver := service.resolver.(*memoryTrustResolver)
+			tc.mutate(resolver)
+			if _, err := service.Capture(t.Context(), request); !errors.Is(err, ErrConflict) {
+				t.Fatalf("error = %v, want stale assignment conflict", err)
+			}
+		})
+	}
+}
+
+func TestFAI520CaptureRejectsTrustChangeBeforeSigning(t *testing.T) {
+	service, request, source := captureFixture(t)
+	resolver := service.resolver.(*memoryTrustResolver)
+	second := resolver.policy
+	second.Authorities = successor.AuthorityRegistry{RegistryVersion: successor.AuthorityRegistryVersion, Keys: append([]successor.AuthorityKey(nil), resolver.policy.Authorities.Keys...)}
+	second.Authorities.Keys[0].Revoked = true
+	second.ExpectedScope = fixtureExpectedScope(resolver.base, source.projection, resolver.profiles)
+	resolver.second = &second
+	if _, err := service.Capture(t.Context(), request); !errors.Is(err, ErrConflict) {
+		t.Fatalf("error = %v, want trust-change conflict", err)
+	}
+}
+
+func TestFAI520CaptureObservationErrorsAreStaticButTyped(t *testing.T) {
+	service, request, _ := captureFixture(t)
+	cause := &secretObservationCause{}
+	service.observations = failingObservationReader{cause: cause}
+	_, err := service.Capture(t.Context(), request)
+	if !errors.Is(err, ErrIncomplete) || !errors.Is(err, cause) {
+		t.Fatalf("error = %v, want incomplete and typed observation cause", err)
+	}
+	if strings.Contains(err.Error(), "SECRET-DO-NOT-LEAK") {
+		t.Fatalf("observation error leaked provider diagnostic: %v", err)
+	}
+}
+
+func TestFAI520CaptureProviderPrefixUsesCanonicalRelativeSegments(t *testing.T) {
+	for value, want := range map[string]bool{
+		"": true, "managed": true, "managed/orders": true,
+		"/managed": false, "managed/": false, "managed//orders": false,
+		"managed/./orders": false, "managed/../orders": false, `managed\orders`: false,
+	} {
+		if got := canonicalPrefix(value); got != want {
+			t.Errorf("canonicalPrefix(%q) = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestFAI520CaptureSignerReceivesFrozenTrustContext(t *testing.T) {
+	service, request, _ := captureFixture(t)
+	original := service.signer
+	var received SigningRequest
+	service.signer = SignerFunc(func(ctx context.Context, signing SigningRequest) ([]byte, error) {
+		received = signing
+		return original.Sign(ctx, signing)
+	})
+	if _, err := service.Capture(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if len(received.Payload) == 0 || received.AuthorityID != request.AuthorityID || received.KeyID != request.KeyID || received.Generation != request.Assignment.Generation || received.WorkerFence != request.Assignment.WorkerFence || !received.Deadline.Equal(request.Assignment.Deadline) {
+		t.Fatalf("signing request omitted frozen trust context: %#v", received)
+	}
+	if received.Authority.PublicKey == "" || len(received.Authority.ProviderProfileDigests) == 0 {
+		t.Fatalf("signing request omitted immutable authority key: %#v", received.Authority)
+	}
+}
+
+func TestFAI520CaptureConcurrentIdenticalRequestsRemainImmutable(t *testing.T) {
+	service, request, _ := captureFixture(t)
+	const workers = 8
+	results := make([]Result, workers)
+	errs := make([]error, workers)
+	start := make(chan struct{})
+	var group sync.WaitGroup
+	for i := range results {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			results[i], errs[i] = service.Capture(context.Background(), request)
+		}()
+	}
+	close(start)
+	group.Wait()
+	for i := range results {
+		if errs[i] != nil {
+			t.Fatalf("capture %d: %v", i, errs[i])
+		}
+		if !bytes.Equal(results[0].Documents.Manifest, results[i].Documents.Manifest) || results[0].Set.FrontierDigest != results[i].Set.FrontierDigest {
+			t.Fatalf("capture %d differs from immutable winner", i)
+		}
+	}
+}
+
+type captureFixtureState struct {
+	request     Request
+	source      *staticProjectionSource
+	reader      *memoryObservationReader
+	resolver    *memoryTrustResolver
+	observation storage.ProviderVersionObservation
+}
+
+type staticProjectionSource struct {
+	projection manageddata.CapturedProjection
+}
+
+func (s *staticProjectionSource) CaptureManagedProjection(context.Context) (manageddata.CapturedProjection, error) {
+	return s.projection, nil
+}
+
+type memoryObservationReader struct {
+	mu     sync.RWMutex
+	values map[string]storage.ProviderVersionObservation
+}
+
+type memoryObservationVerifier struct {
+	expected storage.ProviderVersionObservation
+}
+
+func (v *memoryObservationVerifier) VerifyExact(_ context.Context, observation storage.ProviderVersionObservation) error {
+	if observation != v.expected {
+		return errors.New("exact provider version did not match verified bytes")
+	}
+	return nil
+}
+
+type memoryTrustResolver struct {
+	mu            sync.RWMutex
+	policy        TrustPolicy
+	second        *TrustPolicy
+	calls         int
+	source        *staticProjectionSource
+	base          recoveryset.RecoverySet
+	profiles      successor.ProviderProfileSet
+	scopeOverride *successor.ExpectedScope
+}
+
+func (r *memoryTrustResolver) Resolve(_ context.Context, request Request) (TrustPolicy, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	policy := r.policy
+	r.calls++
+	if r.calls > 1 && r.second != nil {
+		policy = *r.second
+	}
+	if r.scopeOverride != nil {
+		policy.ExpectedScope = *r.scopeOverride
+	} else {
+		policy.ExpectedScope = fixtureExpectedScope(request.Base, r.source.projection, r.profiles)
+	}
+	return policy, nil
+}
+
+type fixedClock struct{ value time.Time }
+
+func (c fixedClock) Now() time.Time { return c.value }
+
+type secretObservationCause struct{}
+
+func (*secretObservationCause) Error() string { return "provider token SECRET-DO-NOT-LEAK" }
+
+type failingObservationReader struct{ cause error }
+
+func (r failingObservationReader) ProviderVersionObservation(context.Context, string, string) (storage.ProviderVersionObservation, error) {
+	return storage.ProviderVersionObservation{}, r.cause
+}
+
+func fixtureExpectedScope(base recoveryset.RecoverySet, projection manageddata.CapturedProjection, _ successor.ProviderProfileSet) successor.ExpectedScope {
+	revisions := make([]successor.Revision, 0, len(projection.Revisions))
+	for _, captured := range projection.Revisions {
+		revision := successor.Revision{ProjectID: captured.ProjectID, CollectionID: captured.CollectionID, RevisionID: captured.RevisionID, RevisionManifestDigest: captured.ManifestDigest, Files: make([]successor.File, 0, len(captured.Files))}
+		for _, file := range captured.Files {
+			revision.Files = append(revision.Files, successor.File{Path: file.Path, SHA256: file.SHA256, Size: file.Size})
+		}
+		revisions = append(revisions, revision)
+	}
+	closure, _ := successor.ClosureDigest(revisions)
+	return successor.ExpectedScope{SetID: base.ID, ManagedClosureDigest: closure, Revisions: revisions, EmptyScopeVerified: len(revisions) == 0}
+}
+
+func (r *memoryObservationReader) ProviderVersionObservation(_ context.Context, profileID, objectKey string) (storage.ProviderVersionObservation, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	value, ok := r.values[observationKey(profileID, objectKey)]
+	if !ok {
+		return storage.ProviderVersionObservation{}, errors.New("observation not found")
+	}
+	return value, nil
+}
+
+func observationKey(profileID, objectKey string) string { return profileID + "\x00" + objectKey }
+
+func captureFixture(t *testing.T) (*Service, Request, *staticProjectionSource) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "testdata", "successor-legacy", "recoveryset-v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := recoveryset.ParseRecoverySet(bytes.TrimSpace(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("historical bytes")
+	hash := sha256.Sum256(content)
+	fileHash := hex.EncodeToString(hash[:])
+	manifestDigest := manageddata.Manifest{Files: []manageddata.File{{Path: "data.csv", SHA256: fileHash, Size: int64(len(content))}}}.RevisionID()
+	source := &staticProjectionSource{projection: manageddata.CapturedProjection{
+		DatabaseIdentity: "control-db", SystemIdentity: "777777", Timeline: 1, LSN: "0/ABC", RestorePointName: "provider_observation_capture",
+		Revisions: []manageddata.CapturedProjectionRevision{{ProjectID: "project-a", CollectionID: "collection-a", RevisionID: "revision-a", ManifestDigest: manifestDigest,
+			Files: []manageddata.CapturedProjectionFile{{Path: "data.csv", SHA256: fileHash, StorageKey: "s3://bucket-a/managed/data.csv", Size: int64(len(content))}}}},
+	}}
+	profile := storage.ProviderProfileIdentity{ProfileID: "profile-a", Implementation: "s3", AccountIdentity: "account-a", Endpoint: "https://objects.example.com", Region: "us-east-1", Bucket: "bucket-a", Namespace: "managed"}
+	observation := storage.ProviderVersionObservation{Profile: profile, ObjectKey: "managed/data.csv", VersionID: "version-a", SHA256: fileHash, Size: int64(len(content)), CapturedAt: time.Date(2026, 9, 9, 23, 59, 0, 0, time.UTC)}
+	reader := &memoryObservationReader{values: map[string]storage.ProviderVersionObservation{observationKey(profile.ProfileID, observation.ObjectKey): observation}}
+	profiles := successor.ProviderProfileSet{ProfileVersion: successor.ProviderProfileVersion, Profiles: []successor.ProviderProfile{{
+		Implementation: "s3", AccountIdentity: profile.AccountIdentity, Endpoint: profile.Endpoint, Region: profile.Region, Bucket: profile.Bucket, VersionSemantics: "opaque-exact-version",
+		Namespaces: []successor.Namespace{{ProjectID: "project-a", CollectionID: "collection-a", Prefix: "managed"}},
+	}}}
+	profileDigest, err := profiles.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKey := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{9}, ed25519.SeedSize))
+	authorities := successor.AuthorityRegistry{RegistryVersion: successor.AuthorityRegistryVersion, Keys: []successor.AuthorityKey{{
+		AuthorityID: "authority-a", KeyID: "key-a", Algorithm: "Ed25519", PublicKey: base64.StdEncoding.EncodeToString(privateKey.Public().(ed25519.PublicKey)),
+		NotBefore: "2026-09-09T00:00:00.000000Z", NotAfter: "2026-09-11T00:00:00.000000Z", ProviderProfileDigests: []string{profileDigest},
+	}}}
+	signer := SignerFunc(func(_ context.Context, request SigningRequest) ([]byte, error) {
+		return ed25519.Sign(privateKey, request.Payload), nil
+	})
+	verifier := &memoryObservationVerifier{expected: observation}
+	request := Request{
+		Base: base, CaptureID: "capture-a", AuthorityID: "authority-a", KeyID: "key-a",
+		StartedAt: time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC), CompletedAt: time.Date(2026, 9, 10, 0, 1, 0, 0, time.UTC),
+		Assignment: TrustAssignment{Generation: TrustGeneration{IncarnationID: "11111111-1111-4111-8111-111111111111", Revision: 1, PolicyDigest: "sha256:" + strings.Repeat("9", 64)}, WorkerFence: 7, Deadline: time.Date(2099, 9, 10, 2, 0, 0, 0, time.UTC)},
+	}
+	resolver := &memoryTrustResolver{source: source, base: base, profiles: profiles, policy: TrustPolicy{Profiles: profiles, Authorities: authorities, ProfileBindings: []ProfileBinding{{ProjectID: "project-a", CollectionID: "collection-a", Prefix: "managed", ObservationProfileID: profile.ProfileID}}}}
+	service, err := New(source, reader, verifier, signer, resolver, fixedClock{value: time.Date(2026, 9, 10, 1, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.policy.Assignment = request.Assignment
+	// The resolver computes expected scope from its independent closure view.
+	resolver.policy.ExpectedScope = fixtureExpectedScope(base, source.projection, profiles)
+	return service, request, source
+}
+
+func digestOf(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/recoveryset/postgres/manifest_capture_qualification_test.go
+++ b/internal/recoveryset/postgres/manifest_capture_qualification_test.go
@@ -1,0 +1,439 @@
+//go:build fai520qualification
+
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/manageddata"
+	managedpostgres "github.com/flidai/leapview/internal/manageddata/postgres"
+	"github.com/flidai/leapview/internal/manageddata/storage"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/recoveryset/capture"
+	"github.com/flidai/leapview/internal/recoveryset/successor"
+	jobspkg "github.com/flidai/leapview/pkg/jobs"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestFAI520ManifestCapturePostgreSQLQualification exercises the complete handoff:
+// PostgreSQL-owned managed-data closure and observations are consumed by the
+// capture service, then all signed v2 evidence is persisted through the
+// existing exact-version successor repository.
+func TestFAI520ManifestCapturePostgreSQLQualification(t *testing.T) {
+	t.Setenv("LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED", "1")
+	fixture := providerObservationFixtureDB(t)
+	ctx := t.Context()
+	tx, err := fixture.db.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplySchema(ctx, tx); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("apply recovery schema: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.db.Exec(ctx, SuccessorSchemaSQL()); err != nil {
+		t.Fatalf("apply successor schema: %v", err)
+	}
+	pool, admin, reopenURL := fixture.db, fixture.db, fixture.db.Config().ConnString()
+
+	managed := managedpostgres.New(admin)
+	projectID := projectgraph.ResourceID("project_manifest_capture")
+	collectionID := projectgraph.ResourceID("collection_manifest_capture")
+	const (
+		profileID = "profile-manifest-capture"
+		objectKey = "managed/orders.parquet"
+	)
+	content := []byte("durable managed bytes")
+	hash := sha256.Sum256(content)
+	fileSHA := hex.EncodeToString(hash[:])
+	manifest := manageddata.Manifest{Files: []manageddata.File{{Path: "orders.parquet", SHA256: fileSHA, Size: int64(len(content))}}}
+	collection, err := managed.CreateCollection(ctx, manageddata.CreateCollectionInput{
+		ID: collectionID, ProjectID: projectID, ConnectionID: projectgraph.ResourceID("connection_manifest_capture"), Name: "Manifest capture qualification",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := managed.CreateUploadSession(ctx, manageddata.CreateUploadSessionInput{
+		ID: manageddata.UploadID("upload_manifest_capture"), CollectionID: collection.ID, Manifest: manifest,
+		StorageBackend: "s3", StagingPrefix: "staging/manifest-capture", ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managed.BeginUploadFinalization(ctx, session.ID, jobspkg.WorkflowIntent{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managed.CompleteUpload(ctx, manageddata.CompleteUploadInput{
+		SessionID: session.ID, RevisionID: manageddata.RevisionID("revision_manifest_capture"),
+		Files: []manageddata.StoredFile{{File: manifest.Files[0], StorageKey: "s3://capture-bucket/" + objectKey}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := storage.ProviderProfileIdentity{
+		ProfileID: profileID, Implementation: "s3", AccountIdentity: "qualification-account",
+		Endpoint: "https://objects.example.test", Region: "test-region-1", Bucket: "capture-bucket", Namespace: "managed",
+	}
+	observed := storage.ProviderVersionObservation{
+		Profile: profile, ObjectKey: objectKey, VersionID: "immutable-orders-v1", SHA256: fileSHA,
+		Size: int64(len(content)), CapturedAt: time.Date(2026, 9, 9, 23, 59, 0, 0, time.UTC),
+	}
+	if _, err := managed.RecordProviderVersionObservation(ctx, observed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use separately pooled handles for the service's source and observation
+	// reads so the input is demonstrably durable, rather than process-local.
+	dsn := admin.Config().ConnString()
+	sourceDB := openManifestCapturePool(t, dsn)
+	observationDB := openManifestCapturePool(t, dsn)
+	source := managedpostgres.New(sourceDB)
+	observations := managedpostgres.New(observationDB)
+	durable, err := observations.ProviderVersionObservation(ctx, profileID, objectKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameManifestCaptureObservation(durable, observed) {
+		t.Fatalf("durable provider observation = %#v, want %#v", durable, observed)
+	}
+
+	base := manifestCaptureBase(t)
+	profiles := successor.ProviderProfileSet{ProfileVersion: successor.ProviderProfileVersion, Profiles: []successor.ProviderProfile{{
+		Implementation: "s3", AccountIdentity: profile.AccountIdentity, Endpoint: profile.Endpoint, Region: profile.Region,
+		Bucket: profile.Bucket, VersionSemantics: "opaque-exact-version",
+		Namespaces: []successor.Namespace{{ProjectID: projectID.String(), CollectionID: collectionID.String(), Prefix: profile.Namespace}},
+	}}}
+	profileDigest, err := profiles.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKey := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{17}, ed25519.SeedSize))
+	authorities := successor.AuthorityRegistry{RegistryVersion: successor.AuthorityRegistryVersion, Keys: []successor.AuthorityKey{{
+		AuthorityID: "authority-manifest-capture", KeyID: "key-manifest-capture", Algorithm: "Ed25519",
+		PublicKey: base64.StdEncoding.EncodeToString(privateKey.Public().(ed25519.PublicKey)),
+		NotBefore: "2026-09-09T00:00:00.000000Z", NotAfter: "2099-09-11T00:00:00.000000Z", ProviderProfileDigests: []string{profileDigest},
+	}}}
+	expectedRevisions := []successor.Revision{{
+		ProjectID: projectID.String(), CollectionID: collectionID.String(), RevisionID: "revision_manifest_capture", RevisionManifestDigest: manifest.RevisionID(),
+		Files: []successor.File{{Path: manifest.Files[0].Path, SHA256: manifest.Files[0].SHA256, Size: manifest.Files[0].Size}},
+	}}
+	closureDigest, err := successor.ClosureDigest(expectedRevisions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assignment := capture.TrustAssignment{
+		Generation: capture.TrustGeneration{
+			IncarnationID: "11111111-1111-4111-8111-111111111111", Revision: 1,
+			PolicyDigest: "sha256:" + strings.Repeat("9", 64),
+		},
+		WorkerFence: 7,
+		Deadline:    time.Date(2099, 9, 10, 2, 0, 0, 0, time.UTC),
+	}
+	policy := capture.TrustPolicy{
+		Profiles:    profiles,
+		Authorities: authorities,
+		ProfileBindings: []capture.ProfileBinding{{
+			ProjectID: projectID.String(), CollectionID: collectionID.String(), Prefix: profile.Namespace, ObservationProfileID: profileID,
+		}},
+		ExpectedScope: successor.ExpectedScope{
+			SetID: base.ID, ManagedClosureDigest: closureDigest, Revisions: expectedRevisions,
+		},
+		Assignment: assignment,
+	}
+	request := capture.Request{
+		Base: base, CaptureID: "capture-manifest-capture", AuthorityID: "authority-manifest-capture", KeyID: "key-manifest-capture",
+		StartedAt: time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC), CompletedAt: time.Date(2026, 9, 10, 0, 1, 0, 0, time.UTC),
+		Assignment: assignment,
+	}
+	verifier := manifestCaptureObservationVerifier{versions: map[string][]byte{observed.VersionID: bytes.Clone(content)}}
+	signer := capture.SignerFunc(func(_ context.Context, signing capture.SigningRequest) ([]byte, error) {
+		return ed25519.Sign(privateKey, signing.Payload), nil
+	})
+	resolver := capture.PolicyScopeResolverFunc(func(context.Context, capture.Request) (capture.TrustPolicy, error) { return policy, nil })
+	clock := capture.ClockFunc(func() time.Time { return time.Date(2026, 9, 10, 1, 0, 0, 0, time.UTC) })
+	service, err := capture.New(source, observations, verifier, signer, resolver, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := service.Capture(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Evidence.Manifest.Revisions) != 1 || len(result.Evidence.Manifest.Revisions[0].Files) != 1 {
+		t.Fatalf("captured managed closure = %#v", result.Evidence.Manifest.Revisions)
+	}
+	gotRevision := result.Evidence.Manifest.Revisions[0]
+	if gotRevision.ProjectID != projectID.String() || gotRevision.CollectionID != collectionID.String() || gotRevision.RevisionID != "revision_manifest_capture" {
+		t.Fatalf("captured managed revision identity = %#v", gotRevision)
+	}
+	gotFile := gotRevision.Files[0]
+	if gotFile.Provider.VersionID != observed.VersionID || gotFile.Provider.Key != objectKey {
+		t.Fatalf("captured exact provider identity = %#v", gotFile.Provider)
+	}
+
+	reader := &manifestCapturePayloadReader{objects: make(map[ValidatedLocator][]byte)}
+	payloads := manifestCapturePayloads(t, result, reader)
+	trust := TrustInput{Evidence: result.Evidence, Generation: TrustGeneration{
+		IncarnationID: assignment.Generation.IncarnationID, Revision: assignment.Generation.Revision, PolicyDigest: assignment.Generation.PolicyDigest,
+	}}
+	if _, err := admin.Exec(ctx, `INSERT INTO recovery.successor_trust_generation(singleton,incarnation_id,revision,policy_digest) VALUES(true,$1,$2,$3)`, trust.Generation.IncarnationID, trust.Generation.Revision, trust.Generation.PolicyDigest); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewSuccessorRepository(pool, SuccessorOptions{Reader: reader,
+		Trust: func(context.Context, string) (TrustInput, error) { return trust, nil }})
+	input := Set3Input{Set: result.Set, Payloads: payloads}
+	created, err := repository.CreateSet3(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateSet3: %v", err)
+	}
+	createdBytes, err := created.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(createdBytes, payloads.Set.CanonicalBytes) {
+		t.Fatal("stored set input was not the service's canonical set bytes")
+	}
+
+	// Exact retries are byte-identical and the repository converges under
+	// concurrent identical requests.
+	for range 2 {
+		retried, retryErr := repository.CreateSet3(ctx, input)
+		if retryErr != nil {
+			t.Fatalf("exact CreateSet3 retry: %v", retryErr)
+		}
+		retriedBytes, _ := retried.CanonicalJSON()
+		if !bytes.Equal(createdBytes, retriedBytes) {
+			t.Fatal("exact CreateSet3 retry changed canonical set bytes")
+		}
+	}
+	const workers = 8
+	errResults := make(chan error, workers)
+	start := make(chan struct{})
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			_, err := repository.CreateSet3(context.Background(), input)
+			errResults <- err
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(errResults)
+	for err := range errResults {
+		if err != nil {
+			t.Fatalf("concurrent identical CreateSet3: %v", err)
+		}
+	}
+
+	// A separately valid capture for the same set identity cannot replace the
+	// immutable winner, even when its own receipt and evidence graph verify.
+	conflictingRequest := request
+	conflictingRequest.CaptureID = "capture-manifest-conflict"
+	conflicting, err := service.Capture(ctx, conflictingRequest)
+	if err != nil {
+		t.Fatalf("construct conflicting capture: %v", err)
+	}
+	conflictingTrust := trust
+	conflictingTrust.Evidence = conflicting.Evidence
+	conflictingRepo := NewSuccessorRepository(pool, SuccessorOptions{Reader: reader,
+		Trust: func(context.Context, string) (TrustInput, error) { return conflictingTrust, nil }})
+	conflictingInput := Set3Input{Set: conflicting.Set, Payloads: manifestCapturePayloads(t, conflicting, reader)}
+	if _, err := conflictingRepo.CreateSet3(ctx, conflictingInput); !errors.Is(err, ErrSuccessorConflict) {
+		t.Fatalf("conflicting CreateSet3 error = %v, want immutable conflict", err)
+	}
+
+	// A separately authenticated/restarted repository still reads every exact
+	// payload from the in-memory versioned locator fixture.
+	reopened := openManifestCapturePool(t, reopenURL)
+	readRepo := NewSuccessorRepository(reopened, SuccessorOptions{Reader: reader,
+		Trust: func(context.Context, string) (TrustInput, error) { return trust, nil }})
+	read, err := readRepo.ReadSet3(ctx, result.Set.ID)
+	if err != nil {
+		t.Fatalf("separate repository ReadSet3: %v", err)
+	}
+	readBytes, err := read.CanonicalJSON()
+	if err != nil || !bytes.Equal(readBytes, createdBytes) {
+		t.Fatalf("separate repository canonical set = %q, err=%v", readBytes, err)
+	}
+	reader.mu.Lock()
+	if reader.reads == 0 || reader.reads != reader.closes {
+		t.Fatalf("exact payload readers leaked: reads=%d closes=%d", reader.reads, reader.closes)
+	}
+	reader.mu.Unlock()
+
+	stale := trust
+	stale.Generation.Revision++
+	staleRepo := NewSuccessorRepository(reopened, SuccessorOptions{Reader: reader,
+		Trust: func(context.Context, string) (TrustInput, error) { return stale, nil }})
+	if _, err := staleRepo.ReadSet3(ctx, result.Set.ID); !errors.Is(err, ErrSuccessorConflict) {
+		t.Fatalf("stale trust generation error = %v, want conflict", err)
+	}
+	badSignature := trust
+	badSignature.Evidence.Receipt.Signature = base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	badRepo := NewSuccessorRepository(reopened, SuccessorOptions{Reader: reader,
+		Trust: func(context.Context, string) (TrustInput, error) { return badSignature, nil }})
+	if _, err := badRepo.ReadSet3(ctx, result.Set.ID); !errors.Is(err, ErrSuccessorTampered) {
+		t.Fatalf("receipt substitution error = %v, want tampered evidence", err)
+	}
+}
+
+func openManifestCapturePool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	p, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(p.Close)
+	return p
+}
+
+func manifestCaptureBase(t *testing.T) recoveryset.RecoverySet {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "testdata", "successor-legacy", "recoveryset-v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := recoveryset.ParseRecoverySet(bytes.TrimSpace(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base
+}
+
+func manifestCapturePayloads(t *testing.T, result capture.Result, reader *manifestCapturePayloadReader) EvidencePayloads {
+	t.Helper()
+	setDigest, err := result.Set.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest, err := result.Evidence.Manifest.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchorDigest, err := result.Evidence.Anchor.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	profilesDigest, err := result.Evidence.Profiles.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptDigest, err := result.Evidence.Receipt.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorityDigest, err := result.Evidence.Authorities.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return EvidencePayloads{
+		Set:       manifestCapturePayloadRef(t, PayloadFamilySet, successor.RecoverySetVersion, setDigest, result.Documents.Set, reader, "set"),
+		Manifest:  manifestCapturePayloadRef(t, PayloadFamilyManifest, successor.ManagedManifestVersion, manifestDigest, result.Documents.Manifest, reader, "manifest"),
+		Anchor:    manifestCapturePayloadRef(t, PayloadFamilyAnchor, successor.SourceAnchorVersion, anchorDigest, result.Documents.Anchor, reader, "anchor"),
+		Profiles:  manifestCapturePayloadRef(t, PayloadFamilyProfiles, successor.ProviderProfileVersion, profilesDigest, result.Documents.Profiles, reader, "profiles"),
+		Receipt:   manifestCapturePayloadRef(t, PayloadFamilyReceipt, successor.ReceiptVersion, receiptDigest, result.Documents.Receipt, reader, "receipt"),
+		Authority: manifestCapturePayloadRef(t, PayloadFamilyAuthority, successor.AuthorityRegistryVersion, authorityDigest, result.Documents.Authorities, reader, "authority"),
+	}
+}
+
+func manifestCapturePayloadRef(t *testing.T, family string, version int32, digest string, raw []byte, reader *manifestCapturePayloadReader, name string) PayloadReference {
+	t.Helper()
+	sum := sha256.Sum256(raw)
+	sha := hex.EncodeToString(sum[:])
+	locator := ValidatedLocator{
+		Backend: "s3", StorageProfileID: "22222222-2222-4222-8222-222222222222", StorageProfileRevision: 1,
+		AccountIdentity: "qualification", Endpoint: "https://evidence.example.test", Region: "test-region-1", Bucket: "evidence-bucket", Namespace: "evidence",
+		Key:       "evidence/" + strings.TrimPrefix(family, "leapview.") + "/v" + strconv.Itoa(int(version)) + "/sha256/" + sha,
+		VersionID: "immutable-" + name, PayloadFamily: family, PayloadVersion: version, PayloadDigest: digest, PayloadSHA256: sha, PayloadSize: int64(len(raw)),
+	}
+	if err := locator.Validate(); err != nil {
+		t.Fatalf("%s locator: %v", name, err)
+	}
+	reader.mu.Lock()
+	reader.objects[locator] = bytes.Clone(raw)
+	reader.mu.Unlock()
+	return PayloadReference{Locator: locator, CanonicalBytes: bytes.Clone(raw)}
+}
+
+// manifestCaptureObservationVerifier models the exact-version provider
+// boundary: the observed VersionID chooses immutable bytes, and the digest
+// and size returned by PostgreSQL must agree with those bytes.
+type manifestCaptureObservationVerifier struct {
+	versions map[string][]byte
+}
+
+func (v manifestCaptureObservationVerifier) VerifyExact(_ context.Context, observation storage.ProviderVersionObservation) error {
+	raw, ok := v.versions[observation.VersionID]
+	if !ok {
+		return errors.New("exact provider version is unavailable")
+	}
+	sum := sha256.Sum256(raw)
+	if observation.Size != int64(len(raw)) || observation.SHA256 != hex.EncodeToString(sum[:]) {
+		return errors.New("exact provider bytes do not match durable observation")
+	}
+	return nil
+}
+
+func sameManifestCaptureObservation(left, right storage.ProviderVersionObservation) bool {
+	return left.Profile == right.Profile && left.ObjectKey == right.ObjectKey && left.VersionID == right.VersionID &&
+		left.SHA256 == right.SHA256 && left.Size == right.Size && left.CapturedAt.Equal(right.CapturedAt)
+}
+
+type manifestCapturePayloadReader struct {
+	mu      sync.Mutex
+	objects map[ValidatedLocator][]byte
+	reads   int
+	closes  int
+}
+
+type manifestCapturePayloadBody struct {
+	io.Reader
+	close func()
+}
+
+func (b *manifestCapturePayloadBody) Close() error {
+	b.close()
+	return nil
+}
+
+func (r *manifestCapturePayloadReader) ReadExact(ctx context.Context, locator ValidatedLocator) (io.ReadCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	raw, ok := r.objects[locator]
+	if ok {
+		raw = bytes.Clone(raw)
+		r.reads++
+	}
+	r.mu.Unlock()
+	if !ok {
+		return nil, errors.New("exact payload version unavailable")
+	}
+	return &manifestCapturePayloadBody{Reader: bytes.NewReader(raw), close: func() {
+		r.mu.Lock()
+		r.closes++
+		r.mu.Unlock()
+	}}, nil
+}

--- a/internal/recoveryset/postgres/observation_capture_qualification_test.go
+++ b/internal/recoveryset/postgres/observation_capture_qualification_test.go
@@ -86,6 +86,16 @@ func TestProviderObservationCaptureQualification(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	projection, err := managed.CaptureManagedProjection(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projection.Revisions) != 1 {
+		t.Fatalf("captured projection revisions = %#v", projection.Revisions)
+	}
+	if got := projection.Revisions[0]; got.ProjectID != collection.ProjectID.String() || got.CollectionID != collection.ID.String() || got.RevisionID != "revision_observation" {
+		t.Fatalf("captured revision identity = %#v, want project=%q collection=%q revision=%q", got, collection.ProjectID, collection.ID, "revision_observation")
+	}
 
 	first, err := Capture(ctx, managed)
 	if err != nil {


### PR DESCRIPTION
## Problem

Durable provider-version observations can be stored and replayed, but FAI-520 had no bounded path that assembled the authoritative managed revision closure into canonical Manifest v2 evidence, signed it under independently resolved trust, and handed it to existing RecoverySet v3 persistence.

## Solution

- Capture the PostgreSQL-owned ready revision projection and join every file to its durable provider-version observation.
- Re-verify each exact S3 VersionID using trusted profile configuration, returned version, byte size, and streamed SHA-256.
- Independently resolve expected closure membership, provider profiles, signing authority, trust generation, worker fence, and deadline.
- Build the frozen source anchor, canonical ManagedObservationManifest v2, detached Ed25519 receipt, and RecoverySet v3 documents.
- Re-resolve trust immediately before signing and validate the complete evidence graph before returning canonical documents.
- Reuse the existing CreateSet3 path for immutable PostgreSQL association, deterministic retries, conflict rejection, and restart readback.
- Preserve existing RecoverySet v1 normalization, bytes, hashes, and guarantees.

## Tests added and updated

- Deterministic canonical bytes and digest mutation coverage.
- Missing, conflicting, stale, incomplete, and substituted provider observations.
- Unknown/revoked authorities, stale generation/fence, changed trust policy, signer failure, and signature mismatch.
- Exact-version S3 verification using the production Store verifier and disposable MinIO qualification.
- PostgreSQL CreateSet3 retry, concurrency, immutable conflict, close/reopen readback, and trust-tamper qualification.
- Recovery evidence qualification workflow coverage for the new capture package.

## Verification

- Focused manifest, capture, successor, managed-data, S3, RecoverySet, PostgreSQL, and MinIO qualification tests passed.
- Repeated tagged PostgreSQL/MinIO qualification under the race detector passed.
- Architecture tests and go vet passed.
- task generated:check, task docs:check, and git diff --check passed.
- Full local task ci passed before the non-overlapping rebase onto origin/main.
- After rebase, focused race tests, go vet, docs/generated checks, git diff --check, and the new upstream performance guard tests passed.

## Remaining limitations

- The frozen standalone managed-capture-core transport family is not independently persisted by CreateSet3; the core is currently included in the receipt. This remains a blocker for complete production evidence transport.
- This does not deploy production signing keys or capture authority.
- This does not establish provider retention guarantees.
- This does not add recovery admission, startup recovery, restore orchestration, PITR, activation, or RPO/RTO qualification.

Signed evidence does not prove physical disaster recovery.
