### PR TITLE
feat(recovery): persist managed capture core transport evidence

### DIFF
--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -1954,7 +1954,10 @@ core remains embedded in the detached receipt for signature verification, but
 the transport persistence path now requires the independent
 `leapview.managed-capture-core` version-2 bytes and frozen domain digest. New
 associations retain the core locator and verify its exact bytes and relation to
-the receipt and manifest. An explicit persistence marker distinguishes those
+the receipt and manifest. The association verification metadata records the
+resolved worker fence, and the same transaction locks the authoritative trust
+generation row and rejects a changed generation or fence before inserting any
+evidence. An explicit persistence marker distinguishes those
 associations from the legacy embedded-only form. Historical v3 rows and
 in-flight older writers remain compatible without backfill; they retain the
 original embedded receipt-core behavior, are not presented as independently

--- a/docs/articles/data/storage-recovery.md
+++ b/docs/articles/data/storage-recovery.md
@@ -421,7 +421,7 @@ adapter.
 ### Intended qualification cases
 
 The qualification uses a disposable versioned MinIO bucket and the frozen
-RecoverySet v3 evidence bundle. It uploads all six canonical payloads, captures
+RecoverySet v3 evidence bundle. It uploads all seven canonical payloads, captures
 their provider VersionIDs, overwrites each current object, and creates a delete
 marker before the repository reads anything. `CreateSet3` succeeds only by
 using the selected historical versions. After the PostgreSQL connection is
@@ -1946,11 +1946,19 @@ PostgreSQL. The transaction performs no provider I/O. A separate connection
 can read back the same exact payloads and reverify them under independently
 resolved trust.
 
-This slice follows the current `CreateSet3` bundle, where the capture core is
-embedded in the detached receipt and committed by its domain digest. It does
-not add the separately located capture-core transport entry described by the
-frozen transport design; that representation must be reconciled explicitly
-before production evidence upload is enabled.
+### Managed-capture-core persistence boundary
+
+This slice extends the `CreateSet3` bundle with the separately located,
+canonical capture-core entry described by the frozen transport design. The
+core remains embedded in the detached receipt for signature verification, but
+the transport persistence path now requires the independent
+`leapview.managed-capture-core` version-2 bytes and frozen domain digest. New
+associations retain the core locator and verify its exact bytes and relation to
+the receipt and manifest. An explicit persistence marker distinguishes those
+associations from the legacy embedded-only form. Historical v3 rows and
+in-flight older writers remain compatible without backfill; they retain the
+original embedded receipt-core behavior, are not presented as independently
+transported core payloads, and cannot be silently upgraded by retry.
 
 ### Deterministic and failure behavior
 
@@ -1972,7 +1980,11 @@ association is accepted.
 This qualification does not establish provider retention, restart durability of
 the source system, PostgreSQL restore or PITR, physical provider recovery,
 production signer/key deployment, or RPO/RTO. It also does not grant admission,
-startup, publication, or activation authority. Standalone capture-core payload
-transport remains unresolved as noted above. Signed evidence does not prove physical disaster recovery.
+startup, publication, or activation authority. Standalone capture-core
+transport is bounded to this persistence slice; upload intent execution,
+provider retention and production evidence enablement remain separate. Signed
+evidence does not prove physical disaster recovery.
+
+Evidence persistence does not prove physical disaster recovery.
 
 This validates recovery evidence binding. It does not prove successful physical disaster recovery.

--- a/internal/platform/postgres/migrations/012_recovery_capture_core_transport.sql
+++ b/internal/platform/postgres/migrations/012_recovery_capture_core_transport.sql
@@ -90,6 +90,30 @@ ALTER TABLE recovery.recovery_set_v3
     REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
     ON DELETE RESTRICT NOT VALID;
 
+-- Historical generation rows predate assignment fencing, so the new value is
+-- nullable for read compatibility. New successor associations fail closed
+-- unless the independently managed row carries a positive current fence.
+ALTER TABLE recovery.successor_trust_generation
+    ADD COLUMN IF NOT EXISTS worker_fence bigint;
+ALTER TABLE recovery.successor_trust_generation
+    ADD CONSTRAINT successor_trust_generation_worker_fence_ck
+    CHECK (worker_fence IS NULL OR worker_fence > 0);
+
+-- Preserve the existing three-column function for in-flight older binaries.
+-- New writers lock the same singleton row through this fenced variant.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION recovery.lock_successor_assignment()
+RETURNS TABLE(incarnation_id uuid, revision bigint, policy_digest text, worker_fence bigint)
+LANGUAGE sql SECURITY DEFINER
+SET search_path = pg_catalog, recovery
+AS $$
+    SELECT g.incarnation_id, g.revision, g.policy_digest, g.worker_fence
+      FROM recovery.successor_trust_generation AS g
+     WHERE g.singleton = true
+     FOR UPDATE
+$$;
+-- +goose StatementEnd
+
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION recovery.guard_successor_set_complete()
 RETURNS trigger LANGUAGE plpgsql
@@ -123,6 +147,7 @@ $$;
 REVOKE ALL ON TABLE recovery.successor_evidence_v2,
     recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
     recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM PUBLIC;
+REVOKE ALL ON FUNCTION recovery.lock_successor_assignment() FROM PUBLIC;
 -- +goose StatementBegin
 DO $$
 BEGIN
@@ -130,6 +155,7 @@ BEGIN
         GRANT SELECT, INSERT ON TABLE recovery.successor_evidence_v2,
             recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
             recovery.recovery_set_v3, recovery.recovery_set_v3_root TO leapview_control_maintenance;
+        GRANT EXECUTE ON FUNCTION recovery.lock_successor_assignment() TO leapview_control_maintenance;
         REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.successor_evidence_v2,
             recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
             recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM leapview_control_maintenance;

--- a/internal/platform/postgres/migrations/012_recovery_capture_core_transport.sql
+++ b/internal/platform/postgres/migrations/012_recovery_capture_core_transport.sql
@@ -1,0 +1,170 @@
+-- +goose Up
+SET LOCAL ROLE leapview_control_owner;
+
+-- FAI-520 capture-core transport is additive. Existing evidence rows and v3
+-- associations are retained byte-for-byte. Nullable capture references and an
+-- explicit required marker preserve both historical rows and in-flight older
+-- writers without presenting embedded receipt cores as standalone transport.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    -- The original migration left these checks unnamed. Identify only the
+    -- family/domain checks so their existing canonical-byte checks remain
+    -- untouched while the allowlist gains the core family.
+    FOR constraint_name IN
+        SELECT c.conname
+          FROM pg_constraint AS c
+         WHERE c.conrelid = 'recovery.successor_evidence_v2'::regclass
+           AND c.contype = 'c'
+           AND (pg_get_constraintdef(c.oid) LIKE '%payload_family%'
+                OR pg_get_constraintdef(c.oid) LIKE '%payload_digest = recovery.successor_domain_sha256%')
+    LOOP
+        EXECUTE format('ALTER TABLE recovery.successor_evidence_v2 DROP CONSTRAINT %I', constraint_name);
+    END LOOP;
+    FOR constraint_name IN
+        SELECT c.conname
+          FROM pg_constraint AS c
+         WHERE c.conrelid = 'recovery.successor_evidence_locator_v2'::regclass
+           AND c.contype = 'c'
+           AND pg_get_constraintdef(c.oid) LIKE '%payload_family%'
+    LOOP
+        EXECUTE format('ALTER TABLE recovery.successor_evidence_locator_v2 DROP CONSTRAINT %I', constraint_name);
+    END LOOP;
+END
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE recovery.successor_evidence_v2
+    ADD CONSTRAINT successor_evidence_v2_family_core_ck
+    CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'core', 'receipt', 'authority'));
+ALTER TABLE recovery.successor_evidence_v2
+    ADD CONSTRAINT successor_evidence_v2_domain_core_ck
+    CHECK (payload_digest = recovery.successor_domain_sha256(
+        CASE payload_family
+            WHEN 'manifest' THEN 'leapview/managed-observations/v2'
+            WHEN 'anchor' THEN 'leapview/recovery-source-anchor/v2'
+            WHEN 'profile' THEN 'leapview/managed-provider-profiles/v2'
+            WHEN 'core' THEN 'leapview/managed-capture-core/v2'
+            WHEN 'receipt' THEN 'leapview/managed-capture-receipt/v2'
+            WHEN 'authority' THEN 'leapview/authority-registry/v2'
+        END || chr(10), canonical_bytes));
+ALTER TABLE recovery.successor_evidence_locator_v2
+    ADD CONSTRAINT successor_evidence_locator_v2_family_core_ck
+    CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'core', 'receipt', 'authority'));
+
+ALTER TABLE recovery.successor_manifest_binding
+    ADD COLUMN IF NOT EXISTS capture_core_digest text;
+ALTER TABLE recovery.successor_manifest_binding
+    ADD COLUMN IF NOT EXISTS capture_core_required boolean NOT NULL DEFAULT false;
+ALTER TABLE recovery.successor_manifest_binding
+    ADD COLUMN IF NOT EXISTS core_family text GENERATED ALWAYS AS ('core') STORED;
+ALTER TABLE recovery.successor_manifest_binding
+    ADD COLUMN IF NOT EXISTS core_version smallint GENERATED ALWAYS AS (2) STORED;
+ALTER TABLE recovery.successor_manifest_binding
+    ADD CONSTRAINT successor_manifest_binding_core_digest_ck
+    CHECK ((capture_core_required AND capture_core_digest IS NOT NULL AND capture_core_digest ~ '^sha256:[0-9a-f]{64}$') OR
+           (NOT capture_core_required AND capture_core_digest IS NULL));
+ALTER TABLE recovery.successor_manifest_binding
+    ADD CONSTRAINT successor_manifest_binding_core_fk
+    FOREIGN KEY (core_family, core_version, capture_core_digest)
+    REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
+    ON DELETE RESTRICT;
+
+ALTER TABLE recovery.recovery_set_v3
+    ADD COLUMN IF NOT EXISTS capture_core_digest text;
+ALTER TABLE recovery.recovery_set_v3
+    ADD COLUMN IF NOT EXISTS capture_core_required boolean NOT NULL DEFAULT false;
+ALTER TABLE recovery.recovery_set_v3
+    ADD COLUMN IF NOT EXISTS core_family text GENERATED ALWAYS AS ('core') STORED;
+ALTER TABLE recovery.recovery_set_v3
+    ADD COLUMN IF NOT EXISTS core_version smallint GENERATED ALWAYS AS (2) STORED;
+ALTER TABLE recovery.recovery_set_v3
+    ADD CONSTRAINT recovery_set_v3_capture_core_ck
+    CHECK ((capture_core_required AND capture_core_digest IS NOT NULL AND capture_core_digest = receipt_core_digest) OR
+           (NOT capture_core_required AND capture_core_digest IS NULL));
+ALTER TABLE recovery.recovery_set_v3
+    ADD CONSTRAINT recovery_set_v3_core_fk
+    FOREIGN KEY (core_family, core_version, capture_core_digest)
+    REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
+    ON DELETE RESTRICT NOT VALID;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION recovery.guard_successor_set_complete()
+RETURNS trigger LANGUAGE plpgsql
+SET search_path = pg_catalog, recovery
+AS $$
+BEGIN
+    IF (SELECT count(*) FROM recovery.recovery_set_v3_root WHERE set_id = NEW.set_id) <> 2
+       OR (SELECT count(*) FROM recovery.recovery_set_v3_root WHERE set_id = NEW.set_id AND root_kind IN ('ducklake', 'serving-artifact')) <> 2 THEN
+        RAISE EXCEPTION 'prepared successor recovery set requires exactly two canonical roots';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = s.manifest_family AND l.payload_version = s.manifest_version AND l.payload_digest = s.manifest_digest)
+       OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = s.anchor_family AND l.payload_version = s.anchor_version AND l.payload_digest = s.anchor_digest)
+       OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = s.profile_family AND l.payload_version = s.profile_version AND l.payload_digest = s.profile_digest)
+       OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = s.receipt_family AND l.payload_version = s.receipt_version AND l.payload_digest = s.receipt_digest)
+       OR (EXISTS (SELECT 1 FROM recovery.recovery_set_v3 s WHERE s.set_id = NEW.set_id AND s.capture_core_required)
+           AND NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = 'core' AND l.payload_version = 2 AND l.payload_digest = s.capture_core_digest))
+       OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+                   WHERE l.payload_family = s.authority_family AND l.payload_version = s.authority_version AND l.payload_digest = s.authority_digest) THEN
+        RAISE EXCEPTION 'prepared successor recovery set requires exact locators for every selected evidence payload';
+    END IF;
+    RETURN NEW;
+END
+$$;
+-- +goose StatementEnd
+
+REVOKE ALL ON TABLE recovery.successor_evidence_v2,
+    recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+    recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM PUBLIC;
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_maintenance') THEN
+        GRANT SELECT, INSERT ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root TO leapview_control_maintenance;
+        REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM leapview_control_maintenance;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_runtime') THEN
+        REVOKE ALL ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM leapview_control_runtime;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_readonly') THEN
+        GRANT SELECT ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root TO leapview_control_readonly;
+        REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM leapview_control_readonly;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_backup') THEN
+        GRANT SELECT ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root TO leapview_control_backup;
+        REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.successor_evidence_v2,
+            recovery.successor_evidence_locator_v2, recovery.successor_manifest_binding,
+            recovery.recovery_set_v3, recovery.recovery_set_v3_root FROM leapview_control_backup;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+RESET ROLE;
+
+-- +goose Down
+SET LOCAL ROLE leapview_control_owner;
+-- +goose StatementBegin
+DO $$ BEGIN
+    RAISE EXCEPTION 'capture-core transport migration is immutable; destructive down is forbidden';
+END $$;
+-- +goose StatementEnd
+RESET ROLE;

