### PR TITLE
fix(ci): allow performance gate to read reviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,9 @@ jobs:
     needs: [prepare, apigen-validation, go-packages-validation, go-application-validation, frontend-validation, postgres-isolation-validation, spatial-tile-benchmarks, dbt-warehouse-boundary-validation, docs-validation, quality-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Require successful planning
         env:

--- a/scripts/frontend_ci_contract.test.ts
+++ b/scripts/frontend_ci_contract.test.ts
@@ -5,6 +5,14 @@ import { parse } from 'yaml'
 const shards = ['core', 'reports', 'chat', 'data', 'site']
 const tasks = parse(readFileSync('Taskfile.yml', 'utf8')).tasks
 
+test('CI gate can read the independent pull-request review it enforces', () => {
+  const config = parse(readFileSync('.github/workflows/ci.yml', 'utf8'))
+  expect(config.jobs['ci-gate'].permissions).toEqual({
+    contents: 'read',
+    'pull-requests': 'read',
+  })
+})
+
 test('local frontend validation runs every bounded shard without suppressing failure', () => {
   expect(tasks['ci:lane:frontend'].cmds).toEqual(shards.map((shard) => ({
     task: 'ci:lane:frontend:shard', vars: { SHARD: shard },


### PR DESCRIPTION
## Summary
- grant the aggregate CI gate least-privilege read access to pull-request review metadata
- retain explicit contents read access required by checkout
- add a contract test that prevents silent permission removal or expansion

## Why
PR #541 has a valid independent exact-head approval, but the trusted workflow on `main` cannot observe it. Its token inherits only `contents: read`, so the fail-closed performance review guard receives no qualifying review and correctly refuses to pass. This bootstrap change gives only the gate job the read permission it needs.

## Validation
- `bun test scripts/frontend_ci_contract.test.ts` (5 passed)
- `git diff --check`
- independent diff review: no findings

## Delivery
This PR targets `main`. Do not merge until reviewed and explicitly approved. After merge, rerun PR #541 CI without changing its approved head.