### PR TITLE
Fix hosted demo clean-checkout generation

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -34,17 +34,19 @@ jobs:
         with:
           ref: ${{ env.SOURCE_REVISION }}
 
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Set up the cached CI toolchain
+        uses: ./.github/actions/setup-ci
         with:
-          go-version-file: go.mod
-          cache: true
+          browser: "false"
 
       - name: Restore the pinned Olist dataset cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/leapview
           key: olist-v2-967e41e04fc306fe604e2a693f488995a8b41e5047418f8a5c8e4abd6deca784
+
+      - name: Prepare generated code
+        run: task generate
 
       - name: Fetch demo deployment credentials
         uses: Infisical/secrets-action@6cd3f7c0e4cc0d2395ee4ef414eb6eeb5d3e73db # v1.0.17

--- a/scripts/frontend_ci_contract.test.ts
+++ b/scripts/frontend_ci_contract.test.ts
@@ -36,3 +36,15 @@ for (const workflow of ['ci', 'merge-validation', 'nightly']) {
       .toBe(true)
   })
 }
+
+test('hosted demo generates build-only packages before publishing', () => {
+  const config = parse(readFileSync('.github/workflows/demo-deploy.yml', 'utf8'))
+  const steps = config.jobs.deploy.steps
+  const setupIndex = steps.findIndex((step: any) => step.uses === './.github/actions/setup-ci')
+  const generateIndex = steps.findIndex((step: any) => step.run === 'task generate')
+  const publishIndex = steps.findIndex((step: any) => step.run === './scripts/deploy_demo.sh')
+
+  expect(setupIndex).toBeGreaterThan(-1)
+  expect(generateIndex).toBeGreaterThan(setupIndex)
+  expect(publishIndex).toBeGreaterThan(generateIndex)
+})


### PR DESCRIPTION
The hosted demo workflow builds `./cmd/leapview` from a clean checkout, but build-only APIGen, sqlc, and UI signal packages are intentionally untracked. Every recent main deployment therefore fails before publication with missing-package errors.

Use the repository's pinned CI setup and generate build inputs before fetching deployment credentials or running the publisher. A workflow contract test locks in setup → generation → publish ordering.

Validation:
- `bun test scripts/frontend_ci_contract.test.ts`
- `bun run typecheck:tests`
- `git diff --check`