--- a/internal/platform/postgres/migrations/goose.go
+++ b/internal/platform/postgres/migrations/goose.go
@@ -25,7 +25,7 @@ const (
 	// CurrentRevision is the latest control-plane schema revision understood by
 	// this binary. Serving admission requires every embedded migration through
 	// this revision to be applied.
-	CurrentRevision int64 = 11
+	CurrentRevision int64 = 12
 	// AdvisoryLockKey serializes migration attempts across instances. Goose
 	// owns acquisition and release of this session-level PostgreSQL lock. The
 	// combined River+Goose path below uses the same key for one shared fence.

--- a/internal/platform/postgres/migrations/migrations_test.go
+++ b/internal/platform/postgres/migrations/migrations_test.go
@@ -112,6 +112,8 @@ func TestCaptureCoreTransportMigrationIsAdditiveAndImmutable(t *testing.T) {
 		"leapview/managed-capture-core/v2",
 		"receipt_core_digest",
 		"capture_core_required",
+		"worker_fence",
+		"lock_successor_assignment",
 		"NOT VALID",
 		"guard_successor_set_complete",
 		"GRANT SELECT, INSERT",
@@ -199,6 +201,11 @@ func TestSuccessorV3MigrationMirrorsOwnerSchemaAndRefusesDestructiveDown(t *test
 		t.Fatal(err)
 	}
 	migration := string(migrationBytes)
+	captureCoreBytes, err := fs.ReadFile(MigrationFS(), "012_recovery_capture_core_transport.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentSuccessorMigrations := migration + "\n" + string(captureCoreBytes)
 	owner := recoverypostgres.SuccessorSchemaSQL()
 	for _, marker := range []string{
 		"recovery.set_identity_registry",
@@ -210,10 +217,11 @@ func TestSuccessorV3MigrationMirrorsOwnerSchemaAndRefusesDestructiveDown(t *test
 		"recovery.recovery_set_v3_root",
 		"successor_domain_sha256",
 		"lock_successor_generation",
+		"lock_successor_assignment",
 		"guard_successor_set_complete",
 		"successor_registry_immutable",
 	} {
-		if !strings.Contains(owner, marker) || !strings.Contains(migration, marker) {
+		if !strings.Contains(owner, marker) || !strings.Contains(currentSuccessorMigrations, marker) {
 			t.Errorf("successor schema/migration missing %q", marker)
 		}
 	}
@@ -233,14 +241,18 @@ func TestSuccessorV3MigrationMirrorsOwnerSchemaAndRefusesDestructiveDown(t *test
 	for _, pattern := range patterns {
 		matches := func(source string) []string {
 			all := pattern.FindAllStringSubmatch(source, -1)
-			names := make([]string, 0, len(all))
+			unique := make(map[string]struct{}, len(all))
 			for _, match := range all {
-				names = append(names, match[1])
+				unique[match[1]] = struct{}{}
+			}
+			names := make([]string, 0, len(unique))
+			for name := range unique {
+				names = append(names, name)
 			}
 			return names
 		}
 		ownerNames := matches(owner)
-		migrationNames := matches(migration)
+		migrationNames := matches(currentSuccessorMigrations)
 		sort.Strings(ownerNames)
 		sort.Strings(migrationNames)
 		if len(ownerNames) != len(migrationNames) {

--- a/internal/platform/postgres/migrations/migrations_test.go
+++ b/internal/platform/postgres/migrations/migrations_test.go
@@ -27,7 +27,7 @@ func TestEmbeddedGooseBaselineIsImmutableAndForwardMigrationsAreOrdered(t *testi
 			sqlFiles = append(sqlFiles, entry.Name())
 		}
 	}
-	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql,005_resource_uid_registry.sql,006_recovery_successor_v3.sql,007_contract_publication_evidence.sql,008_managed_provider_version_observation.sql,009_managed_data_retention_lifecycle.sql,010_remove_unreachable_fenced_attempt_state.sql,011_agent_conversation_transcript_revision.sql"; got != want {
+	if got, want := strings.Join(sqlFiles, ","), "001_control_plane.sql,002_project_free_source_bundle.sql,003_dashboard_authoring_runtime_lock.sql,004_dashboard_authoring_capability_evidence.sql,005_resource_uid_registry.sql,006_recovery_successor_v3.sql,007_contract_publication_evidence.sql,008_managed_provider_version_observation.sql,009_managed_data_retention_lifecycle.sql,010_remove_unreachable_fenced_attempt_state.sql,011_agent_conversation_transcript_revision.sql,012_recovery_capture_core_transport.sql"; got != want {
 		t.Fatalf("embedded Goose migrations = %v", sqlFiles)
 	}
 	contents, err := fs.ReadFile(MigrationFS(), "001_control_plane.sql")
@@ -99,6 +99,33 @@ func TestManagedDataRetentionLifecycleMigrationIsAdditiveAndImmutable(t *testing
 	down := migration[strings.Index(migration, "-- +goose Down"):]
 	if strings.Contains(strings.ToUpper(down), "DROP TABLE") {
 		t.Error("retention lifecycle Down must refuse instead of deleting evidence")
+	}
+}
+
+func TestCaptureCoreTransportMigrationIsAdditiveAndImmutable(t *testing.T) {
+	contents, err := fs.ReadFile(MigrationFS(), "012_recovery_capture_core_transport.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	migration := string(contents)
+	for _, required := range []string{
+		"leapview/managed-capture-core/v2",
+		"receipt_core_digest",
+		"capture_core_required",
+		"NOT VALID",
+		"guard_successor_set_complete",
+		"GRANT SELECT, INSERT",
+		"capture-core transport migration is immutable",
+	} {
+		if !strings.Contains(migration, required) {
+			t.Errorf("capture-core migration missing %q", required)
+		}
+	}
+	if strings.Contains(strings.ToUpper(migration[strings.Index(migration, "-- +goose Down"):]), "DROP TABLE") {
+		t.Error("capture-core migration Down must refuse instead of deleting evidence")
+	}
+	if !strings.HasSuffix(strings.TrimSpace(migration), "RESET ROLE;") {
+		t.Error("capture-core migration must restore the migrator role")
 	}
 }
 

--- a/internal/recoveryset/capture/service.go
+++ b/internal/recoveryset/capture/service.go
@@ -160,6 +160,7 @@ type Documents struct {
 	Manifest    []byte
 	Anchor      []byte
 	Profiles    []byte
+	Core        []byte
 	Receipt     []byte
 	Authorities []byte
 }
@@ -725,6 +726,7 @@ func canonicalDocuments(set successor.RecoverySet3, evidence successor.Evidence)
 	}{
 		{"set", &documents.Set, set.CanonicalJSON}, {"manifest", &documents.Manifest, evidence.Manifest.CanonicalJSON},
 		{"anchor", &documents.Anchor, evidence.Anchor.CanonicalJSON}, {"profiles", &documents.Profiles, evidence.Profiles.CanonicalJSON},
+		{"core", &documents.Core, evidence.Receipt.Core.CanonicalJSON},
 		{"receipt", &documents.Receipt, evidence.Receipt.CanonicalJSON}, {"authorities", &documents.Authorities, evidence.Authorities.CanonicalJSON},
 	}
 	for _, encoder := range encoders {

--- a/internal/recoveryset/capture/service_test.go
+++ b/internal/recoveryset/capture/service_test.go
@@ -34,6 +34,7 @@ func TestFAI520CaptureCanonicalizesSameFixedCapturedEvidence(t *testing.T) {
 	for name, pair := range map[string][2][]byte{
 		"set": {first.Documents.Set, second.Documents.Set}, "manifest": {first.Documents.Manifest, second.Documents.Manifest},
 		"anchor": {first.Documents.Anchor, second.Documents.Anchor}, "profiles": {first.Documents.Profiles, second.Documents.Profiles},
+		"core":    {first.Documents.Core, second.Documents.Core},
 		"receipt": {first.Documents.Receipt, second.Documents.Receipt}, "authorities": {first.Documents.Authorities, second.Documents.Authorities},
 	} {
 		if !bytes.Equal(pair[0], pair[1]) {

--- a/internal/recoveryset/postgres/manifest_capture_qualification_test.go
+++ b/internal/recoveryset/postgres/manifest_capture_qualification_test.go
@@ -339,6 +339,10 @@ func manifestCapturePayloads(t *testing.T, result capture.Result, reader *manife
 	if err != nil {
 		t.Fatal(err)
 	}
+	coreDigest, err := result.Evidence.Receipt.Core.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
 	receiptDigest, err := result.Evidence.Receipt.Digest()
 	if err != nil {
 		t.Fatal(err)
@@ -352,6 +356,7 @@ func manifestCapturePayloads(t *testing.T, result capture.Result, reader *manife
 		Manifest:  manifestCapturePayloadRef(t, PayloadFamilyManifest, successor.ManagedManifestVersion, manifestDigest, result.Documents.Manifest, reader, "manifest"),
 		Anchor:    manifestCapturePayloadRef(t, PayloadFamilyAnchor, successor.SourceAnchorVersion, anchorDigest, result.Documents.Anchor, reader, "anchor"),
 		Profiles:  manifestCapturePayloadRef(t, PayloadFamilyProfiles, successor.ProviderProfileVersion, profilesDigest, result.Documents.Profiles, reader, "profiles"),
+		Core:      manifestCapturePayloadRef(t, PayloadFamilyCore, successor.ReceiptCoreVersion, coreDigest, result.Documents.Core, reader, "core"),
 		Receipt:   manifestCapturePayloadRef(t, PayloadFamilyReceipt, successor.ReceiptVersion, receiptDigest, result.Documents.Receipt, reader, "receipt"),
 		Authority: manifestCapturePayloadRef(t, PayloadFamilyAuthority, successor.AuthorityRegistryVersion, authorityDigest, result.Documents.Authorities, reader, "authority"),
 	}

--- a/internal/recoveryset/postgres/manifest_capture_qualification_test.go
+++ b/internal/recoveryset/postgres/manifest_capture_qualification_test.go
@@ -193,8 +193,8 @@ func TestFAI520ManifestCapturePostgreSQLQualification(t *testing.T) {
 	payloads := manifestCapturePayloads(t, result, reader)
 	trust := TrustInput{Evidence: result.Evidence, Generation: TrustGeneration{
 		IncarnationID: assignment.Generation.IncarnationID, Revision: assignment.Generation.Revision, PolicyDigest: assignment.Generation.PolicyDigest,
-	}}
-	if _, err := admin.Exec(ctx, `INSERT INTO recovery.successor_trust_generation(singleton,incarnation_id,revision,policy_digest) VALUES(true,$1,$2,$3)`, trust.Generation.IncarnationID, trust.Generation.Revision, trust.Generation.PolicyDigest); err != nil {
+	}, WorkerFence: assignment.WorkerFence}
+	if _, err := admin.Exec(ctx, `INSERT INTO recovery.successor_trust_generation(singleton,incarnation_id,revision,policy_digest,worker_fence) VALUES(true,$1,$2,$3,$4)`, trust.Generation.IncarnationID, trust.Generation.Revision, trust.Generation.PolicyDigest, trust.WorkerFence); err != nil {
 		t.Fatal(err)
 	}
 	repository := NewSuccessorRepository(pool, SuccessorOptions{Reader: reader,

--- a/internal/recoveryset/postgres/queries/successor.sql
+++ b/internal/recoveryset/postgres/queries/successor.sql
@@ -1,7 +1,8 @@
 -- Static sqlc leaves for the additive RecoverySet v3 evidence graph.
 
 -- name: GetSuccessorEvidenceDigests :one
-SELECT anchor_digest, profile_digest, receipt_digest, authority_digest
+SELECT anchor_digest, profile_digest, capture_core_digest, capture_core_required,
+       receipt_digest, authority_digest
 FROM recovery.successor_manifest_binding
 WHERE manifest_digest = sqlc.arg(manifest_digest);
 
@@ -51,11 +52,11 @@ ON CONFLICT (payload_family, payload_version, payload_digest) DO NOTHING;
 
 -- name: InsertSuccessorBinding :exec
 INSERT INTO recovery.successor_manifest_binding
-    (manifest_digest, set_id, anchor_digest, profile_digest, receipt_digest,
+    (manifest_digest, set_id, anchor_digest, profile_digest, capture_core_digest, capture_core_required, receipt_digest,
      authority_digest, canonical_set, set_locator, verification_metadata)
 VALUES (sqlc.arg(manifest_digest), sqlc.arg(set_id)::text::uuid,
         sqlc.arg(anchor_digest), sqlc.arg(profile_digest),
-        sqlc.arg(receipt_digest), sqlc.arg(authority_digest),
+        sqlc.arg(capture_core_digest), true, sqlc.arg(receipt_digest), sqlc.arg(authority_digest),
         sqlc.arg(canonical_set), sqlc.arg(set_locator),
         sqlc.arg(verification_metadata))
 ON CONFLICT (manifest_digest) DO NOTHING;
@@ -65,6 +66,8 @@ SELECT manifest_digest,
        set_id::text AS set_id,
        anchor_digest,
        profile_digest,
+       capture_core_digest,
+       capture_core_required,
        receipt_digest,
        authority_digest,
        canonical_set,
@@ -76,11 +79,13 @@ WHERE manifest_digest = sqlc.arg(manifest_digest);
 -- name: InsertRecoverySet3 :exec
 INSERT INTO recovery.recovery_set_v3
     (set_id, schema_version, manifest_digest, anchor_digest, profile_digest,
-     receipt_digest, receipt_core_digest, authority_digest, frontier_projection,
+     receipt_digest, receipt_core_digest, capture_core_digest, capture_core_required,
+     authority_digest, frontier_projection,
      frontier_digest, canonical_bytes, created_by)
 VALUES (sqlc.arg(set_id)::text::uuid, 3, sqlc.arg(manifest_digest),
         sqlc.arg(anchor_digest), sqlc.arg(profile_digest),
         sqlc.arg(receipt_digest), sqlc.arg(receipt_core_digest),
+        sqlc.arg(capture_core_digest), true,
         sqlc.arg(authority_digest), sqlc.arg(frontier_projection),
         sqlc.arg(frontier_digest), sqlc.arg(canonical_bytes),
         sqlc.arg(created_by))
@@ -111,6 +116,8 @@ SELECT set_id::text AS set_id,
        receipt_version::integer AS receipt_version,
        receipt_digest,
        receipt_core_digest,
+       capture_core_digest,
+       capture_core_required,
        authority_family,
        authority_version::integer AS authority_version,
        authority_digest,

--- a/internal/recoveryset/postgres/queries/successor.sql
+++ b/internal/recoveryset/postgres/queries/successor.sql
@@ -141,8 +141,9 @@ FROM recovery.recovery_set_v3_root
 WHERE set_id::text = sqlc.arg(set_id_text)::varchar
 ORDER BY root_kind;
 
--- name: LockSuccessorGeneration :one
+-- name: LockSuccessorAssignment :one
 SELECT g.incarnation_id::text AS incarnation_id,
        g.revision::bigint AS revision,
-       g.policy_digest::text AS policy_digest
-FROM recovery.lock_successor_generation() AS g(incarnation_id, revision, policy_digest);
+       g.policy_digest::text AS policy_digest,
+       g.worker_fence::bigint AS worker_fence
+FROM recovery.lock_successor_assignment() AS g(incarnation_id, revision, policy_digest, worker_fence);

--- a/internal/recoveryset/postgres/successor_fixture_test.go
+++ b/internal/recoveryset/postgres/successor_fixture_test.go
@@ -94,8 +94,12 @@ func successorDatabase(t *testing.T) (*pgxpool.Pool, *pgxpool.Pool, string) {
 func successorGolden(t *testing.T, name string) (successor.RecoverySet3, successor.Evidence, map[string][]byte) {
 	t.Helper()
 	docs := make(map[string][]byte)
-	for _, part := range []string{"set", "manifest", "anchor", "profiles", "receipt", "authority"} {
-		raw, err := os.ReadFile(filepath.Join("..", "successor", "testdata", "frozen", name+"-"+part+".json"))
+	for _, part := range []string{"set", "manifest", "anchor", "profiles", "core", "receipt", "authority"} {
+		filePart := part
+		if part == "core" {
+			filePart = "receipt-core"
+		}
+		raw, err := os.ReadFile(filepath.Join("..", "successor", "testdata", "frozen", name+"-"+filePart+".json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,6 +124,15 @@ func successorGolden(t *testing.T, name string) (successor.RecoverySet3, success
 	receipt, err := successor.ParseReceipt(docs["receipt"])
 	if err != nil {
 		t.Fatal(err)
+	}
+	core, err := successor.ParseReceiptCore(docs["core"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	coreDigest, coreErr := core.Digest()
+	receiptCoreDigest, receiptCoreErr := receipt.Core.Digest()
+	if coreErr != nil || receiptCoreErr != nil || coreDigest != receiptCoreDigest {
+		t.Fatalf("capture core fixture does not match receipt: core=%v receipt=%v", coreErr, receiptCoreErr)
 	}
 	authority, err := successor.ParseAuthorityRegistry(docs["authority"])
 	if err != nil {

--- a/internal/recoveryset/postgres/successor_integrity.go
+++ b/internal/recoveryset/postgres/successor_integrity.go
@@ -151,10 +151,12 @@ type successorSet3ScalarRow struct {
 	ProfileVersion int32
 	ProfileDigest  string
 
-	ReceiptFamily     string
-	ReceiptVersion    int32
-	ReceiptDigest     string
-	ReceiptCoreDigest string
+	ReceiptFamily       string
+	ReceiptVersion      int32
+	ReceiptDigest       string
+	ReceiptCoreDigest   string
+	CaptureCoreDigest   string
+	CaptureCoreRequired bool
 
 	AuthorityFamily  string
 	AuthorityVersion int32
@@ -171,7 +173,7 @@ type successorSet3ScalarRow struct {
 // canonical successor set and independently selected evidence.  canonical is
 // checked against the owner serialization so a caller cannot accidentally
 // compare SQL metadata against a different byte representation.
-func successorSet3ScalarsForOwner(set successor.RecoverySet3, trust TrustInput, canonical []byte) (successorSet3ScalarRow, error) {
+func successorSet3ScalarsForOwner(set successor.RecoverySet3, trust TrustInput, canonical []byte, captureCoreRequired bool) (successorSet3ScalarRow, error) {
 	ownerCanonical, err := set.CanonicalJSON()
 	if err != nil {
 		return successorSet3ScalarRow{}, err
@@ -214,6 +216,10 @@ func successorSet3ScalarsForOwner(set successor.RecoverySet3, trust TrustInput, 
 	if err != nil {
 		return successorSet3ScalarRow{}, err
 	}
+	captureCoreDigest := ""
+	if captureCoreRequired {
+		captureCoreDigest = receiptCoreDigest
+	}
 	return successorSet3ScalarRow{
 		SetID: set.ID,
 
@@ -231,10 +237,12 @@ func successorSet3ScalarsForOwner(set successor.RecoverySet3, trust TrustInput, 
 		ProfileVersion: familyVersion(PayloadFamilyProfiles),
 		ProfileDigest:  profileDigest,
 
-		ReceiptFamily:     dbFamily(PayloadFamilyReceipt),
-		ReceiptVersion:    familyVersion(PayloadFamilyReceipt),
-		ReceiptDigest:     receiptDigest,
-		ReceiptCoreDigest: receiptCoreDigest,
+		ReceiptFamily:       dbFamily(PayloadFamilyReceipt),
+		ReceiptVersion:      familyVersion(PayloadFamilyReceipt),
+		ReceiptDigest:       receiptDigest,
+		ReceiptCoreDigest:   receiptCoreDigest,
+		CaptureCoreDigest:   captureCoreDigest,
+		CaptureCoreRequired: captureCoreRequired,
 
 		AuthorityFamily:  dbFamily(PayloadFamilyAuthority),
 		AuthorityVersion: familyVersion(PayloadFamilyAuthority),
@@ -264,6 +272,8 @@ func successorSet3ScalarsEqual(stored, want successorSet3ScalarRow) bool {
 		stored.ReceiptVersion == want.ReceiptVersion &&
 		stored.ReceiptDigest == want.ReceiptDigest &&
 		stored.ReceiptCoreDigest == want.ReceiptCoreDigest &&
+		stored.CaptureCoreDigest == want.CaptureCoreDigest &&
+		stored.CaptureCoreRequired == want.CaptureCoreRequired &&
 		stored.AuthorityFamily == want.AuthorityFamily &&
 		stored.AuthorityVersion == want.AuthorityVersion &&
 		stored.AuthorityDigest == want.AuthorityDigest &&

--- a/internal/recoveryset/postgres/successor_integrity.go
+++ b/internal/recoveryset/postgres/successor_integrity.go
@@ -18,24 +18,35 @@ const successorVerificationTimeLayout = "2006-01-02T15:04:05.000000Z"
 // association. It is not a replacement for the independently resolved trust
 // input used during a read.
 type successorVerificationMetadata struct {
-	Generation TrustGeneration
-	VerifiedAt time.Time
+	Generation  TrustGeneration
+	WorkerFence int64
+	VerifiedAt  time.Time
 }
 
 type successorVerificationMetadataJSON struct {
 	IncarnationID string `json:"incarnation_id"`
 	Revision      int64  `json:"revision"`
 	PolicyDigest  string `json:"policy_digest"`
+	WorkerFence   int64  `json:"worker_fence,omitempty"`
 	VerifiedAt    string `json:"verified_at"`
 }
 
-// marshalSuccessorVerificationMetadata emits the current flat metadata
-// format, extending the original generation tuple with a canonical UTC
-// microsecond verification clock. The clock is selected by the trust resolver,
-// never taken from a receipt or request.
-func marshalSuccessorVerificationMetadata(generation TrustGeneration, verifiedAt time.Time) ([]byte, error) {
+// marshalSuccessorVerificationMetadata emits the current flat metadata format,
+// extending the original generation/clock tuple with the independently
+// resolved worker fence. Neither value is taken from a receipt or wire record.
+func marshalSuccessorVerificationMetadata(generation TrustGeneration, workerFence int64, verifiedAt time.Time) ([]byte, error) {
+	if workerFence <= 0 {
+		return nil, fmt.Errorf("%w: malformed successor worker fence", ErrSuccessorInvalid)
+	}
+	return marshalSuccessorVerificationMetadataValue(generation, workerFence, verifiedAt)
+}
+
+func marshalSuccessorVerificationMetadataValue(generation TrustGeneration, workerFence int64, verifiedAt time.Time) ([]byte, error) {
 	if err := validateSuccessorTrustGeneration(generation); err != nil {
 		return nil, err
+	}
+	if workerFence < 0 {
+		return nil, fmt.Errorf("%w: malformed successor worker fence", ErrSuccessorInvalid)
 	}
 	verifiedAt, err := canonicalSuccessorVerificationTime(verifiedAt)
 	if err != nil {
@@ -45,6 +56,7 @@ func marshalSuccessorVerificationMetadata(generation TrustGeneration, verifiedAt
 		IncarnationID: generation.IncarnationID,
 		Revision:      generation.Revision,
 		PolicyDigest:  generation.PolicyDigest,
+		WorkerFence:   workerFence,
 		VerifiedAt:    verifiedAt.Format(successorVerificationTimeLayout),
 	})
 	if err != nil {
@@ -53,10 +65,10 @@ func marshalSuccessorVerificationMetadata(generation TrustGeneration, verifiedAt
 	return raw, nil
 }
 
-// parseSuccessorVerificationMetadata accepts only the exact JSON shape emitted
-// by marshalSuccessorVerificationMetadata. In particular, it rejects unknown
-// fields, duplicate fields (via canonical-byte comparison), trailing values,
-// non-canonical generation values, and non-UTC/microsecond clocks.
+// parseSuccessorVerificationMetadata accepts the exact current JSON shape plus
+// the historical shape without worker_fence. Canonical-byte comparison rejects
+// unknown/duplicate fields, trailing values, non-canonical generation values,
+// and non-UTC/microsecond clocks.
 func parseSuccessorVerificationMetadata(raw []byte) (successorVerificationMetadata, error) {
 	if len(raw) == 0 || len(raw) > successorLocatorLimit {
 		return successorVerificationMetadata{}, errors.New("successor verification metadata is empty")
@@ -79,22 +91,22 @@ func parseSuccessorVerificationMetadata(raw []byte) (successorVerificationMetada
 	if err != nil {
 		return successorVerificationMetadata{}, fmt.Errorf("parse successor verification clock: %w", err)
 	}
-	canonical, err := marshalSuccessorVerificationMetadata(generation, verifiedAt)
+	canonical, err := marshalSuccessorVerificationMetadataValue(generation, encoded.WorkerFence, verifiedAt)
 	if err != nil {
 		return successorVerificationMetadata{}, err
 	}
 	if !bytes.Equal(raw, canonical) {
 		return successorVerificationMetadata{}, errors.New("successor verification metadata is not canonical JSON")
 	}
-	return successorVerificationMetadata{Generation: generation, VerifiedAt: verifiedAt}, nil
+	return successorVerificationMetadata{Generation: generation, WorkerFence: encoded.WorkerFence, VerifiedAt: verifiedAt}, nil
 }
 
-// successorVerificationMetadataGenerationEqual is intended for immutable
+// successorVerificationMetadataAssignmentEqual is intended for immutable
 // write-replay checks. The first winner's VerifiedAt is retained; a retry must
-// match the identity/generation but must not replace that original clock.
-func successorVerificationMetadataGenerationEqual(raw []byte, want TrustGeneration) bool {
+// match the identity/generation/fence but must not replace that original clock.
+func successorVerificationMetadataAssignmentEqual(raw []byte, want TrustGeneration, workerFence int64) bool {
 	got, err := parseSuccessorVerificationMetadata(raw)
-	return err == nil && got.Generation == want
+	return err == nil && got.Generation == want && got.WorkerFence == workerFence
 }
 
 // validateSuccessorVerificationMetadataRead validates historical metadata and
@@ -102,10 +114,13 @@ func successorVerificationMetadataGenerationEqual(raw []byte, want TrustGenerati
 // independently selected trust clock. It intentionally does not require the
 // historical generation to equal the current generation; current-generation
 // fencing is a separate policy check.
-func validateSuccessorVerificationMetadataRead(raw []byte, current time.Time) error {
+func validateSuccessorVerificationMetadataRead(raw []byte, current time.Time, requireWorkerFence bool) error {
 	got, err := parseSuccessorVerificationMetadata(raw)
 	if err != nil {
 		return err
+	}
+	if requireWorkerFence && got.WorkerFence <= 0 {
+		return errors.New("successor verification metadata worker fence is missing")
 	}
 	if current.IsZero() {
 		return errors.New("current successor verification clock is missing")

--- a/internal/recoveryset/postgres/successor_integrity_test.go
+++ b/internal/recoveryset/postgres/successor_integrity_test.go
@@ -16,8 +16,9 @@ func TestSuccessorVerificationMetadataIsCanonicalAndGenerationStable(t *testing.
 		Revision:      7,
 		PolicyDigest:  "sha256:" + "a" + "bcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
 	}
+	const workerFence int64 = 11
 	verifiedAt := time.Date(2026, 9, 8, 1, 2, 3, 456789000, time.UTC)
-	raw, err := marshalSuccessorVerificationMetadata(generation, verifiedAt)
+	raw, err := marshalSuccessorVerificationMetadata(generation, workerFence, verifiedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,16 +26,19 @@ func TestSuccessorVerificationMetadataIsCanonicalAndGenerationStable(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if parsed.Generation != generation || !parsed.VerifiedAt.Equal(verifiedAt) {
-		t.Fatalf("parsed metadata = %#v, want generation %#v at %s", parsed, generation, verifiedAt)
+	if parsed.Generation != generation || parsed.WorkerFence != workerFence || !parsed.VerifiedAt.Equal(verifiedAt) {
+		t.Fatalf("parsed metadata = %#v, want generation %#v fence %d at %s", parsed, generation, workerFence, verifiedAt)
 	}
-	if !successorVerificationMetadataGenerationEqual(raw, generation) {
-		t.Fatal("exact generation should match")
+	if !successorVerificationMetadataAssignmentEqual(raw, generation, workerFence) {
+		t.Fatal("exact generation and worker fence should match")
 	}
-	if err := validateSuccessorVerificationMetadataRead(raw, verifiedAt.Add(-time.Microsecond)); err == nil {
+	if successorVerificationMetadataAssignmentEqual(raw, generation, workerFence+1) {
+		t.Fatal("different worker fence compared equal")
+	}
+	if err := validateSuccessorVerificationMetadataRead(raw, verifiedAt.Add(-time.Microsecond), true); err == nil {
 		t.Fatal("future archival verification clock was accepted")
 	}
-	if err := validateSuccessorVerificationMetadataRead(raw, verifiedAt.Add(time.Microsecond)); err != nil {
+	if err := validateSuccessorVerificationMetadataRead(raw, verifiedAt.Add(time.Microsecond), true); err != nil {
 		t.Fatalf("historical verification clock rejected: %v", err)
 	}
 
@@ -55,12 +59,26 @@ func TestSuccessorVerificationMetadataIsCanonicalAndGenerationStable(t *testing.
 		t.Fatal("missing verification clock was accepted")
 	}
 
-	retry, err := marshalSuccessorVerificationMetadata(generation, verifiedAt.Add(time.Hour))
+	retry, err := marshalSuccessorVerificationMetadata(generation, workerFence, verifiedAt.Add(time.Hour))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !successorVerificationMetadataGenerationEqual(retry, generation) {
-		t.Fatal("retry with the same generation should compare equal")
+	if !successorVerificationMetadataAssignmentEqual(retry, generation, workerFence) {
+		t.Fatal("retry with the same assignment should compare equal")
+	}
+
+	legacy, err := marshalSuccessorVerificationMetadataValue(generation, 0, verifiedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseSuccessorVerificationMetadata(legacy); err != nil {
+		t.Fatalf("legacy verification metadata became unreadable: %v", err)
+	}
+	if err := validateSuccessorVerificationMetadataRead(legacy, verifiedAt, true); err == nil {
+		t.Fatal("new capture-core association accepted legacy metadata without worker fence")
+	}
+	if err := validateSuccessorVerificationMetadataRead(legacy, verifiedAt, false); err != nil {
+		t.Fatalf("legacy association metadata rejected: %v", err)
 	}
 }
 

--- a/internal/recoveryset/postgres/successor_integrity_test.go
+++ b/internal/recoveryset/postgres/successor_integrity_test.go
@@ -70,7 +70,7 @@ func TestSuccessorSet3ScalarAndRootIntegrityComparisons(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, err := successorSet3ScalarsForOwner(set, TrustInput{Evidence: trust}, canonical)
+	want, err := successorSet3ScalarsForOwner(set, TrustInput{Evidence: trust}, canonical, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestSuccessorSet3ScalarAndRootIntegrityComparisons(t *testing.T) {
 	if successorSet3ScalarsEqual(badCanonical, want) {
 		t.Fatal("canonical set corruption was accepted")
 	}
-	if _, err := successorSet3ScalarsForOwner(set, TrustInput{Evidence: trust}, []byte("{}")); err == nil {
+	if _, err := successorSet3ScalarsForOwner(set, TrustInput{Evidence: trust}, []byte("{}"), true); err == nil {
 		t.Fatal("caller-supplied non-owner canonical bytes were accepted")
 	}
 

--- a/internal/recoveryset/postgres/successor_repository.go
+++ b/internal/recoveryset/postgres/successor_repository.go
@@ -37,6 +37,7 @@ const (
 	PayloadFamilyManifest  = "leapview.managed-observation-manifest"
 	PayloadFamilyAnchor    = "leapview.recovery-source-anchor"
 	PayloadFamilyProfiles  = "leapview.managed-provider-profiles"
+	PayloadFamilyCore      = "leapview.managed-capture-core"
 	PayloadFamilyReceipt   = "leapview.managed-capture-receipt"
 	PayloadFamilyAuthority = "leapview.authority-registry"
 )
@@ -88,6 +89,7 @@ type EvidencePayloads struct {
 	Manifest  PayloadReference
 	Anchor    PayloadReference
 	Profiles  PayloadReference
+	Core      PayloadReference
 	Receipt   PayloadReference
 	Authority PayloadReference
 }
@@ -290,6 +292,11 @@ func (r *SuccessorRepository) ReadSet3(ctx context.Context, setID string) (succe
 	if binding.SetID != setID || !bytes.Equal(binding.CanonicalSet, setRaw) {
 		return successor.RecoverySet3{}, tampered(errors.New("stored association differs from set"))
 	}
+	if binding.CaptureCoreRequired != setRow.CaptureCoreRequired ||
+		(binding.CaptureCoreDigest == nil) != (setRow.CaptureCoreDigest == nil) ||
+		(binding.CaptureCoreDigest != nil && *binding.CaptureCoreDigest != *setRow.CaptureCoreDigest) {
+		return successor.RecoverySet3{}, tampered(errors.New("capture core association differs from set"))
+	}
 	if err := validateSuccessorVerificationMetadataRead(binding.VerificationMetadata, trust.Evidence.VerificationTime); err != nil {
 		return successor.RecoverySet3{}, tampered(err)
 	}
@@ -313,6 +320,7 @@ type readBundle struct {
 	Manifest  successor.ManagedManifest2
 	Anchor    successor.SourceAnchor
 	Profiles  successor.ProviderProfileSet
+	Core      *successor.ReceiptCore
 	Receipt   successor.SignedReceipt
 	Authority successor.AuthorityRegistry
 }
@@ -348,6 +356,7 @@ func (r *SuccessorRepository) verifyBundle(ctx context.Context, set successor.Re
 		{PayloadFamilyManifest, p.Manifest, trust.Evidence.Manifest},
 		{PayloadFamilyAnchor, p.Anchor, trust.Evidence.Anchor},
 		{PayloadFamilyProfiles, p.Profiles, trust.Evidence.Profiles},
+		{PayloadFamilyCore, p.Core, trust.Evidence.Receipt.Core},
 		{PayloadFamilyReceipt, p.Receipt, trust.Evidence.Receipt},
 		{PayloadFamilyAuthority, p.Authority, trust.Evidence.Authorities},
 	}
@@ -370,8 +379,10 @@ func (r *SuccessorRepository) verifyBundle(ctx context.Context, set successor.Re
 		case 2:
 			checked.Profiles = ref
 		case 3:
-			checked.Receipt = ref
+			checked.Core = ref
 		case 4:
+			checked.Receipt = ref
+		case 5:
 			checked.Authority = ref
 		}
 	}
@@ -426,6 +437,25 @@ func (r *SuccessorRepository) readBundle(ctx context.Context, set successor.Reco
 	if err != nil {
 		return b, tampered(err)
 	}
+	if refs.CoreRequired {
+		coreRaw, err := r.readReference(ctx, PayloadFamilyCore, refs.Core, nil)
+		if err != nil {
+			return b, err
+		}
+		core, err := successor.ParseReceiptCore(coreRaw)
+		if err != nil {
+			return b, tampered(err)
+		}
+		coreDigest, err := core.Digest()
+		receiptCoreDigest, receiptCoreErr := b.Receipt.Core.Digest()
+		if err != nil || receiptCoreErr != nil || coreDigest != refs.Core.Locator.PayloadDigest || coreDigest != receiptCoreDigest {
+			return b, tampered(errors.New("capture core relationship"))
+		}
+		if coreDigest != b.Manifest.Capture.ReceiptDigest {
+			return b, tampered(errors.New("capture core manifest relationship"))
+		}
+		b.Core = &core
+	}
 	authorityRaw, err := r.readReference(ctx, PayloadFamilyAuthority, refs.Authority, nil)
 	if err != nil {
 		return b, err
@@ -440,7 +470,10 @@ func (r *SuccessorRepository) readBundle(ctx context.Context, set successor.Reco
 	return b, nil
 }
 
-type evidenceRefs struct{ Manifest, Anchor, Profiles, Receipt, Authority PayloadReference }
+type evidenceRefs struct {
+	Manifest, Anchor, Profiles, Core, Receipt, Authority PayloadReference
+	CoreRequired                                         bool
+}
 
 func (r *SuccessorRepository) loadEvidenceRefs(ctx context.Context, manifestDigest string) (evidenceRefs, error) {
 	var refs evidenceRefs
@@ -463,6 +496,19 @@ func (r *SuccessorRepository) loadEvidenceRefs(ctx context.Context, manifestDige
 	refs.Profiles, err2 = r.loadRef(ctx, PayloadFamilyProfiles, digests.ProfileDigest)
 	if err2 != nil {
 		return refs, err2
+	}
+	refs.CoreRequired = digests.CaptureCoreRequired
+	if refs.CoreRequired && digests.CaptureCoreDigest == nil {
+		return refs, ErrSuccessorTampered
+	}
+	if !refs.CoreRequired && digests.CaptureCoreDigest != nil {
+		return refs, ErrSuccessorTampered
+	}
+	if digests.CaptureCoreDigest != nil {
+		refs.Core, err2 = r.loadRef(ctx, PayloadFamilyCore, *digests.CaptureCoreDigest)
+		if err2 != nil {
+			return refs, err2
+		}
 	}
 	refs.Receipt, err2 = r.loadRef(ctx, PayloadFamilyReceipt, digests.ReceiptDigest)
 	if err2 != nil {
@@ -641,6 +687,19 @@ func parsePayload(family string, raw []byte, expected any) error {
 			}
 		}
 		return nil
+	case PayloadFamilyCore:
+		v, err := successor.ParseReceiptCore(raw)
+		if err != nil {
+			return err
+		}
+		if x, ok := expected.(successor.ReceiptCore); ok {
+			a, _ := v.Digest()
+			b, _ := x.Digest()
+			if a != b {
+				return errors.New("capture core identity mismatch")
+			}
+		}
+		return nil
 	case PayloadFamilyReceipt:
 		v, err := successor.ParseReceipt(raw)
 		if err != nil {
@@ -694,6 +753,12 @@ func payloadDigest(family string, raw []byte) (string, error) {
 		return v.Digest()
 	case PayloadFamilyProfiles:
 		v, err := successor.ParseProviderProfileSet(raw)
+		if err != nil {
+			return "", err
+		}
+		return v.Digest()
+	case PayloadFamilyCore:
+		v, err := successor.ParseReceiptCore(raw)
 		if err != nil {
 			return "", err
 		}
@@ -775,7 +840,7 @@ func insertEvidence(ctx context.Context, db DBTX, ref PayloadReference) error {
 }
 
 func (r *SuccessorRepository) insertBundle(ctx context.Context, db DBTX, set successor.RecoverySet3, p EvidencePayloads, trust TrustInput, bind bool) error {
-	refs := []PayloadReference{p.Manifest, p.Anchor, p.Profiles, p.Receipt, p.Authority}
+	refs := []PayloadReference{p.Manifest, p.Anchor, p.Profiles, p.Core, p.Receipt, p.Authority}
 	for _, ref := range refs {
 		if err := insertEvidence(ctx, db, ref); err != nil {
 			return err
@@ -791,6 +856,7 @@ func insertBinding(ctx context.Context, db DBTX, set successor.RecoverySet3, p E
 	md, _ := trust.Evidence.Manifest.Digest()
 	ad, _ := trust.Evidence.Anchor.Digest()
 	pd, _ := trust.Evidence.Profiles.Digest()
+	cd, _ := trust.Evidence.Receipt.Core.Digest()
 	rd, _ := trust.Evidence.Receipt.Digest()
 	au, _ := trust.Evidence.Authorities.Digest()
 	setRaw, _ := set.CanonicalJSON()
@@ -808,6 +874,7 @@ func insertBinding(ctx context.Context, db DBTX, set successor.RecoverySet3, p E
 		SetID:                set.ID,
 		AnchorDigest:         ad,
 		ProfileDigest:        pd,
+		CaptureCoreDigest:    &cd,
 		ReceiptDigest:        rd,
 		AuthorityDigest:      au,
 		CanonicalSet:         setRaw,
@@ -822,7 +889,7 @@ func insertBinding(ctx context.Context, db DBTX, set successor.RecoverySet3, p E
 		return err
 	}
 	if old.ManifestDigest != md || old.SetID != set.ID || old.AnchorDigest != ad || old.ProfileDigest != pd ||
-		old.ReceiptDigest != rd || old.AuthorityDigest != au || !bytes.Equal(old.CanonicalSet, setRaw) ||
+		!old.CaptureCoreRequired || old.CaptureCoreDigest == nil || *old.CaptureCoreDigest != cd || old.ReceiptDigest != rd || old.AuthorityDigest != au || !bytes.Equal(old.CanonicalSet, setRaw) ||
 		!bytes.Equal(old.SetLocator, locator) || !successorVerificationMetadataGenerationEqual(old.VerificationMetadata, trust.Generation) {
 		return ErrSuccessorConflict
 	}
@@ -849,6 +916,7 @@ func insertSet3(ctx context.Context, db DBTX, set successor.RecoverySet3, p Evid
 		ProfileDigest:      pd,
 		ReceiptDigest:      rd,
 		ReceiptCoreDigest:  cd,
+		CaptureCoreDigest:  &cd,
 		AuthorityDigest:    au,
 		FrontierProjection: frontier,
 		FrontierDigest:     fd,
@@ -885,34 +953,38 @@ func frontierProjection(set successor.RecoverySet3) ([]byte, error) {
 }
 
 func verifyStoredSet3Rows(ctx context.Context, db DBTX, set successor.RecoverySet3, row recoverydb.GetRecoverySet3Row, trust TrustInput) error {
-	want, err := successorSet3ScalarsForOwner(set, trust, row.CanonicalBytes)
+	want, err := successorSet3ScalarsForOwner(set, trust, row.CanonicalBytes, row.CaptureCoreRequired)
 	if err != nil {
 		return tampered(err)
 	}
 	stored := successorSet3ScalarRow{
-		SetID:              row.SetID,
-		SchemaVersion:      row.SchemaVersion,
-		ManifestFamily:     row.ManifestFamily,
-		ManifestVersion:    row.ManifestVersion,
-		ManifestDigest:     row.ManifestDigest,
-		AnchorFamily:       row.AnchorFamily,
-		AnchorVersion:      row.AnchorVersion,
-		AnchorDigest:       row.AnchorDigest,
-		ProfileFamily:      row.ProfileFamily,
-		ProfileVersion:     row.ProfileVersion,
-		ProfileDigest:      row.ProfileDigest,
-		ReceiptFamily:      row.ReceiptFamily,
-		ReceiptVersion:     row.ReceiptVersion,
-		ReceiptDigest:      row.ReceiptDigest,
-		ReceiptCoreDigest:  row.ReceiptCoreDigest,
-		AuthorityFamily:    row.AuthorityFamily,
-		AuthorityVersion:   row.AuthorityVersion,
-		AuthorityDigest:    row.AuthorityDigest,
-		FrontierProjection: row.FrontierProjection,
-		FrontierDigest:     row.FrontierDigest,
-		CanonicalBytes:     row.CanonicalBytes,
-		Status:             row.Status,
-		CreatedBy:          row.CreatedBy,
+		SetID:               row.SetID,
+		SchemaVersion:       row.SchemaVersion,
+		ManifestFamily:      row.ManifestFamily,
+		ManifestVersion:     row.ManifestVersion,
+		ManifestDigest:      row.ManifestDigest,
+		AnchorFamily:        row.AnchorFamily,
+		AnchorVersion:       row.AnchorVersion,
+		AnchorDigest:        row.AnchorDigest,
+		ProfileFamily:       row.ProfileFamily,
+		ProfileVersion:      row.ProfileVersion,
+		ProfileDigest:       row.ProfileDigest,
+		ReceiptFamily:       row.ReceiptFamily,
+		ReceiptVersion:      row.ReceiptVersion,
+		ReceiptDigest:       row.ReceiptDigest,
+		ReceiptCoreDigest:   row.ReceiptCoreDigest,
+		CaptureCoreRequired: row.CaptureCoreRequired,
+		AuthorityFamily:     row.AuthorityFamily,
+		AuthorityVersion:    row.AuthorityVersion,
+		AuthorityDigest:     row.AuthorityDigest,
+		FrontierProjection:  row.FrontierProjection,
+		FrontierDigest:      row.FrontierDigest,
+		CanonicalBytes:      row.CanonicalBytes,
+		Status:              row.Status,
+		CreatedBy:           row.CreatedBy,
+	}
+	if row.CaptureCoreDigest != nil {
+		stored.CaptureCoreDigest = *row.CaptureCoreDigest
 	}
 	if !successorSet3ScalarsEqual(stored, want) {
 		return ErrSuccessorConflict
@@ -987,7 +1059,7 @@ func familyVersion(f string) int32 {
 	switch f {
 	case PayloadFamilySet:
 		return successor.RecoverySetVersion
-	case PayloadFamilyManifest, PayloadFamilyAnchor, PayloadFamilyProfiles, PayloadFamilyReceipt, PayloadFamilyAuthority:
+	case PayloadFamilyManifest, PayloadFamilyAnchor, PayloadFamilyProfiles, PayloadFamilyCore, PayloadFamilyReceipt, PayloadFamilyAuthority:
 		return 2
 	}
 	return 0
@@ -1000,6 +1072,8 @@ func dbFamily(f string) string {
 		return "anchor"
 	case PayloadFamilyProfiles:
 		return "profile"
+	case PayloadFamilyCore:
+		return "core"
 	case PayloadFamilyReceipt:
 		return "receipt"
 	case PayloadFamilyAuthority:
@@ -1017,6 +1091,8 @@ func publicFamily(f string) string {
 		return PayloadFamilyAnchor
 	case "profile":
 		return PayloadFamilyProfiles
+	case "core":
+		return PayloadFamilyCore
 	case "receipt":
 		return PayloadFamilyReceipt
 	case "authority":
@@ -1042,6 +1118,13 @@ func verifyEvidence(set successor.RecoverySet3, b readBundle, trust TrustInput) 
 			return fmt.Errorf("%w: persisted evidence differs from independent trust", ErrSuccessorUntrusted)
 		}
 	}
+	if b.Core != nil {
+		persistedCoreDigest, persistedCoreErr := b.Core.Digest()
+		trustedCoreDigest, trustedCoreErr := trusted.Receipt.Core.Digest()
+		if persistedCoreErr != nil || trustedCoreErr != nil || persistedCoreDigest != trustedCoreDigest || persistedCoreDigest != trusted.Manifest.Capture.ReceiptDigest {
+			return fmt.Errorf("%w: persisted capture core differs from independent trust", ErrSuccessorUntrusted)
+		}
+	}
 	if err := set.ValidateEvidence(trusted); err != nil {
 		return fmt.Errorf("%w: %v", ErrSuccessorUntrusted, err)
 	}
@@ -1051,6 +1134,7 @@ func verifyEvidence(set successor.RecoverySet3, b readBundle, trust TrustInput) 
 func mustDigestManifest(v successor.ManagedManifest2) string   { d, _ := v.Digest(); return d }
 func mustDigestAnchor(v successor.SourceAnchor) string         { d, _ := v.Digest(); return d }
 func mustDigestProfiles(v successor.ProviderProfileSet) string { d, _ := v.Digest(); return d }
+func mustDigestCore(v successor.ReceiptCore) string            { d, _ := v.Digest(); return d }
 func mustDigestReceipt(v successor.SignedReceipt) string       { d, _ := v.Digest(); return d }
 func mustDigestAuthority(v successor.AuthorityRegistry) string { d, _ := v.Digest(); return d }
 func mustCanonicalSet(v successor.RecoverySet3) []byte         { b, _ := v.CanonicalJSON(); return b }

--- a/internal/recoveryset/postgres/successor_repository.go
+++ b/internal/recoveryset/postgres/successor_repository.go
@@ -82,6 +82,10 @@ type TrustGeneration struct {
 type TrustInput struct {
 	Evidence   successor.Evidence
 	Generation TrustGeneration
+	// WorkerFence is the coordinator-resolved assignment fence that produced
+	// the evidence. PostgreSQL independently locks and compares its current
+	// fence before association; it is not part of the frozen wire contracts.
+	WorkerFence int64
 }
 
 type EvidencePayloads struct {
@@ -137,7 +141,7 @@ func (r *SuccessorRepository) resolveTrust(ctx context.Context, setID string) (T
 	if err != nil {
 		return TrustInput{}, &successorTrustFailure{cause: err}
 	}
-	if !canonicalUUID(input.Generation.IncarnationID) || input.Generation.Revision <= 0 || !domainDigest.MatchString(input.Generation.PolicyDigest) || input.Evidence.VerificationTime.IsZero() {
+	if !canonicalUUID(input.Generation.IncarnationID) || input.Generation.Revision <= 0 || !domainDigest.MatchString(input.Generation.PolicyDigest) || input.WorkerFence <= 0 || input.Evidence.VerificationTime.IsZero() {
 		return TrustInput{}, fmt.Errorf("%w: malformed independent trust", ErrSuccessorUntrusted)
 	}
 	return input, nil
@@ -170,7 +174,7 @@ func (r *SuccessorRepository) InsertManifest(ctx context.Context, input Manifest
 		return err
 	}
 	return r.withTx(ctx, func(tx DBTX) error {
-		if err := checkStoredGeneration(ctx, tx, trust.Generation); err != nil {
+		if err := checkStoredAssignment(ctx, tx, trust); err != nil {
 			return err
 		}
 		return r.insertBundle(ctx, tx, input.Set, checked, trust, true)
@@ -195,7 +199,7 @@ func (r *SuccessorRepository) ReadManifest(ctx context.Context, manifestDigest s
 	if err != nil {
 		return successor.ManagedManifest2{}, err
 	}
-	if err := validateSuccessorVerificationMetadataRead(binding.VerificationMetadata, trust.Evidence.VerificationTime); err != nil {
+	if err := validateSuccessorVerificationMetadataRead(binding.VerificationMetadata, trust.Evidence.VerificationTime, binding.CaptureCoreRequired); err != nil {
 		return successor.ManagedManifest2{}, tampered(err)
 	}
 	set, err := successor.ParseRecoverySet3(setRaw)
@@ -205,7 +209,7 @@ func (r *SuccessorRepository) ReadManifest(ctx context.Context, manifestDigest s
 	if storedManifest != manifestDigest {
 		return successor.ManagedManifest2{}, tampered(errors.New("manifest association digest"))
 	}
-	if err := checkStoredGeneration(ctx, r.db, trust.Generation); err != nil {
+	if err := checkStoredAssignment(ctx, r.db, trust); err != nil {
 		return successor.ManagedManifest2{}, err
 	}
 	if err := r.verifyStoredSet(ctx, set, setLocator, setRaw); err != nil {
@@ -218,7 +222,7 @@ func (r *SuccessorRepository) ReadManifest(ctx context.Context, manifestDigest s
 	if err := verifyEvidence(set, bundle, trust); err != nil {
 		return successor.ManagedManifest2{}, err
 	}
-	if err := checkStoredGeneration(ctx, r.db, trust.Generation); err != nil {
+	if err := checkStoredAssignment(ctx, r.db, trust); err != nil {
 		return successor.ManagedManifest2{}, err
 	}
 	return bundle.Manifest, nil
@@ -246,7 +250,7 @@ func (r *SuccessorRepository) CreateSet3(ctx context.Context, input Set3Input) (
 		return successor.RecoverySet3{}, tampered(errors.New("prepared set cache differs"))
 	}
 	if err := r.withTx(ctx, func(tx DBTX) error {
-		if err := checkStoredGeneration(ctx, tx, trust.Generation); err != nil {
+		if err := checkStoredAssignment(ctx, tx, trust); err != nil {
 			return err
 		}
 		if err := r.insertBundle(ctx, tx, input.Set, checked, trust, true); err != nil {
@@ -279,7 +283,7 @@ func (r *SuccessorRepository) ReadSet3(ctx context.Context, setID string) (succe
 	if err != nil {
 		return successor.RecoverySet3{}, err
 	}
-	if err := checkStoredGeneration(ctx, r.db, trust.Generation); err != nil {
+	if err := checkStoredAssignment(ctx, r.db, trust); err != nil {
 		return successor.RecoverySet3{}, err
 	}
 	if err := verifyStoredSet3Rows(ctx, r.db, set, setRow, trust); err != nil {
@@ -297,7 +301,7 @@ func (r *SuccessorRepository) ReadSet3(ctx context.Context, setID string) (succe
 		(binding.CaptureCoreDigest != nil && *binding.CaptureCoreDigest != *setRow.CaptureCoreDigest) {
 		return successor.RecoverySet3{}, tampered(errors.New("capture core association differs from set"))
 	}
-	if err := validateSuccessorVerificationMetadataRead(binding.VerificationMetadata, trust.Evidence.VerificationTime); err != nil {
+	if err := validateSuccessorVerificationMetadataRead(binding.VerificationMetadata, trust.Evidence.VerificationTime, binding.CaptureCoreRequired); err != nil {
 		return successor.RecoverySet3{}, tampered(err)
 	}
 	if err := r.verifyStoredSet(ctx, set, binding.SetLocator, setRaw); err != nil {
@@ -310,7 +314,7 @@ func (r *SuccessorRepository) ReadSet3(ctx context.Context, setID string) (succe
 	if err := verifyEvidence(set, bundle, trust); err != nil {
 		return successor.RecoverySet3{}, err
 	}
-	if err := checkStoredGeneration(ctx, r.db, trust.Generation); err != nil {
+	if err := checkStoredAssignment(ctx, r.db, trust); err != nil {
 		return successor.RecoverySet3{}, err
 	}
 	return set, nil
@@ -864,7 +868,7 @@ func insertBinding(ctx context.Context, db DBTX, set successor.RecoverySet3, p E
 	if err != nil {
 		return err
 	}
-	metadata, err := marshalSuccessorVerificationMetadata(trust.Generation, trust.Evidence.VerificationTime)
+	metadata, err := marshalSuccessorVerificationMetadata(trust.Generation, trust.WorkerFence, trust.Evidence.VerificationTime)
 	if err != nil {
 		return err
 	}
@@ -890,7 +894,7 @@ func insertBinding(ctx context.Context, db DBTX, set successor.RecoverySet3, p E
 	}
 	if old.ManifestDigest != md || old.SetID != set.ID || old.AnchorDigest != ad || old.ProfileDigest != pd ||
 		!old.CaptureCoreRequired || old.CaptureCoreDigest == nil || *old.CaptureCoreDigest != cd || old.ReceiptDigest != rd || old.AuthorityDigest != au || !bytes.Equal(old.CanonicalSet, setRaw) ||
-		!bytes.Equal(old.SetLocator, locator) || !successorVerificationMetadataGenerationEqual(old.VerificationMetadata, trust.Generation) {
+		!bytes.Equal(old.SetLocator, locator) || !successorVerificationMetadataAssignmentEqual(old.VerificationMetadata, trust.Generation, trust.WorkerFence) {
 		return ErrSuccessorConflict
 	}
 	return nil
@@ -1015,15 +1019,15 @@ func verifyStoredSet3Rows(ctx context.Context, db DBTX, set successor.RecoverySe
 	return nil
 }
 
-func checkStoredGeneration(ctx context.Context, db DBTX, want TrustGeneration) error {
-	row, err := successorQueries(db).LockSuccessorGeneration(ctx)
+func checkStoredAssignment(ctx context.Context, db DBTX, want TrustInput) error {
+	row, err := successorQueries(db).LockSuccessorAssignment(ctx)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrSuccessorUntrusted
 	}
 	if err != nil {
 		return err
 	}
-	if row.IncarnationID != want.IncarnationID || row.Revision != want.Revision || row.PolicyDigest != want.PolicyDigest {
+	if row.IncarnationID != want.Generation.IncarnationID || row.Revision != want.Generation.Revision || row.PolicyDigest != want.Generation.PolicyDigest || row.WorkerFence != want.WorkerFence {
 		return ErrSuccessorConflict
 	}
 	return nil

--- a/internal/recoveryset/postgres/successor_repository_test.go
+++ b/internal/recoveryset/postgres/successor_repository_test.go
@@ -66,7 +66,7 @@ func successorInputs(t *testing.T, name string) (recoverypg.Set3Input, recoveryp
 	t.Helper()
 	set, evidence, docs := successorGolden(t, name)
 	reader := &successorPayloadReader{objects: make(map[recoverypg.ValidatedLocator][]byte)}
-	trust := recoverypg.TrustInput{Evidence: evidence, Generation: recoverypg.TrustGeneration{IncarnationID: "11111111-1111-4111-8111-111111111111", Revision: 1, PolicyDigest: "sha256:" + fmt.Sprintf("%064x", 19)}}
+	trust := recoverypg.TrustInput{Evidence: evidence, Generation: recoverypg.TrustGeneration{IncarnationID: "11111111-1111-4111-8111-111111111111", Revision: 1, PolicyDigest: "sha256:" + fmt.Sprintf("%064x", 19)}, WorkerFence: 7}
 	input := recoverypg.Set3Input{Set: set}
 	values := []struct {
 		name, family string
@@ -98,10 +98,10 @@ func successorInputs(t *testing.T, name string) (recoverypg.Set3Input, recoveryp
 	return input, trust, reader
 }
 
-func provisionSuccessorGeneration(t *testing.T, admin *pgxpool.Pool, g recoverypg.TrustGeneration) {
+func provisionSuccessorGeneration(t *testing.T, admin *pgxpool.Pool, trust recoverypg.TrustInput) {
 	t.Helper()
 	// Operator-owned policy provisioning, not a test-only permission grant.
-	_, err := admin.Exec(t.Context(), `INSERT INTO recovery.successor_trust_generation(singleton,incarnation_id,revision,policy_digest) VALUES(true,$1,$2,$3)`, g.IncarnationID, g.Revision, g.PolicyDigest)
+	_, err := admin.Exec(t.Context(), `INSERT INTO recovery.successor_trust_generation(singleton,incarnation_id,revision,policy_digest,worker_fence) VALUES(true,$1,$2,$3,$4)`, trust.Generation.IncarnationID, trust.Generation.Revision, trust.Generation.PolicyDigest, trust.WorkerFence)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestSuccessorPersistenceRestartRetryAndExactRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			pool, admin, reopenURL := successorDatabase(t)
 			input, trust, reader := successorInputs(t, name)
-			provisionSuccessorGeneration(t, admin, trust.Generation)
+			provisionSuccessorGeneration(t, admin, trust)
 			repo := successorRepo(pool, reader, trust)
 			manifestInput := recoverypg.ManifestInput{Set: input.Set, Payloads: input.Payloads}
 			for range 2 {
@@ -235,7 +235,7 @@ func TestSuccessorPersistenceProcessRestartReadback(t *testing.T) {
 
 	pool, admin, reopenURL := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	if _, err := successorRepo(pool, reader, trust).CreateSet3(t.Context(), input); err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func runSuccessorCoreReadbackHelper(t *testing.T) {
 func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	for _, phase := range []string{"open", "close"} {
 		t.Run("sanitized transport "+phase, func(t *testing.T) {
 			cause := errors.New("provider failure with credential=private-test-sentinel")
@@ -309,7 +309,7 @@ func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 			}
 		})
 	}
-	for _, name := range []string{"missing manifest", "missing core", "wrong digest", "invalid core digest", "wrong anchor", "core authority mismatch", "invalid receipt", "cache substitution", "locator substitution", "stale generation"} {
+	for _, name := range []string{"missing manifest", "missing core", "wrong digest", "invalid core digest", "wrong anchor", "core authority mismatch", "invalid receipt", "cache substitution", "locator substitution", "stale generation", "missing worker fence"} {
 		t.Run(name, func(t *testing.T) {
 			bad, badTrust, badReader := successorInputs(t, "minimal")
 			switch name {
@@ -346,6 +346,8 @@ func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 				bad.Payloads.Manifest.Locator.Namespace = "unrelated/"
 			case "stale generation":
 				badTrust.Generation.Revision++
+			case "missing worker fence":
+				badTrust.WorkerFence = 0
 			}
 			if _, err := successorRepo(pool, badReader, badTrust).CreateSet3(t.Context(), bad); err == nil {
 				t.Fatal("invalid evidence accepted")
@@ -386,7 +388,7 @@ func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 func TestSuccessorPersistenceConcurrentImmutableWinner(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	repo := successorRepo(pool, reader, trust)
 	run := func(n int, fn func(int) error) []error {
 		result := make([]error, n)
@@ -449,7 +451,7 @@ func TestSuccessorPersistenceConcurrentImmutableWinner(t *testing.T) {
 func TestSuccessorPersistenceAssociationRollback(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	// A storage failure after inserts must abort the entire association transaction.
 	_, err := admin.Exec(t.Context(), `CREATE FUNCTION recovery.qualification_reject_root() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'injected association failure'; END $$; CREATE TRIGGER qualification_reject_root BEFORE INSERT ON recovery.recovery_set_v3_root FOR EACH ROW EXECUTE FUNCTION recovery.qualification_reject_root()`)
 	if err != nil {
@@ -479,7 +481,7 @@ func TestSuccessorPersistenceAssociationRollback(t *testing.T) {
 func TestSuccessorPersistencePreservesV1AndReservesIdentity(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	raw, err := os.ReadFile("../testdata/successor-legacy/recoveryset-v1.json")
 	if err != nil {
 		t.Fatal(err)
@@ -518,7 +520,7 @@ func TestSuccessorPersistencePreservesV1AndReservesIdentity(t *testing.T) {
 func TestSuccessorPersistenceReadsLegacyV3WithoutFabricatedCoreTransport(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	insertLegacySuccessorSet(t, admin, input, trust)
 
 	repo := successorRepo(pool, reader, trust)
@@ -620,7 +622,7 @@ func insertLegacySuccessorSet(t *testing.T, admin *pgxpool.Pool, input recoveryp
 func TestSuccessorPersistenceGenerationChangesDuringVerification(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	var once sync.Once
 	var advanceErr error
 	changingReader := successorReaderFunc(func(ctx context.Context, l recoverypg.ValidatedLocator) (io.ReadCloser, error) {
@@ -676,10 +678,44 @@ func TestSuccessorPersistenceGenerationChangesDuringVerification(t *testing.T) {
 	}
 }
 
+func TestFAI520SuccessorPersistenceWorkerFenceAdvancesBeforeAssociation(t *testing.T) {
+	pool, admin, _ := successorDatabase(t)
+	input, trust, reader := successorInputs(t, "minimal")
+	provisionSuccessorGeneration(t, admin, trust)
+
+	var once sync.Once
+	var advanceErr error
+	changingReader := successorReaderFunc(func(ctx context.Context, locator recoverypg.ValidatedLocator) (io.ReadCloser, error) {
+		once.Do(func() {
+			_, advanceErr = admin.Exec(ctx, `UPDATE recovery.successor_trust_generation SET worker_fence=worker_fence+1 WHERE singleton=true`)
+		})
+		if advanceErr != nil {
+			return nil, advanceErr
+		}
+		return reader.ReadExact(ctx, locator)
+	})
+	repo := recoverypg.NewSuccessorRepository(pool, recoverypg.SuccessorOptions{
+		Reader: changingReader,
+		Trust:  func(context.Context, string) (recoverypg.TrustInput, error) { return trust, nil },
+	})
+	if _, err := repo.CreateSet3(t.Context(), input); !errors.Is(err, recoverypg.ErrSuccessorConflict) {
+		t.Fatalf("stale worker fence category: %v", err)
+	}
+	for _, table := range []string{"successor_evidence_v2", "successor_manifest_binding", "recovery_set_v3"} {
+		var count int
+		if err := admin.QueryRow(t.Context(), `SELECT count(*) FROM recovery.`+table).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("stale worker fence left partial state in %s", table)
+		}
+	}
+}
+
 func TestSuccessorPersistenceFirstContendedManifestWinner(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	a, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	b := a
 	b.Payloads.Manifest.Locator.VersionID = "second-version-same-bytes"
 	reader.objects[b.Payloads.Manifest.Locator] = bytes.Clone(a.Payloads.Manifest.CanonicalBytes)
@@ -716,7 +752,7 @@ func TestSuccessorPersistenceFirstContendedManifestWinner(t *testing.T) {
 func TestSuccessorPersistenceImmutableRowsAndUntrustedSQL(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	repo := successorRepo(pool, reader, trust)
 	if _, err := repo.CreateSet3(t.Context(), input); err != nil {
 		t.Fatal(err)

--- a/internal/recoveryset/postgres/successor_repository_test.go
+++ b/internal/recoveryset/postgres/successor_repository_test.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/flidai/leapview/internal/recoveryset"
 	recoverypg "github.com/flidai/leapview/internal/recoveryset/postgres"
@@ -76,6 +78,7 @@ func successorInputs(t *testing.T, name string) (recoverypg.Set3Input, recoveryp
 		{"manifest", recoverypg.PayloadFamilyManifest, 2, evidence.Manifest, &input.Payloads.Manifest},
 		{"anchor", recoverypg.PayloadFamilyAnchor, 2, evidence.Anchor, &input.Payloads.Anchor},
 		{"profiles", recoverypg.PayloadFamilyProfiles, 2, evidence.Profiles, &input.Payloads.Profiles},
+		{"core", recoverypg.PayloadFamilyCore, 2, evidence.Receipt.Core, &input.Payloads.Core},
 		{"receipt", recoverypg.PayloadFamilyReceipt, 2, evidence.Receipt, &input.Payloads.Receipt},
 		{"authority", recoverypg.PayloadFamilyAuthority, 2, evidence.Authorities, &input.Payloads.Authority},
 	}
@@ -224,6 +227,61 @@ func TestSuccessorPersistenceRestartRetryAndExactRead(t *testing.T) {
 	}
 }
 
+func TestSuccessorPersistenceProcessRestartReadback(t *testing.T) {
+	if os.Getenv("LEAPVIEW_FAI520_CORE_READBACK_HELPER") == "1" {
+		runSuccessorCoreReadbackHelper(t)
+		return
+	}
+
+	pool, admin, reopenURL := successorDatabase(t)
+	input, trust, reader := successorInputs(t, "minimal")
+	provisionSuccessorGeneration(t, admin, trust.Generation)
+	if _, err := successorRepo(pool, reader, trust).CreateSet3(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+	pool.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSuccessorPersistenceProcessRestartReadback$", "-test.count=1")
+	cmd.Env = append(os.Environ(),
+		"LEAPVIEW_FAI520_CORE_READBACK_HELPER=1",
+		"LEAPVIEW_FAI520_CORE_READBACK_DSN="+reopenURL,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fresh-process capture-core readback failed: %v\n%s", err, output)
+	}
+}
+
+func runSuccessorCoreReadbackHelper(t *testing.T) {
+	dsn := os.Getenv("LEAPVIEW_FAI520_CORE_READBACK_DSN")
+	if dsn == "" {
+		t.Fatal("readback DSN is required")
+	}
+	pool, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	input, trust, reader := successorInputs(t, "minimal")
+	got, err := successorRepo(pool, reader, trust).ReadSet3(t.Context(), input.Set.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotRaw, err := got.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotRaw, input.Payloads.Set.CanonicalBytes) {
+		t.Fatal("set bytes changed after process restart")
+	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	if reader.reads != 7 || reader.closes != reader.reads {
+		t.Fatalf("fresh process did not read and close all seven exact payloads: read=%d close=%d", reader.reads, reader.closes)
+	}
+}
+
 func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
@@ -251,16 +309,33 @@ func TestSuccessorPersistenceRejectsInvalidEvidence(t *testing.T) {
 			}
 		})
 	}
-	for _, name := range []string{"missing manifest", "wrong digest", "wrong anchor", "invalid receipt", "cache substitution", "locator substitution", "stale generation"} {
+	for _, name := range []string{"missing manifest", "missing core", "wrong digest", "invalid core digest", "wrong anchor", "core authority mismatch", "invalid receipt", "cache substitution", "locator substitution", "stale generation"} {
 		t.Run(name, func(t *testing.T) {
 			bad, badTrust, badReader := successorInputs(t, "minimal")
 			switch name {
 			case "missing manifest":
 				delete(badReader.objects, bad.Payloads.Manifest.Locator)
+			case "missing core":
+				delete(badReader.objects, bad.Payloads.Core.Locator)
 			case "wrong digest":
 				bad.Payloads.Manifest.Locator.PayloadDigest = "sha256:" + fmt.Sprintf("%064x", 22)
+			case "invalid core digest":
+				locator := bad.Payloads.Core.Locator
+				core := badTrust.Evidence.Receipt.Core
+				core.CaptureID = "different-capture"
+				raw, err := core.CanonicalJSON()
+				if err != nil {
+					t.Fatal(err)
+				}
+				sum := sha256.Sum256(raw)
+				bad.Payloads.Core.Locator.PayloadSHA256 = hex.EncodeToString(sum[:])
+				bad.Payloads.Core.Locator.PayloadSize = int64(len(raw))
+				delete(badReader.objects, locator)
+				badReader.objects[bad.Payloads.Core.Locator] = raw
 			case "wrong anchor":
 				bad.Set.SourceFrontierAnchorDigest = "sha256:" + fmt.Sprintf("%064x", 23)
+			case "core authority mismatch":
+				badTrust.Evidence.Receipt.Core.AuthorityID = "authority-b"
 			case "invalid receipt":
 				raw := bytes.Clone(badReader.objects[bad.Payloads.Receipt.Locator])
 				raw[len(raw)-3] ^= 1
@@ -440,6 +515,108 @@ func TestSuccessorPersistencePreservesV1AndReservesIdentity(t *testing.T) {
 	}
 }
 
+func TestSuccessorPersistenceReadsLegacyV3WithoutFabricatedCoreTransport(t *testing.T) {
+	pool, admin, _ := successorDatabase(t)
+	input, trust, reader := successorInputs(t, "minimal")
+	provisionSuccessorGeneration(t, admin, trust.Generation)
+	insertLegacySuccessorSet(t, admin, input, trust)
+
+	repo := successorRepo(pool, reader, trust)
+	if _, err := repo.ReadManifest(t.Context(), input.Set.ManagedObservationManifestDigest); err != nil {
+		t.Fatalf("legacy v3 manifest became unreadable: %v", err)
+	}
+	if _, err := repo.ReadSet3(t.Context(), input.Set.ID); err != nil {
+		t.Fatalf("legacy v3 set became unreadable: %v", err)
+	}
+	if _, err := repo.CreateSet3(t.Context(), input); !errors.Is(err, recoverypg.ErrSuccessorConflict) {
+		t.Fatalf("legacy evidence was silently upgraded instead of conflicting: %v", err)
+	}
+	var cores int
+	if err := admin.QueryRow(t.Context(), `SELECT count(*) FROM recovery.successor_evidence_v2 WHERE payload_family='core'`).Scan(&cores); err != nil {
+		t.Fatal(err)
+	}
+	if cores != 0 {
+		t.Fatal("legacy v3 evidence gained a fabricated capture-core transport")
+	}
+}
+
+func insertLegacySuccessorSet(t *testing.T, admin *pgxpool.Pool, input recoverypg.Set3Input, trust recoverypg.TrustInput) {
+	t.Helper()
+	tx, err := admin.Begin(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(t.Context()) }()
+	for _, item := range []struct {
+		family string
+		ref    recoverypg.PayloadReference
+	}{
+		{"manifest", input.Payloads.Manifest},
+		{"anchor", input.Payloads.Anchor},
+		{"profile", input.Payloads.Profiles},
+		{"receipt", input.Payloads.Receipt},
+		{"authority", input.Payloads.Authority},
+	} {
+		ref := item.ref
+		if _, err := tx.Exec(t.Context(), `INSERT INTO recovery.successor_evidence_v2(payload_family,payload_version,payload_digest,canonical_bytes) VALUES($1,2,$2,$3)`, item.family, ref.Locator.PayloadDigest, ref.CanonicalBytes); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(t.Context(), `INSERT INTO recovery.successor_evidence_locator_v2(payload_family,payload_version,payload_digest,backend,storage_profile_id,storage_profile_revision,account_identity,endpoint,region,bucket,namespace,object_key,version_id,byte_length,raw_sha256) VALUES($1,2,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+			item.family, ref.Locator.PayloadDigest, ref.Locator.Backend, ref.Locator.StorageProfileID, ref.Locator.StorageProfileRevision, ref.Locator.AccountIdentity, ref.Locator.Endpoint, ref.Locator.Region, ref.Locator.Bucket, ref.Locator.Namespace, ref.Locator.Key, ref.Locator.VersionID, ref.Locator.PayloadSize, strings.TrimPrefix(ref.Locator.PayloadSHA256, "sha256:")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	setRaw, err := input.Set.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	setLocator, err := json.Marshal(input.Payloads.Set.Locator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := json.Marshal(struct {
+		IncarnationID string `json:"incarnation_id"`
+		Revision      int64  `json:"revision"`
+		PolicyDigest  string `json:"policy_digest"`
+		VerifiedAt    string `json:"verified_at"`
+	}{trust.Generation.IncarnationID, trust.Generation.Revision, trust.Generation.PolicyDigest, trust.Evidence.VerificationTime.UTC().Truncate(time.Microsecond).Format("2006-01-02T15:04:05.000000Z")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest, _ := trust.Evidence.Manifest.Digest()
+	anchorDigest, _ := trust.Evidence.Anchor.Digest()
+	profileDigest, _ := trust.Evidence.Profiles.Digest()
+	receiptDigest, _ := trust.Evidence.Receipt.Digest()
+	coreDigest, _ := trust.Evidence.Receipt.Core.Digest()
+	authorityDigest, _ := trust.Evidence.Authorities.Digest()
+	if _, err := tx.Exec(t.Context(), `INSERT INTO recovery.successor_manifest_binding(manifest_digest,set_id,anchor_digest,profile_digest,receipt_digest,authority_digest,canonical_set,set_locator,verification_metadata) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)`, manifestDigest, input.Set.ID, anchorDigest, profileDigest, receiptDigest, authorityDigest, setRaw, setLocator, metadata); err != nil {
+		t.Fatal(err)
+	}
+	frontier, err := input.Set.CommitmentBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	frontierDigest, err := input.Set.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(t.Context(), `INSERT INTO recovery.recovery_set_v3(set_id,schema_version,manifest_digest,anchor_digest,profile_digest,receipt_digest,receipt_core_digest,authority_digest,frontier_projection,frontier_digest,canonical_bytes,created_by) VALUES($1,3,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, input.Set.ID, manifestDigest, anchorDigest, profileDigest, receiptDigest, coreDigest, authorityDigest, frontier, frontierDigest, setRaw, input.Set.CreatedBy); err != nil {
+		t.Fatal(err)
+	}
+	for _, root := range input.Set.ObjectRoots {
+		raw, err := json.Marshal(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(t.Context(), `INSERT INTO recovery.recovery_set_v3_root(set_id,root_kind,root_uri,version_id,root_digest,provider_recovery_frontier,canonical_bytes) VALUES($1,$2,$3,$4,$5,$6,$7)`, input.Set.ID, root.Kind, root.URI, root.VersionID, root.Digest, root.ProviderRecoveryFrontier, raw); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSuccessorPersistenceGenerationChangesDuringVerification(t *testing.T) {
 	pool, admin, _ := successorDatabase(t)
 	input, trust, reader := successorInputs(t, "minimal")
@@ -559,6 +736,40 @@ func TestSuccessorPersistenceImmutableRowsAndUntrustedSQL(t *testing.T) {
 	}
 	if _, err := repo.ReadSet3(t.Context(), input.Set.ID); err != nil {
 		t.Fatal(err)
+	}
+	conflictingCore := input
+	conflictingCore.Payloads.Core.Locator.VersionID = "different-immutable-core-version"
+	reader.mu.Lock()
+	reader.objects[conflictingCore.Payloads.Core.Locator] = bytes.Clone(input.Payloads.Core.CanonicalBytes)
+	reader.mu.Unlock()
+	if _, err := repo.CreateSet3(t.Context(), conflictingCore); !errors.Is(err, recoverypg.ErrSuccessorConflict) {
+		t.Fatalf("conflicting capture-core retry category: %v", err)
+	}
+	reader.mu.Lock()
+	storedCore := reader.objects[input.Payloads.Core.Locator]
+	delete(reader.objects, input.Payloads.Core.Locator)
+	reader.mu.Unlock()
+	if _, err := repo.ReadManifest(t.Context(), input.Set.ManagedObservationManifestDigest); !errors.Is(err, recoverypg.ErrSuccessorTampered) {
+		t.Fatalf("manifest read trusted missing capture-core transport: %v", err)
+	}
+	if _, err := repo.ReadSet3(t.Context(), input.Set.ID); !errors.Is(err, recoverypg.ErrSuccessorTampered) {
+		t.Fatalf("set read trusted missing capture-core transport: %v", err)
+	}
+	reader.mu.Lock()
+	reader.objects[input.Payloads.Core.Locator] = storedCore
+	reader.mu.Unlock()
+	if _, err := repo.ReadSet3(t.Context(), input.Set.ID); err != nil {
+		t.Fatalf("repaired capture-core transport did not read deterministically: %v", err)
+	}
+	if _, err := admin.Exec(t.Context(), `ALTER TABLE recovery.successor_manifest_binding DISABLE TRIGGER successor_manifest_binding_immutable`); err != nil {
+		t.Fatal(err)
+	}
+	_, nullCoreErr := admin.Exec(t.Context(), `UPDATE recovery.successor_manifest_binding SET capture_core_digest=NULL WHERE manifest_digest=$1`, input.Set.ManagedObservationManifestDigest)
+	if _, err := admin.Exec(t.Context(), `ALTER TABLE recovery.successor_manifest_binding ENABLE TRIGGER successor_manifest_binding_immutable`); err != nil {
+		t.Fatal(err)
+	}
+	if nullCoreErr == nil {
+		t.Fatal("capture-core required marker allowed a new binding to lose its transport reference")
 	}
 	// Fault injection explicitly disables a guard using the disposable database
 	// administrator. A damaged SQL scalar must still not be trusted on read.

--- a/internal/recoveryset/postgres/successor_s3_qualification_test.go
+++ b/internal/recoveryset/postgres/successor_s3_qualification_test.go
@@ -47,7 +47,7 @@ func TestFAI520SuccessorS3ExactVersionQualification(t *testing.T) {
 	sentinelVersion := putSuccessorS3Object(t, provider, sentinelKey, sentinelBody)
 
 	pool, admin, reopenURL := successorDatabase(t)
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	reader := newSuccessorS3Reader(t, provider.client, provider.config)
 	repo := recoverypg.NewSuccessorRepository(pool, recoverypg.SuccessorOptions{
 		Reader: reader,
@@ -132,7 +132,7 @@ func TestFAI520SuccessorS3ExactVersionFailures(t *testing.T) {
 	configureSuccessorS3Input(t, provider, &input)
 
 	pool, admin, _ := successorDatabase(t)
-	provisionSuccessorGeneration(t, admin, trust.Generation)
+	provisionSuccessorGeneration(t, admin, trust)
 	reader := newSuccessorS3Reader(t, provider.client, provider.config)
 	baseRepo := func(r recoverypg.ExactVersionReader) *recoverypg.SuccessorRepository {
 		return recoverypg.NewSuccessorRepository(pool, recoverypg.SuccessorOptions{

--- a/internal/recoveryset/postgres/successor_s3_qualification_test.go
+++ b/internal/recoveryset/postgres/successor_s3_qualification_test.go
@@ -332,7 +332,7 @@ func configureSuccessorS3Input(t *testing.T, provider successorS3Provider, input
 	t.Helper()
 	values := []*recoverypg.PayloadReference{
 		&input.Payloads.Set, &input.Payloads.Manifest, &input.Payloads.Anchor,
-		&input.Payloads.Profiles, &input.Payloads.Receipt, &input.Payloads.Authority,
+		&input.Payloads.Profiles, &input.Payloads.Core, &input.Payloads.Receipt, &input.Payloads.Authority,
 	}
 	for _, ref := range values {
 		if ref.Locator.Key == "" || len(ref.CanonicalBytes) == 0 {
@@ -395,7 +395,7 @@ func overwriteAndDeleteCurrent(t *testing.T, provider successorS3Provider, input
 	t.Helper()
 	refs := []*recoverypg.PayloadReference{
 		&input.Payloads.Set, &input.Payloads.Manifest, &input.Payloads.Anchor,
-		&input.Payloads.Profiles, &input.Payloads.Receipt, &input.Payloads.Authority,
+		&input.Payloads.Profiles, &input.Payloads.Core, &input.Payloads.Receipt, &input.Payloads.Authority,
 	}
 	for _, ref := range refs {
 		putSuccessorS3Object(t, provider, ref.Locator.Key, []byte("mutable current replacement"))

--- a/internal/recoveryset/postgres/successor_schema.sql
+++ b/internal/recoveryset/postgres/successor_schema.sql
@@ -39,7 +39,7 @@ END
 $$;
 
 CREATE TABLE IF NOT EXISTS recovery.successor_evidence_v2 (
-    payload_family text NOT NULL CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'receipt', 'authority')),
+    payload_family text NOT NULL CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'core', 'receipt', 'authority')),
     payload_version smallint NOT NULL CHECK (payload_version = 2),
     payload_digest text NOT NULL CHECK (payload_digest ~ '^sha256:[0-9a-f]{64}$'),
     canonical_bytes bytea NOT NULL CHECK (octet_length(canonical_bytes) BETWEEN 2 AND 8388608),
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS recovery.successor_evidence_v2 (
                 WHEN 'manifest' THEN 'leapview/managed-observations/v2'
                 WHEN 'anchor' THEN 'leapview/recovery-source-anchor/v2'
                 WHEN 'profile' THEN 'leapview/managed-provider-profiles/v2'
+                WHEN 'core' THEN 'leapview/managed-capture-core/v2'
                 WHEN 'receipt' THEN 'leapview/managed-capture-receipt/v2'
                 WHEN 'authority' THEN 'leapview/authority-registry/v2'
             END || chr(10), canonical_bytes
@@ -82,7 +83,7 @@ CREATE TABLE IF NOT EXISTS recovery.successor_evidence_locator_v2 (
     FOREIGN KEY (payload_family, payload_version, payload_digest)
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
         ON DELETE RESTRICT,
-    CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'receipt', 'authority')),
+    CHECK (payload_family IN ('manifest', 'anchor', 'profile', 'core', 'receipt', 'authority')),
     CHECK (storage_profile_id = btrim(storage_profile_id) AND storage_profile_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'),
     CHECK (account_identity = btrim(account_identity) AND octet_length(account_identity) BETWEEN 1 AND 4096),
     CHECK (endpoint = btrim(endpoint) AND octet_length(endpoint) BETWEEN 1 AND 2048),
@@ -104,6 +105,10 @@ CREATE TABLE IF NOT EXISTS recovery.successor_manifest_binding (
     profile_digest text NOT NULL CHECK (profile_digest ~ '^sha256:[0-9a-f]{64}$'),
     profile_family text GENERATED ALWAYS AS ('profile') STORED,
     profile_version smallint GENERATED ALWAYS AS (2) STORED,
+	capture_core_digest text,
+	capture_core_required boolean NOT NULL DEFAULT false,
+	core_family text GENERATED ALWAYS AS ('core') STORED,
+	core_version smallint GENERATED ALWAYS AS (2) STORED,
     receipt_digest text NOT NULL CHECK (receipt_digest ~ '^sha256:[0-9a-f]{64}$'),
     receipt_family text GENERATED ALWAYS AS ('receipt') STORED,
     receipt_version smallint GENERATED ALWAYS AS (2) STORED,
@@ -123,6 +128,10 @@ CREATE TABLE IF NOT EXISTS recovery.successor_manifest_binding (
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest) ON DELETE RESTRICT,
     FOREIGN KEY (profile_family, profile_version, profile_digest)
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest) ON DELETE RESTRICT,
+	CHECK ((capture_core_required AND capture_core_digest IS NOT NULL AND capture_core_digest ~ '^sha256:[0-9a-f]{64}$') OR
+	       (NOT capture_core_required AND capture_core_digest IS NULL)),
+	FOREIGN KEY (core_family, core_version, capture_core_digest)
+		REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest) ON DELETE RESTRICT,
     FOREIGN KEY (receipt_family, receipt_version, receipt_digest)
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest) ON DELETE RESTRICT,
     FOREIGN KEY (authority_family, authority_version, authority_digest)
@@ -152,8 +161,12 @@ CREATE TABLE IF NOT EXISTS recovery.recovery_set_v3 (
     profile_digest text NOT NULL,
     receipt_family text NOT NULL DEFAULT 'receipt' CHECK (receipt_family = 'receipt'),
     receipt_version smallint NOT NULL DEFAULT 2 CHECK (receipt_version = 2),
-    receipt_digest text NOT NULL,
-    receipt_core_digest text NOT NULL CHECK (receipt_core_digest ~ '^sha256:[0-9a-f]{64}$'),
+	receipt_digest text NOT NULL,
+	receipt_core_digest text NOT NULL CHECK (receipt_core_digest ~ '^sha256:[0-9a-f]{64}$'),
+	capture_core_digest text,
+	capture_core_required boolean NOT NULL DEFAULT false,
+	core_family text GENERATED ALWAYS AS ('core') STORED,
+	core_version smallint GENERATED ALWAYS AS (2) STORED,
     authority_family text NOT NULL DEFAULT 'authority' CHECK (authority_family = 'authority'),
     authority_version smallint NOT NULL DEFAULT 2 CHECK (authority_version = 2),
     authority_digest text NOT NULL,
@@ -178,6 +191,11 @@ CREATE TABLE IF NOT EXISTS recovery.recovery_set_v3 (
         ON DELETE RESTRICT,
     FOREIGN KEY (receipt_family, receipt_version, receipt_digest)
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
+        ON DELETE RESTRICT,
+	CHECK ((capture_core_required AND capture_core_digest IS NOT NULL AND capture_core_digest = receipt_core_digest) OR
+	       (NOT capture_core_required AND capture_core_digest IS NULL)),
+	FOREIGN KEY (core_family, core_version, capture_core_digest)
+		REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
         ON DELETE RESTRICT,
     FOREIGN KEY (authority_family, authority_version, authority_digest)
         REFERENCES recovery.successor_evidence_v2(payload_family, payload_version, payload_digest)
@@ -282,6 +300,9 @@ BEGIN
                    WHERE l.payload_family = s.profile_family AND l.payload_version = s.profile_version AND l.payload_digest = s.profile_digest)
        OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
                    WHERE l.payload_family = s.receipt_family AND l.payload_version = s.receipt_version AND l.payload_digest = s.receipt_digest)
+	   OR EXISTS (SELECT 1 FROM recovery.recovery_set_v3 s WHERE s.set_id = NEW.set_id AND s.capture_core_required)
+	      AND NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
+				   WHERE l.payload_family = 'core' AND l.payload_version = 2 AND l.payload_digest = s.capture_core_digest)
        OR NOT EXISTS (SELECT 1 FROM recovery.successor_evidence_locator_v2 l JOIN recovery.recovery_set_v3 s ON s.set_id = NEW.set_id
                    WHERE l.payload_family = s.authority_family AND l.payload_version = s.authority_version AND l.payload_digest = s.authority_digest) THEN
         RAISE EXCEPTION 'prepared successor recovery set requires exact locators for every selected evidence payload';

--- a/internal/recoveryset/postgres/successor_schema.sql
+++ b/internal/recoveryset/postgres/successor_schema.sql
@@ -143,6 +143,7 @@ CREATE TABLE IF NOT EXISTS recovery.successor_trust_generation (
     incarnation_id uuid NOT NULL,
     revision bigint NOT NULL CHECK (revision > 0),
     policy_digest text NOT NULL CHECK (policy_digest ~ '^sha256:[0-9a-f]{64}$'),
+    worker_fence bigint CHECK (worker_fence IS NULL OR worker_fence > 0),
     updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
 );
 
@@ -238,6 +239,17 @@ LANGUAGE sql SECURITY DEFINER
 SET search_path = pg_catalog, recovery
 AS $$
     SELECT g.incarnation_id, g.revision, g.policy_digest
+      FROM recovery.successor_trust_generation AS g
+     WHERE g.singleton = true
+     FOR UPDATE
+$$;
+
+CREATE OR REPLACE FUNCTION recovery.lock_successor_assignment()
+RETURNS TABLE(incarnation_id uuid, revision bigint, policy_digest text, worker_fence bigint)
+LANGUAGE sql SECURITY DEFINER
+SET search_path = pg_catalog, recovery
+AS $$
+    SELECT g.incarnation_id, g.revision, g.policy_digest, g.worker_fence
       FROM recovery.successor_trust_generation AS g
      WHERE g.singleton = true
      FOR UPDATE
@@ -376,7 +388,7 @@ REVOKE ALL ON TABLE recovery.set_identity_registry, recovery.successor_evidence_
 REVOKE ALL ON FUNCTION recovery.successor_raw_sha256(bytea), recovery.successor_domain_sha256(text, bytea),
     recovery.reject_successor_mutation(), recovery.guard_successor_set_identity(),
     recovery.guard_successor_locator(), recovery.guard_successor_set_complete(), recovery.guard_v1_set_identity(),
-    recovery.lock_successor_generation() FROM PUBLIC;
+    recovery.lock_successor_generation(), recovery.lock_successor_assignment() FROM PUBLIC;
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'leapview_control_maintenance') THEN
@@ -387,6 +399,7 @@ BEGIN
             recovery.successor_evidence_locator_v2, recovery.recovery_set_v3,
             recovery.recovery_set_v3_root, recovery.successor_manifest_binding TO leapview_control_maintenance;
         GRANT EXECUTE ON FUNCTION recovery.lock_successor_generation() TO leapview_control_maintenance;
+        GRANT EXECUTE ON FUNCTION recovery.lock_successor_assignment() TO leapview_control_maintenance;
         REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.set_identity_registry,
             recovery.successor_trust_generation FROM leapview_control_maintenance;
         REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE recovery.successor_evidence_v2,

--- a/internal/recoveryset/successor/independent_binding_test.go
+++ b/internal/recoveryset/successor/independent_binding_test.go
@@ -190,6 +190,7 @@ func TestIndependentSuccessorVersionMatrixAndMalformedEncoding(t *testing.T) {
 		"manifest":  {e.Manifest.CanonicalJSON, func(b []byte) error { _, err := ParseManagedManifest2(b); return err }, `"manifest_version":2`},
 		"anchor":    {e.Anchor.CanonicalJSON, func(b []byte) error { _, err := ParseSourceAnchor(b); return err }, `"anchor_version":2`},
 		"profiles":  {e.Profiles.CanonicalJSON, func(b []byte) error { _, err := ParseProviderProfileSet(b); return err }, `"profile_version":2`},
+		"core":      {e.Receipt.Core.CanonicalJSON, func(b []byte) error { _, err := ParseReceiptCore(b); return err }, `"core_version":2`},
 		"receipt":   {e.Receipt.CanonicalJSON, func(b []byte) error { _, err := ParseReceipt(b); return err }, `"receipt_version":2`},
 		"authority": {e.Authorities.CanonicalJSON, func(b []byte) error { _, err := ParseAuthorityRegistry(b); return err }, `"registry_version":2`},
 	} {

--- a/internal/recoveryset/successor/receipt.go
+++ b/internal/recoveryset/successor/receipt.go
@@ -114,6 +114,41 @@ func (c ReceiptCore) Digest() (string, error) {
 	return hash(coreDomain, raw), nil
 }
 
+// ParseReceiptCore parses the standalone capture-core transport document. The
+// core is also embedded in SignedReceipt for signature verification, but this
+// parser intentionally verifies the independently retained canonical bytes.
+func ParseReceiptCore(raw []byte) (ReceiptCore, error) {
+	var core ReceiptCore
+	if err := strictDecode(raw, &core, MaxDocumentBytes); err != nil {
+		return core, err
+	}
+	if _, err := exactObject(raw, map[string]bool{
+		"core_version": true, "authority_id": true, "key_id": true,
+		"capture_id": true, "set_id": true, "started_at": true,
+		"completed_at": true, "source_frontier_anchor_digest": true,
+		"managed_closure_digest": true, "provider_profile_digest": true,
+		"observation_projection_digest": true, "membership_count": true,
+		"object_count": true, "result": true,
+	}, map[string]bool{
+		"core_version": true, "authority_id": true, "key_id": true,
+		"capture_id": true, "set_id": true, "started_at": true,
+		"completed_at": true, "source_frontier_anchor_digest": true,
+		"managed_closure_digest": true, "provider_profile_digest": true,
+		"observation_projection_digest": true, "membership_count": true,
+		"object_count": true, "result": true,
+	}, "receipt core"); err != nil {
+		return core, err
+	}
+	canonical, err := core.CanonicalJSON()
+	if err != nil {
+		return core, err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return core, invalid("receipt core is not canonical JSON")
+	}
+	return core, nil
+}
+
 func (r SignedReceipt) Validate() error {
 	if r.ReceiptVersion != ReceiptVersion {
 		return fmt.Errorf("%w: receipt version %d", ErrUnsupportedVersion, r.ReceiptVersion)


### PR DESCRIPTION
## Problem

RecoverySet v3 persisted the Manifest v2 and signed receipt, but the `managed-capture-core` transport family remained available only inside the receipt. That left the complete capture transport evidence without an independently addressable, immutable persistence boundary.

## Solution

- Persist canonical `managed-capture-core` v2 transport bytes and their raw/domain-separated digests independently.
- Bind the transport to its manifest, receipt, immutable locator, capture authority, and trust generation.
- Extend the existing `CreateSet3` transaction so transport verification, immutable insertion, and recovery-set association commit atomically.
- Fence trust-generation changes during verification and reject missing, substituted, or conflicting evidence.
- Add migration 012 and least-privilege grants while preserving existing RecoverySet v1 and legacy v3 behavior without backfills or fabricated transport evidence.

## Tests added or updated

- Exact retry and conflicting retry behavior.
- Concurrent identical and conflicting writes with one immutable winner.
- Canonical/raw/domain digest and locator/receipt/manifest relationship verification.
- Restart/subprocess readback verification.
- Legacy v3 read compatibility and v1 preservation.
- Generation-fence, immutable-row, untrusted-SQL, permission, fresh-migration, and upgrade qualification.

## Verification performed

- Focused capture, successor-contract, and PostgreSQL migration tests passed after rebasing onto `origin/main` at `f37a6af96`.
- Generated-state and documentation checks passed.
- `git diff --check` and final scope/secret review passed.
- Full `task ci` passed on the exact committed tree using Go 1.26.8, Bun 1.3.14, PostgreSQL 18 test containers, isolated Go cache/tmp storage, and serialized heavy application links to avoid runner contention.

## Remaining limitations

- No recovery admission or startup integration.
- No physical restore or PITR implementation.
- No provider-version retention guarantee or production-provider qualification.
- No production signer/key or capture-worker deployment.
- No RPO/RTO qualification.

**Evidence persistence does not prove physical disaster recovery.**

## P1 review fix — worker fence enforcement

- Persist the resolved `WorkerFence` in immutable verification metadata.
- During `CreateSet3`, lock the authoritative successor assignment row and compare both trust generation and worker fence before any evidence insert.
- Reject stale worker evidence transactionally without partial rows or replacement of the immutable winner.
- Preserve existing authority/profile verification, v1 records, legacy v3 reads, and frozen wire contracts.

### Fix validation

- Added a fence-advancement race regression covering fence N evidence rejected after ownership advances to N+1.
- Focused capture/core, RecoverySet, PostgreSQL qualification, migration conformance, race, architecture, `go vet`, generated, docs, and diff checks passed.
- Full `task ci` passed on commit `5aa08e12a` with exit code 0.

> This validates evidence integrity and fencing. It does not prove physical disaster recovery.
