### PR TITLE
test(project): prove dbt multi-source Project closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,9 @@ jobs:
       - name: Run real dbt Parquet through the headless LeapView lifecycle
         run: DBT_BIN="$(command -v dbt)" task dbt:warehouse:qualify
 
+      - name: Prove upstream packages and independent producers share one Project
+        run: DBT_BIN="$(command -v dbt)" task dbt:warehouse:proof
+
       - name: Stop the isolated PostgreSQL development service
         if: always()
         run: task postgres:dev:down

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,6 +47,11 @@ tasks:
     cmds:
       - ./scripts/dbt-warehouse-boundary.sh build
 
+  dbt:warehouse:proof:
+    desc: Prove independent physical producers and upstream dbt packages close into one Project
+    cmds:
+      - ./scripts/dbt-warehouse-boundary.sh proof
+
   dbt:warehouse:qualify:
     desc: Run the physical dbt Parquet publication through the ordinary headless LeapView candidate lifecycle
     cmds:

--- a/adr/specifications/dbt-warehouse-boundary-conformance.md
+++ b/adr/specifications/dbt-warehouse-boundary-conformance.md
@@ -2,7 +2,7 @@
 
 Status: partial; Project-free source prerequisite satisfied
 
-Last updated: 2026-09-06
+Last updated: 2026-09-12
 
 Governing decision:
 [ADR-0019](../0019-integrate-dbt-at-the-warehouse-contract-boundary.md)
@@ -51,7 +51,15 @@ Evidence classifications used below:
 | Serving and refresh require no dbt executable, repository, artifacts, or credentials | Runtime module/image architecture assertion; dbt dependencies are isolated under `examples/` and CI | Proven local by runtime/module assertions. |
 | Source read, serving write, and semantic policy boundaries remain distinct | Azure workflow, existing scoped Azure secret tests in `internal/analytics/duckdb/source_test.go`, and integration guide | Structurally validated — not live Azure; IAM scopes are operator requirements and live Azure authorization is not claimed. |
 | MetricFlow/dbt Semantic Layer definitions do not silently become LeapView definitions | No artifact parser or dbt semantic dependency exists; architecture assertion | Implemented by absence and explicit deferral. |
-| Every SemanticModel dataset resolves inside the same Project candidate/generation | ADR-0018 SEM-01/SEM-02 evidence in `project-namespace-conformance.md` | Partial; Project-free compilation is in place, while FAI-675 owns the closed candidate resolver proof. |
+| Every SemanticModel dataset resolves inside the same Project candidate/generation | ADR-0018 SEM-01/SEM-02 evidence in `project-namespace-conformance.md`; `task dbt:warehouse:proof`; `TestPostgresResourceUIDMultiSourceProjectClosure` | Proven locally for a dbt-package-derived mart plus an independent CRM publication. The graph closes under one issuer ProjectUID and one exact generation ResourceUID inventory. Missing and ambiguous Source mappings fail before delivery. |
+| dbt output has no alternate authorization path | `TestDBTMultiSourceProjectClosure`; ADR-0017 semantic-access compiler, consumer, and PlanIR barrier suites | Proven locally. The exact dbt/CRM semantic mapping rejects unbound execution, admits a request-bound consumer, installs barriers on both dataset scans, and fails closed for denied target-owned attributes. |
+
+The FAI-678 proof adds adoption evidence, not runtime authority. dbt resolves
+its upstream package and materializes the consumer-owned mart before the
+physical boundary. LeapView receives Parquet plus ordinary Connection and
+Source resources; it neither imports dbt artifacts nor resolves live dbt Mesh
+references. The second CRM publication has a separate Connection root, while
+both Sources close into the same SemanticModel and Dashboard generation.
 
 ## Existing capability composition
 
@@ -64,6 +72,7 @@ Evidence classifications used below:
 | Atomic activation, retained generations, rollback, leases, recovery | `internal/runtimehost`, `internal/deployment`, and `internal/servingstate` |
 | Local non-interactive orchestration | `leapview dev --once --no-browser` via `scripts/dev-server.sh` |
 | Project/environment identity and target bindings | existing deployment and connection-binding contracts; Project-free source semantics supplied by FAI-666, with durable identity and final binding tracked by FAI-667/FAI-669 |
+| Semantic authorization over consumer outputs | existing ADR-0017 semantic-access consumer, compiled policy, target-owned attribute authority, and PlanIR SecurityBarrier path |
 
 Physical Parquet is the CI contract evidence. dbt's manifest and run-results
 files are neither parsed nor admitted; a targeted metadata-only case proves

--- a/adr/specifications/project-namespace-conformance.md
+++ b/adr/specifications/project-namespace-conformance.md
@@ -364,6 +364,26 @@ boundary. It does not introduce cross-Project authorization, a foreign catalog,
 ResourceUID behavior, deployment binding, or the dbt adoption fixture owned by
 FAI-678.
 
+### dbt and multi-Source adoption evidence (FAI-678)
+
+The maintained multi-source fixture proves that producer topology does not
+create another LeapView identity boundary. dbt resolves an upstream package and
+materializes a consumer-owned Parquet mart; an independent CRM producer writes
+a second Parquet publication. LeapView compiles only ordinary Connections,
+Sources, thin Models, one SemanticModel, and one Dashboard into its rootless
+portable graph.
+
+| Requirements | Maintained evidence |
+| --- | --- |
+| DBT-01, DBT-03, DBT-06 | `task dbt:warehouse:proof` and `TestDBTMultiSourceProjectClosure` build both physical publications, compile the two-Connection/two-Source graph, and execute a leased cross-producer semantic query under one issuer-minted ProjectUID. |
+| DBT-02, DBT-04 | The same test rejects producer, repository, dbt project, invocation, manifest, path, and target authority from portable bytes while rebinding the unchanged portable digest to independent dev/prod targets. |
+| DBT-05, SEM-04, XPR-01 | The upstream package is resolved before Parquet handoff. Package-qualified, Project-qualified, and missing live Model references fail during rootless compilation; no manifest or dbt runtime resolver is used. |
+| RID-02, RID-03, SEM-02 | `TestPostgresResourceUIDMultiSourceProjectClosure` commits the sealed graph inventory through the activation-owned registry, preserves ResourceUIDs across a compatible generation, and rejects foreign Project and instance lookup. |
+
+This evidence covers local dbt package resolution, not live dbt Mesh, cloud IAM,
+or an atomic snapshot across independent upstream producers. It does not mark
+ADR-0018 as a whole implemented; FAI-679 retains final conformance ownership.
+
 Implementation must update the project-delivery and data-contract versioning
 conformance specifications where their current language conflicts with this
 accepted profile. The final combined implementation change must pass:

--- a/adr/specifications/project-namespace-implementation-delta.md
+++ b/adr/specifications/project-namespace-implementation-delta.md
@@ -115,7 +115,7 @@ binding service, lifecycle, Project context, or registry framework.
 | SEM-01 | Conforming | SemanticModel datasets resolve only through the candidate-local Model map, while `TestSourceRootRejectsQualifiedForeignSemanticModelReferenceDeterministically` and `TestSourceBundleRejectsMissingAndForeignSemanticModelReferences` reject missing and foreign-qualified references during compilation and bundle admission. | — |
 | SEM-02 | Conforming | Compiled models are stored inside one graph/artifact, and active graph readers pin one exact runtime lease in [`internal/project/module/active_graph_test.go`](../../internal/project/module/active_graph_test.go); there is no resolver path to another active catalog. | — |
 | SEM-03 | Conforming | Source-to-Model-to-SemanticModel is the ordinary compiler path and no dbt runtime kind exists. `TestResourceResolverDoesNotResolveThroughProvenance` proves provenance cannot become a semantic resolver alias; FAI-678 separately owns the dbt adoption fixture. | — |
-| SEM-04 | Missing | ADR-0019 documents the upstream dbt boundary, but no fixture proves upstream dependencies become consumer-owned ordinary Sources/Models before LeapView compilation. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
+| SEM-04 | Conforming | `TestDBTMultiSourceProjectClosure` builds a consumer-owned Parquet mart from a local upstream dbt package, then compiles and queries it only through ordinary Project-local Source, Model, and SemanticModel resources. Package-qualified and foreign live references fail closed. | — |
 | SEM-05 | Conforming | The graph is a closed project-local topology: `TestSourceBundleRejectsIncompleteSemanticModelClosure` requires each semantic dataset dependency and its exact edge, and the foreign-reference corpus rejects resolution outside that topology. | — |
 
 ### Isolation boundary
@@ -140,12 +140,12 @@ binding service, lifecycle, Project context, or registry framework.
 
 | Requirement | Disposition | Current evidence or conflict | Gap owner |
 | --- | --- | --- | --- |
-| DBT-01 | Missing | ADR-0019 defines the mapping, but the reference dbt-repository-plus-LeapView deployment fixture does not exist. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
-| DBT-02 | Missing | Provenance types are separate from execution identity, but no dbt fixture proves those identifiers cannot replace Project UID. FAI-667's issuer-owned UID flow is a prerequisite for the FAI-678 adoption evidence. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
+| DBT-01 | Conforming | The maintained [`examples/dbt-warehouse-boundary/multi-source`](../../examples/dbt-warehouse-boundary/multi-source) fixture and `task dbt:warehouse:proof` build an upstream-package-derived consumer mart and combine it with an independent CRM publication in one rootless LeapView resource graph. | — |
+| DBT-02 | Conforming | `TestDBTMultiSourceProjectClosure` mints and replays one issuer-owned ProjectUID, proves the same portable digest binds to separate target contexts, and rejects dbt project, repository, invocation, manifest, target, and path values from the portable artifact. | — |
 | DBT-03 | Conforming | [`discoverAuthoredResources`](../../internal/project/compiler/resource_discovery.go) discovers SemanticModels and Dashboards beside the other four portable kinds without a Project manifest; the maintained [`examples/dbt-warehouse-boundary/leapview`](../../examples/dbt-warehouse-boundary/leapview) fixture contains only those conventional resource directories. | — |
-| DBT-04 | Partial | Target Connection bindings and ordinary Source locations already select environment-specific physical relations, but the dbt mapping fixture is absent. FAI-675 supplies the closed resolver/rejection behavior consumed by that fixture. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
-| DBT-05 | Missing | Runtime has no dbt Mesh resolver, as required, but there is no fixture showing upstream dbt dependencies only as provenance behind consumer-owned outputs. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
-| DBT-06 | Partial | The compiler already supports several ordinary Sources and Models in one closed graph, but a maintained independently-produced multi-Source semantic fixture is absent. FAI-675 supplies the closed-graph and live-reference rejection contract used by that fixture. | [FAI-678](https://linear.app/flid/issue/FAI-678) |
+| DBT-04 | Conforming | The proof binds two ordinary Connection roots independently for dev and prod while preserving the portable artifact digest; the directory publication changes by target without becoming portable identity. | — |
+| DBT-05 | Conforming | dbt resolves the local upstream package and materializes a consumer-owned Parquet mart before handoff. LeapView receives no manifest or live Mesh authority, and package-qualified live references are rejected. | — |
+| DBT-06 | Conforming | The proof compiles two Connections, two independently produced Sources, two thin Models, one SemanticModel, and one Dashboard into one closed graph. PostgreSQL activation assigns a complete, stable generation ResourceUID inventory and rejects foreign Project or instance lookups. | — |
 
 ## Follow-up ownership
 

--- a/docs/articles/integrate/dbt-warehouse-boundary.md
+++ b/docs/articles/integrate/dbt-warehouse-boundary.md
@@ -52,6 +52,17 @@ The non-interactive CI equivalent is:
 task dbt:warehouse:qualify
 ```
 
+For the separate two-producer Project-closure proof, run
+`task dbt:warehouse:proof`. It reuses the example's thin Models and SemanticModel
+with two target-bound Connections, a consumer-owned mart built from a local dbt
+package, and an independent CRM publication. The
+[proof fixture](https://github.com/flidai/leapview/tree/main/examples/dbt-warehouse-boundary/multi-source)
+documents the assertions and distinguishes local physical qualification from
+PostgreSQL registry and full headless lifecycle validation. The proof also
+binds the compiled cross-source mapping to the existing request-scoped semantic
+access consumer: execution without that capability fails, both dataset scans
+carry authorization barriers, and denied target-owned attributes fail closed.
+
 dbt staging and mart SQL owns normalization, joins, and aggregation. The
 LeapView Models only select fields, assign the stable `snake_case` BI field
 IDs, perform safe casts, and enforce the consumer-side contract. The

--- a/examples/dbt-warehouse-boundary/README.md
+++ b/examples/dbt-warehouse-boundary/README.md
@@ -13,3 +13,9 @@ The dbt project owns the transformations and writes the two selected marts to
 those physical Parquet files through its ordinary managed Connection, Sources,
 thin Models, SemanticModel, and Dashboard. Neither `target/`, `manifest.json`,
 nor `run_results.json` is part of the LeapView serving contract.
+
+The [multi-source Project proof](multi-source/README.md) reuses this consumer
+with two independent physical producer roots and two Connections. Run
+`task dbt:warehouse:proof` for the real dbt-package, qualification, and semantic
+query evidence; its README separates that local proof from PostgreSQL lifecycle
+validation.

--- a/examples/dbt-warehouse-boundary/multi-source/README.md
+++ b/examples/dbt-warehouse-boundary/multi-source/README.md
@@ -1,0 +1,87 @@
+# Two producers, one LeapView Project
+
+This FAI-678 proof extends the existing showcase without changing its primary
+two-mart example. Run from the repository root:
+
+```sh
+task dbt:warehouse:proof
+```
+
+The task uses the same pinned dbt requirements as `task dbt:warehouse:build`.
+Set `DBT_BIN` to an absolute executable path to use a separately installed
+toolchain. The test runs producers in disposable directories; it does not write
+dbt outputs, packages, credentials, or target bindings into portable source.
+
+## Physical handoffs
+
+```text
+upstream_orders (local dbt package)
+    → proof_consumer dbt build → commerce/fct_orders.parquet
+                                      ↓ warehouse Connection / orders Source
+independent CRM SQL snapshot → directory/dim_customers.parquet
+                                      ↓ directory Connection / customers Source
+                one Project-free LeapView source bundle
+                    → thin Models → sales SemanticModel
+                    → request-bound semantic access → existing dashboard
+```
+
+The CRM producer does not read the commerce publication. `consumer-overlay/`
+adds a second ordinary managed Connection and routes the existing customers
+Source to it. The test overlays these two files on `../leapview/`; it reuses
+the existing Models, semantics, and dashboard. It does not collapse the two
+physical roots or import dbt graph edges into LeapView.
+
+dbt resolves the local package and builds/tests a **consumer-owned** order mart
+before the handoff. This exercises the package case, not a live dbt Mesh
+service. Live references to package/Project-qualified Models are rejected.
+Project, repository, commit, target, manifest location, and invocation ID (from
+dbt's CLI log) are logged as producer-only test evidence. The harness does not
+read/import dbt manifests or run results. The consumer receives Parquet alone
+and retains its authored IDs.
+
+## Evidence and limits
+
+`internal/app/dbt_multi_source_proof_test.go` uses the real CLI ProfileStore
+issuer, rootless compiler, destination plan builder, DuckLake materializer,
+Source/Model qualification gates, runtime-host activation and leased semantic
+query. The same portable artifact binds to separate dev/prod target contexts
+under one issuer-supplied ProjectUID. The directory target binding changes
+`north` to `west` in production; query assertions check both regional revenue
+results and distinct generation/plan identities. A missing second publication
+blocks a replacement candidate while the retained generation still queries.
+The runtime composition assertion applies the already-qualified portable
+semantic-access representation to the compiled dbt/CRM mapping, proves that an
+unbound execution is rejected, verifies authorization barriers for both
+source-backed datasets, and rejects a principal whose target-owned attribute
+does not satisfy the policy. Semantic-access policy lowering, durable registry
+resolution, activation, cache, and audit remain owned by the ADR-0017 suites;
+this proof does not reimplement them.
+
+The local physical proof uses the existing test repository and activation
+callback; it is **not** a substitute for PostgreSQL admission, bootstrap audit,
+registry durability, or the full headless deployment path. Run those separately:
+
+```sh
+task dbt:warehouse:qualify
+LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=true go test -tags duckdb_arrow ./internal/deployment/postgres -run '^TestPostgresResourceUIDMultiSourceProjectClosure$' -count=1 -v
+```
+
+The PostgreSQL fixture compiles this same consumer graph, seals its complete
+ResourceUID inventory, and commits the inventory through FAI-670's actual
+activation authority. It checks compatible-generation UID stability plus
+foreign-Project and foreign-instance lookup rejection. The surrounding
+ResourceUID qualification suite owns rollback, kind, tombstone, restore, and
+concurrency behavior; this focused proof does not duplicate those tests. Its
+minimal admitted-generation scaffold does not replace full delivery CI.
+
+ResourceUIDs are stable **within an instance**. Environment is not part of their
+identity key; promotion to a different environment uses a different instance
+and therefore does not copy that instance's ResourceUIDs. The ProjectUID and
+authored resource IDs preserve portable meaning. Neither UID comes from dbt
+names, file paths, repository coordinates, or producer invocation metadata.
+
+These are ordinary independently observed Sources: their captured LeapView
+candidate activates together, but this proof makes no atomic upstream snapshot,
+cross-environment byte-identical data, cloud IAM, or live Mesh claim. Missing
+Docker blocks the PostgreSQL and headless commands and must be reported as an
+environmental limitation rather than treated as a pass.

--- a/examples/dbt-warehouse-boundary/multi-source/consumer-overlay/connections/directory.yaml
+++ b/examples/dbt-warehouse-boundary/multi-source/consumer-overlay/connections/directory.yaml
@@ -1,0 +1,12 @@
+apiVersion: leapview.dev/v1
+kind: Connection
+metadata:
+  id: connection:directory
+  name: directory
+  displayName: Independently published customer directory
+spec:
+  type: managed
+  defaults:
+    parquet:
+      hivePartitioning: false
+      unionByName: false

--- a/examples/dbt-warehouse-boundary/multi-source/consumer-overlay/sources/dim_customers.yaml
+++ b/examples/dbt-warehouse-boundary/multi-source/consumer-overlay/sources/dim_customers.yaml
@@ -1,0 +1,20 @@
+apiVersion: leapview.dev/v1
+kind: Source
+metadata:
+  id: source:warehouse.dim_customers
+  name: warehouse.dim_customers
+  displayName: Published customer mart
+spec:
+  connection: directory
+  location:
+    type: path
+    path: dim_customers.parquet
+    format: parquet
+  schema:
+    mode: strict
+    fields:
+      customer_id: {datatype: String, nullable: true}
+      customer_name: {datatype: String, nullable: true}
+      region: {datatype: String, nullable: true}
+      order_count: {datatype: Integer, nullable: true}
+      lifetime_value: {datatype: Float, nullable: true}

--- a/examples/dbt-warehouse-boundary/multi-source/customer-directory.sql
+++ b/examples/dbt-warehouse-boundary/multi-source/customer-directory.sql
@@ -1,0 +1,10 @@
+-- Independently published CRM snapshot. It does not read the commerce mart,
+-- the dbt repository, or any LeapView catalog. Aggregates are producer-owned.
+select customer_id::varchar as customer_id, customer_name::varchar as customer_name,
+       region::varchar as region, order_count::bigint as order_count,
+       lifetime_value::double as lifetime_value
+from (values
+  ('c-1', 'Ada', 'north', 2, 52.25),
+  ('c-2', 'Grace', 'south', 1, 75.00),
+  ('c-3', 'Linus', 'north', 1, 9.99)
+) as directory(customer_id, customer_name, region, order_count, lifetime_value)

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/dbt_project.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/dbt_project.yml
@@ -1,0 +1,9 @@
+name: proof_consumer
+version: 1.0.0
+config-version: 2
+profile: proof_consumer
+model-paths: [models]
+models:
+  proof_consumer:
+    +materialized: external
+    +format: parquet

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/models/fct_orders.sql
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/models/fct_orders.sql
@@ -1,0 +1,9 @@
+-- dbt resolves this package before publishing the consumer-owned physical mart.
+select
+  order_id,
+  customer_id,
+  order_date,
+  order_status,
+  cast(sum(line_amount) as double) as revenue
+from {{ ref('upstream_orders', 'order_lines') }}
+group by order_id, customer_id, order_date, order_status

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/models/properties.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/models/properties.yml
@@ -1,0 +1,11 @@
+version: 2
+models:
+  - name: fct_orders
+    config:
+      contract: {enforced: true}
+    columns:
+      - {name: order_id, data_type: varchar, tests: [not_null, unique]}
+      - {name: customer_id, data_type: varchar, tests: [not_null]}
+      - {name: order_date, data_type: date, tests: [not_null]}
+      - {name: order_status, data_type: varchar, tests: [not_null]}
+      - {name: revenue, data_type: double, tests: [not_null]}

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/packages.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/packages.yml
@@ -1,0 +1,2 @@
+packages:
+  - local: ../upstream-orders

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/profiles.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/profiles.yml
@@ -1,0 +1,9 @@
+proof_consumer:
+  target: local
+  outputs:
+    local:
+      type: duckdb
+      path: target/commerce.duckdb
+      schema: commerce
+      threads: 2
+      external_root: ../published/commerce

--- a/examples/dbt-warehouse-boundary/multi-source/dbt/profiles.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/dbt/profiles.yml
@@ -1,7 +1,7 @@
 proof_consumer:
-  target: local
+  target: dbt-target-production-boundary-proof
   outputs:
-    local:
+    dbt-target-production-boundary-proof:
       type: duckdb
       path: target/commerce.duckdb
       schema: commerce

--- a/examples/dbt-warehouse-boundary/multi-source/upstream-orders/dbt_project.yml
+++ b/examples/dbt-warehouse-boundary/multi-source/upstream-orders/dbt_project.yml
@@ -1,0 +1,8 @@
+name: upstream_orders
+version: 1.0.0
+config-version: 2
+model-paths: [models]
+seed-paths: [seeds]
+models:
+  upstream_orders:
+    +materialized: view

--- a/examples/dbt-warehouse-boundary/multi-source/upstream-orders/models/order_lines.sql
+++ b/examples/dbt-warehouse-boundary/multi-source/upstream-orders/models/order_lines.sql
@@ -1,0 +1,7 @@
+select
+  cast(order_id as varchar) as order_id,
+  cast(customer_id as varchar) as customer_id,
+  cast(order_date as date) as order_date,
+  lower(cast(status as varchar)) as order_status,
+  cast(line_amount as double) as line_amount
+from {{ ref('upstream_orders', 'raw_orders') }}

--- a/examples/dbt-warehouse-boundary/multi-source/upstream-orders/seeds/raw_orders.csv
+++ b/examples/dbt-warehouse-boundary/multi-source/upstream-orders/seeds/raw_orders.csv
@@ -1,0 +1,6 @@
+order_id,customer_id,order_date,status,line_amount
+o-100,c-1,2026-08-01,SHIPPED,24.50
+o-100,c-1,2026-08-01,SHIPPED,15.50
+o-101,c-2,2026-08-02,DELIVERED,75.00
+o-102,c-1,2026-08-03,PROCESSING,12.25
+o-103,c-3,2026-08-03,CANCELLED,9.99

--- a/internal/app/dbt_multi_source_delivery_proof_test.go
+++ b/internal/app/dbt_multi_source_delivery_proof_test.go
@@ -1,0 +1,376 @@
+//go:build duckdb_arrow
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	appruntimefactory "github.com/flidai/leapview/internal/app/runtimefactory"
+	"github.com/flidai/leapview/internal/deployment"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	projectbundle "github.com/flidai/leapview/internal/project/bundle"
+	projectcompiler "github.com/flidai/leapview/internal/project/compiler"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
+	"github.com/flidai/leapview/internal/release"
+	"github.com/flidai/leapview/internal/runtimehost"
+	"github.com/flidai/leapview/internal/servingstate"
+)
+
+const dbtProofTarget = "dbt-target-production-boundary-proof"
+
+type dbtProofBoundDelivery struct {
+	Plan        deployment.DeliveryPlan
+	State       servingstate.State
+	Artifact    servingstate.Artifact
+	ManagedData runtimehost.ManagedDataResolution
+	Spec        warehouseBoundarySpec
+}
+
+func newDBTProofBoundDelivery(
+	input deployment.DeliveryCandidateBuildInput,
+	artifacts release.CandidateArtifactSet,
+	runtimeVersion string,
+	now time.Time,
+	roots map[string]string,
+	accessPolicy semanticmodel.SemanticAccessPolicy,
+	producerTarget string,
+) (dbtProofBoundDelivery, error) {
+	if err := validateDBTProofConnectionRequirements(artifacts); err != nil {
+		return dbtProofBoundDelivery{}, err
+	}
+	artifacts, bundleBytes, err := prepareDBTProofServingArtifact(artifacts)
+	if err != nil {
+		return dbtProofBoundDelivery{}, err
+	}
+	request, err := appruntimefactory.CandidatePlanRequest(input, artifacts, runtimeVersion, now)
+	if err != nil {
+		return dbtProofBoundDelivery{}, err
+	}
+	request.ServingArtifactDigest = artifacts.Generation.ArtifactDigest
+	return bindDBTProofDeliveryRequest(input, artifacts, request, bundleBytes, roots, accessPolicy, producerTarget)
+}
+
+func bindDBTProofDeliveryRequest(
+	input deployment.DeliveryCandidateBuildInput,
+	artifacts release.CandidateArtifactSet,
+	request deployment.DeliveryPlanRequest,
+	bundleBytes []byte,
+	roots map[string]string,
+	accessPolicy semanticmodel.SemanticAccessPolicy,
+	producerTarget string,
+) (dbtProofBoundDelivery, error) {
+	if err := validateDBTProofConnectionRequirements(artifacts); err != nil {
+		return dbtProofBoundDelivery{}, err
+	}
+	if err := request.Governance.Validate(); err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("delivery governance: %w", err)
+	}
+	if request.Governance.PolicyDigest != artifacts.AuthorizationFingerprint || request.Governance.AuthorizationDigest != artifacts.AuthorizationFingerprint {
+		return dbtProofBoundDelivery{}, fmt.Errorf("delivery governance is not bound to the candidate authorization fingerprint")
+	}
+	if producerTarget != dbtProofTarget {
+		return dbtProofBoundDelivery{}, fmt.Errorf("dbt target provenance is missing from delivery metadata")
+	}
+	request.Provenance.BuildDefinition += "+dbt-target:" + producerTarget
+	projectID, err := projectgraph.NewResourceID(request.ProjectID)
+	if err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("delivery project identity: %w", err)
+	}
+	plan, err := deployment.NewDeliveryPlan(deployment.DeliveryPlan{
+		ID: request.ID, ActorID: request.ActorID, SourceOwnerID: input.OwnerID,
+		TargetID: request.TargetID, ProjectID: projectID, Environment: request.Environment,
+		Operation: request.Operation, SourceDigest: request.SourceDigest,
+		ServingArtifactDigest: request.ServingArtifactDigest,
+		Execution:             request.Execution, Provenance: request.Provenance,
+		Governance: request.Governance, Evidence: request.Evidence,
+		PipelinePlan: request.PipelinePlan, CreatedAt: request.CreatedAt,
+	})
+	if err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("validate production-shaped delivery plan: %w", err)
+	}
+	if err := plan.Governance.Validate(); err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("validated plan governance: %w", err)
+	}
+
+	validation, compiled, err := projectbundle.ValidateArtifactBytes(bundleBytes)
+	if err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("validate persisted serving artifact: %w", err)
+	}
+	if validation.Digest != plan.ServingArtifactDigest || artifacts.Generation.ArtifactDigest != plan.ServingArtifactDigest {
+		return dbtProofBoundDelivery{}, fmt.Errorf("persisted serving artifact differs from validated delivery plan")
+	}
+	decodedArtifact, err := projectartifact.NewSourceBundle(compiled.Graph, compiled.Manifest)
+	if err != nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("decode persisted serving artifact: %w", err)
+	}
+	if decodedArtifact.Digest() != plan.SourceDigest {
+		return dbtProofBoundDelivery{}, fmt.Errorf("persisted serving artifact has different portable source identity")
+	}
+	manifest := decodedArtifact.Manifest()
+	model := manifest.SemanticModels["semantic-model:warehouse_sales"]
+	if model == nil {
+		return dbtProofBoundDelivery{}, fmt.Errorf("compiled warehouse_sales semantic model is missing")
+	}
+	if len(roots) != len(model.Connections) {
+		return dbtProofBoundDelivery{}, fmt.Errorf("delivery roots=%d, want exact connection closure of %d", len(roots), len(model.Connections))
+	}
+	model.AccessPolicy = accessPolicy
+	managedRoots := make(map[string]string, len(roots))
+	managedRevisions := make(map[string]string, len(artifacts.Generation.ManagedDataPins))
+	for _, pin := range artifacts.Generation.ManagedDataPins {
+		managedRevisions[pin.ConnectionID] = pin.RevisionID
+		name := strings.TrimPrefix(pin.ConnectionID, "connection:")
+		root := strings.TrimSpace(roots[name])
+		if root == "" {
+			return dbtProofBoundDelivery{}, fmt.Errorf("delivery root for connection %q is missing", pin.ConnectionID)
+		}
+		managedRoots[pin.ConnectionID] = root
+	}
+	managedData := runtimehost.ManagedDataResolution{RevisionID: artifacts.Generation.DataRevision, Roots: managedRoots, Revisions: managedRevisions}
+
+	generationID := artifacts.Generation.Identity.GenerationID
+	stateID := servingstate.ID(generationID)
+	state := servingstate.State{
+		ID: stateID, ProjectID: plan.ProjectID, Environment: servingstate.Environment(plan.Environment),
+		Status: servingstate.StatusValidated, ProjectDigest: plan.SourceDigest, Digest: plan.ServingArtifactDigest,
+	}
+	servingArtifact := servingstate.Artifact{
+		ID: artifacts.Generation.ServingArtifactID, ServingStateID: stateID, Digest: plan.ServingArtifactDigest,
+		Format: projectbundle.BundleFormat, ContentType: projectbundle.BundleContentType,
+		ManifestJSON: artifacts.Generation.BundleManifestJSON, SizeBytes: int64(len(bundleBytes)),
+	}
+	graph := decodedArtifact.Graph()
+	spec := warehouseBoundarySpec{
+		root: filepath.Dir(roots["warehouse"]), compiled: model, graph: &graph, targetID: plan.TargetID,
+		deliveryPlan: &plan, bundleBytes: bundleBytes, managedData: managedData,
+	}
+	return dbtProofBoundDelivery{
+		Plan: plan, State: state, Artifact: servingArtifact, ManagedData: managedData, Spec: spec,
+	}, nil
+}
+
+type dbtProofManagedDataResolver struct {
+	resolution runtimehost.ManagedDataResolution
+}
+
+func (resolver dbtProofManagedDataResolver) ResolveManagedDataForIdentity(_ context.Context, identity projectgraph.ServingIdentity) (runtimehost.ManagedDataResolution, error) {
+	if err := identity.Validate(); err != nil {
+		return runtimehost.ManagedDataResolution{}, err
+	}
+	return resolver.resolution, nil
+}
+
+func prepareDBTProofServingArtifact(artifacts release.CandidateArtifactSet) (release.CandidateArtifactSet, []byte, error) {
+	var packed bytes.Buffer
+	manifest, servingDigest, err := projectbundle.PackCompiledProject(artifacts.Compiler.Artifact, artifacts.Compiler.Plan, &packed)
+	if err != nil {
+		return release.CandidateArtifactSet{}, nil, fmt.Errorf("pack production-shaped serving artifact: %w", err)
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		return release.CandidateArtifactSet{}, nil, fmt.Errorf("encode serving artifact manifest: %w", err)
+	}
+	artifacts.Artifact.ContentDigest = servingDigest
+	artifacts.Generation.ArtifactDigest = servingDigest
+	artifacts.Generation.ServingArtifactID = "artifact-" + strings.TrimPrefix(servingDigest, "sha256:")
+	artifacts.Generation.BundleManifestJSON = string(manifestJSON)
+	return artifacts, packed.Bytes(), nil
+}
+
+func validateDBTProofConnectionRequirements(artifacts release.CandidateArtifactSet) error {
+	activations, err := artifacts.Compiler.Artifact.ConnectionActivations()
+	if err != nil {
+		return fmt.Errorf("compiled connection requirements: %w", err)
+	}
+	if len(activations) == 0 {
+		return fmt.Errorf("compiled connection requirements are empty")
+	}
+	pins := make(map[string]string, len(artifacts.Generation.ManagedDataPins))
+	for _, pin := range artifacts.Generation.ManagedDataPins {
+		if pin.ConnectionID == "" || pin.RevisionID == "" {
+			return fmt.Errorf("managed connection requirement is incomplete")
+		}
+		if _, duplicate := pins[pin.ConnectionID]; duplicate {
+			return fmt.Errorf("duplicate managed connection requirement %q", pin.ConnectionID)
+		}
+		pins[pin.ConnectionID] = pin.RevisionID
+	}
+	requirements := make(map[string]release.CandidateConnectionRequirement, len(artifacts.Generation.Connections))
+	for _, requirement := range artifacts.Generation.Connections {
+		requirements[requirement.ConnectionID.String()] = requirement
+	}
+	authored := make(map[string]release.CandidateAuthoredConnection, len(artifacts.Generation.AuthoredConnections))
+	for _, requirement := range artifacts.Generation.AuthoredConnections {
+		authored[requirement.ConnectionID.String()] = requirement
+	}
+	for _, activation := range activations {
+		switch activation.Mode {
+		case projectartifact.ManagedActivation:
+			if pins[activation.LogicalConnectionID] == "" {
+				return fmt.Errorf("managed connection requirement %q is missing", activation.LogicalConnectionID)
+			}
+			delete(pins, activation.LogicalConnectionID)
+		case projectartifact.TargetBindingActivation:
+			requirement, ok := requirements[activation.LogicalConnectionID]
+			if !ok || requirement.ConnectorKind != activation.ConnectorKind || requirement.Access != activation.Access {
+				return fmt.Errorf("target connection requirement %q is missing or incompatible", activation.LogicalConnectionID)
+			}
+			delete(requirements, activation.LogicalConnectionID)
+		case projectartifact.AuthoredActivation:
+			requirement, ok := authored[activation.LogicalConnectionID]
+			if !ok || requirement.ConnectorKind != activation.ConnectorKind || requirement.Access != activation.Access {
+				return fmt.Errorf("authored connection requirement %q is missing or incompatible", activation.LogicalConnectionID)
+			}
+			delete(authored, activation.LogicalConnectionID)
+		default:
+			return fmt.Errorf("connection %q has unsupported activation mode %q", activation.LogicalConnectionID, activation.Mode)
+		}
+	}
+	if len(pins) != 0 || len(requirements) != 0 || len(authored) != 0 {
+		return fmt.Errorf("candidate contains connection requirements outside the compiled graph")
+	}
+	return nil
+}
+
+func dbtProofAuthorizationFingerprint(projectID projectgraph.ResourceID, environment string, graph projectgraph.ProjectGraph) (string, error) {
+	identity, err := projectgraph.NewServingIdentity(projectID, environment, "candidate-policy")
+	if err != nil {
+		return "", err
+	}
+	snapshot, err := projectmanifest.CompileAuthorizationSnapshot(identity, graph, projectmanifest.AccessPolicy{})
+	if err != nil {
+		return "", err
+	}
+	return snapshot.Digest()
+}
+
+func validateDBTProofPortableBytes(portable []byte, forbidden ...string) error {
+	for _, value := range forbidden {
+		if value != "" && bytes.Contains(portable, []byte(value)) {
+			return fmt.Errorf("target or producer provenance leaked into portable artifact: %q", value)
+		}
+	}
+	return nil
+}
+
+func compileDBTProofConsumer(t *testing.T) (projectartifact.SourceBundle, projectcompiler.BundlePlan) {
+	t.Helper()
+	example := filepath.Join("..", "..", "examples", "dbt-warehouse-boundary")
+	consumer := t.TempDir()
+	if err := os.CopyFS(consumer, os.DirFS(filepath.Join(example, "leapview"))); err != nil {
+		t.Fatal(err)
+	}
+	for _, relative := range dbtProofConsumerOverlays() {
+		content, err := os.ReadFile(filepath.Join(example, "multi-source", "consumer-overlay", relative))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(consumer, relative), content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	artifact, err := projectcompiler.Compile(consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := projectcompiler.PlanSourceRoot(consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return artifact, plan
+}
+
+func dbtProofConsumerOverlays() []string {
+	return []string{
+		"connections/directory.yaml",
+		"sources/dim_customers.yaml",
+	}
+}
+
+func TestDBTProofDeliveryPlanRequiresProductionEvidence(t *testing.T) {
+	artifact, compilerPlan := compileDBTProofConsumer(t)
+	projectID := projectgraph.ResourceID("project:fai678-delivery-proof")
+	identity := projectgraph.ServingIdentity{ProjectID: projectID, Environment: "dev", GenerationID: "00000000-0000-4000-8000-000000000001"}
+	pins := []release.ManagedDataPin{
+		{ConnectionID: "connection:directory", RevisionID: "sha256:" + strings.Repeat("a", 64)},
+		{ConnectionID: "connection:warehouse", RevisionID: "sha256:" + strings.Repeat("b", 64)},
+	}
+	dataRevision, err := release.CandidateSourcesDataRevision(artifact.Digest(), pins)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizationFingerprint, err := dbtProofAuthorizationFingerprint(projectID, identity.Environment, artifact.Graph())
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifacts := release.CandidateArtifactSet{
+		Artifact:                 release.ProjectArtifactProvenance{SourceDigest: artifact.Digest(), ProjectDigest: artifact.Digest(), CompilerVersion: projectartifact.CompilerVersion, SchemaVersion: projectartifact.Version},
+		AuthorizationFingerprint: authorizationFingerprint,
+		Generation:               release.CandidateGenerationArtifact{Identity: identity, DataMode: release.GenerationDataRefreshSources, DataRevision: dataRevision, ManagedDataPins: pins, Deterministic: true},
+		Compiler:                 release.CandidateCompilerEvidence{Graph: artifact.Graph(), Manifest: artifact.Manifest(), Plan: compilerPlan, Artifact: artifact},
+	}
+	input := deployment.DeliveryCandidateBuildInput{
+		ProjectID: projectID, OwnerID: "publisher", ArtifactDigest: artifact.Digest(),
+		Candidate: deployment.Candidate{ID: "candidate-dev", TargetID: "lvinst_0123456789abcdefghijklmnopqrstuv", Scope: deployment.CandidateScope{ProjectID: projectID, Environment: "dev"}},
+	}
+	roots := map[string]string{"warehouse": filepath.Join(t.TempDir(), "commerce"), "directory": filepath.Join(t.TempDir(), "directory")}
+	now := time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC)
+	valid, err := newDBTProofBoundDelivery(input, artifacts, "runtime:v1", now, roots, dbtProofAccessPolicy(t), dbtProofTarget)
+	if err != nil {
+		t.Fatalf("valid production-shaped delivery plan: %v", err)
+	}
+	if err := valid.Plan.Validate(); err != nil {
+		t.Fatalf("persistable delivery plan failed validation: %v", err)
+	}
+	if valid.Plan.Governance.PolicyDigest != authorizationFingerprint || valid.Plan.Governance.AuthorizationDigest != authorizationFingerprint {
+		t.Fatal("validated delivery plan lost authorization identity")
+	}
+	if !strings.Contains(valid.Plan.Provenance.BuildDefinition, dbtProofTarget) {
+		t.Fatal("dbt target provenance is absent from non-portable delivery metadata")
+	}
+	if err := validateDBTProofPortableBytes(artifact.Canonical(), dbtProofTarget); err != nil {
+		t.Fatal(err)
+	}
+	embedded := bytes.Replace(artifact.Canonical(), []byte(`{"version":3,`), []byte(`{"producerTarget":"`+dbtProofTarget+`","version":3,`), 1)
+	if bytes.Equal(embedded, artifact.Canonical()) {
+		t.Fatal("portable artifact wire shape changed")
+	}
+	if _, err := projectartifact.Decode(embedded); err == nil {
+		t.Fatal("portable artifact with embedded dbt target provenance was accepted")
+	}
+
+	t.Run("missing authorization fingerprint", func(t *testing.T) {
+		missing := artifacts
+		missing.AuthorizationFingerprint = ""
+		if _, err := newDBTProofBoundDelivery(input, missing, "runtime:v1", now, roots, dbtProofAccessPolicy(t), dbtProofTarget); err == nil {
+			t.Fatal("delivery without AuthorizationFingerprint was accepted")
+		}
+	})
+	t.Run("missing connection requirements", func(t *testing.T) {
+		missing := artifacts
+		missing.Generation.ManagedDataPins = nil
+		if _, err := newDBTProofBoundDelivery(input, missing, "runtime:v1", now, roots, dbtProofAccessPolicy(t), dbtProofTarget); err == nil || !strings.Contains(err.Error(), "connection requirement") {
+			t.Fatalf("delivery without connection requirements: %v", err)
+		}
+	})
+	t.Run("invalid governance binding", func(t *testing.T) {
+		request, err := appruntimefactory.CandidatePlanRequest(input, artifacts, "runtime:v1", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Governance.AuthorizationDigest = "sha256:" + strings.Repeat("c", 64)
+		if _, err := bindDBTProofDeliveryRequest(input, artifacts, request, nil, roots, dbtProofAccessPolicy(t), dbtProofTarget); err == nil || !strings.Contains(err.Error(), "not bound") {
+			t.Fatalf("invalid governance binding: %v", err)
+		}
+	})
+}

--- a/internal/app/dbt_multi_source_proof_test.go
+++ b/internal/app/dbt_multi_source_proof_test.go
@@ -21,9 +21,9 @@ import (
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	semanticquery "github.com/flidai/leapview/internal/analytics/query"
 	"github.com/flidai/leapview/internal/analytics/query/planir"
-	appruntimefactory "github.com/flidai/leapview/internal/app/runtimefactory"
 	"github.com/flidai/leapview/internal/deployment"
 	"github.com/flidai/leapview/internal/platform/cliapi"
+	"github.com/flidai/leapview/internal/project"
 	projectartifact "github.com/flidai/leapview/internal/project/artifact"
 	projectcompiler "github.com/flidai/leapview/internal/project/compiler"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
@@ -87,7 +87,7 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("producer-only provenance: repository=flidai/leapview commit=%s project=proof_consumer target=local invocation=%s manifest=target/manifest.json upstream=upstream_orders (local dbt package)", strings.TrimSpace(string(commit)), invocation)
+	t.Logf("producer-only provenance: repository=flidai/leapview commit=%s project=proof_consumer target=%s invocation=%s manifest=target/manifest.json upstream=upstream_orders (local dbt package)", strings.TrimSpace(string(commit)), dbtProofTarget, invocation)
 
 	// Handoff one dbt-produced Parquet file. No dbt metadata crosses this
 	// boundary.
@@ -122,7 +122,7 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 	if err := os.CopyFS(consumer, os.DirFS(filepath.Join(example, "leapview"))); err != nil {
 		t.Fatal(err)
 	}
-	for _, relative := range []string{"connections/directory.yaml", "sources/dim_customers.yaml"} {
+	for _, relative := range dbtProofConsumerOverlays() {
 		content, err := os.ReadFile(filepath.Join(producer, "consumer-overlay", relative))
 		if err != nil {
 			t.Fatal(err)
@@ -137,6 +137,10 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 		t.Fatal(err)
 	}
 	artifact, err := projectcompiler.Compile(consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compilerPlan, err := projectcompiler.PlanSourceRoot(consumer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,15 +227,15 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 	for _, forbidden := range []string{
 		authority.ProjectUID, authority.IssuerID, targets[0], targets[1], commerce, directory,
 		invocation, strings.TrimSpace(string(commit)), "flidai/leapview", "manifest.json",
-		"run_results.json", "proof_consumer", "upstream_orders", "resourceUid",
+		"run_results.json", "proof_consumer", "upstream_orders", "resourceUid", dbtProofTarget,
 	} {
-		if bytes.Contains(artifact.Canonical(), []byte(forbidden)) {
-			t.Fatalf("producer/target authority leaked into portable artifact: %q", forbidden)
+		if err := validateDBTProofPortableBytes(artifact.Canonical(), forbidden); err != nil {
+			t.Fatal(err)
 		}
 	}
 
 	admission := newTestExactExtensionAdmission(t, "ducklake")
-	var plans []deployment.DeliveryPlanRequest
+	var plans []deployment.DeliveryPlan
 	for index, environment := range []string{"dev", "prod"} {
 		t.Run(environment, func(t *testing.T) {
 			generation := fmt.Sprintf("00000000-0000-4000-8000-%012d", index+1)
@@ -257,48 +261,50 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			plan, err := appruntimefactory.CandidatePlanRequest(deployment.DeliveryCandidateBuildInput{
-				ProjectID: projectID, OwnerID: "publisher", ArtifactDigest: artifact.Digest(),
-				Candidate: deployment.Candidate{ID: candidate, TargetID: target, Scope: deployment.CandidateScope{ProjectID: projectID, Environment: environment}},
-			}, release.CandidateArtifactSet{
-				Artifact:   release.ProjectArtifactProvenance{SourceDigest: artifact.Digest(), ProjectDigest: artifact.Digest(), CompilerVersion: projectartifact.CompilerVersion, SchemaVersion: projectartifact.Version},
-				Generation: release.CandidateGenerationArtifact{Identity: identity, DataMode: release.GenerationDataRefreshSources, DataRevision: dataRevision, ManagedDataPins: pins, Deterministic: true},
-				Compiler:   release.CandidateCompilerEvidence{Graph: artifact.Graph(), Manifest: manifest, Artifact: artifact},
-			}, "runtime:v1", time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC))
+			authorizationFingerprint, err := dbtProofAuthorizationFingerprint(projectID, environment, artifact.Graph())
 			if err != nil {
 				t.Fatal(err)
 			}
-			if plan.ProjectID != projectID.String() || plan.TargetID != target || plan.Environment != environment || candidate == generation || plan.ID == candidate {
+			candidateArtifacts := release.CandidateArtifactSet{
+				Artifact:                 release.ProjectArtifactProvenance{SourceDigest: artifact.Digest(), ProjectDigest: artifact.Digest(), CompilerVersion: projectartifact.CompilerVersion, SchemaVersion: projectartifact.Version},
+				AuthorizationFingerprint: authorizationFingerprint,
+				Generation:               release.CandidateGenerationArtifact{Identity: identity, DataMode: release.GenerationDataRefreshSources, DataRevision: dataRevision, ManagedDataPins: pins, Deterministic: true},
+				Compiler:                 release.CandidateCompilerEvidence{Graph: artifact.Graph(), Manifest: manifest, Plan: compilerPlan, Artifact: artifact},
+			}
+			buildInput := deployment.DeliveryCandidateBuildInput{
+				ProjectID: projectID, OwnerID: "publisher", ArtifactDigest: artifact.Digest(),
+				Candidate: deployment.Candidate{ID: candidate, TargetID: target, Scope: deployment.CandidateScope{ProjectID: projectID, Environment: environment}},
+				Source: project.CandidateSourceSnapshot{
+					ProjectID: projectID, ArtifactDigest: artifact.Digest(), ProjectDigest: artifact.Digest(),
+					SourceAttestationDigest: fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(invocation))),
+					SourceRevision:          &project.CandidateSourceRevision{Repository: "flidai/leapview", Revision: strings.TrimSpace(string(commit))},
+				},
+			}
+			bound, err := newDBTProofBoundDelivery(
+				buildInput, candidateArtifacts, "runtime:v1", time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC),
+				map[string]string{"warehouse": commerce, "directory": boundDirectory}, dbtProofAccessPolicy(t),
+				dbtProofTarget,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan := bound.Plan
+			if plan.ProjectID != projectID || plan.TargetID != target || plan.Environment != environment || candidate == generation || plan.ID == candidate {
 				t.Fatal("delivery identities collapsed")
+			}
+			if err := plan.Governance.Validate(); err != nil || plan.Governance.AuthorizationDigest != authorizationFingerprint || plan.Governance.PolicyDigest != authorizationFingerprint {
+				t.Fatalf("delivery governance is not exact: %v", err)
+			}
+			if !strings.Contains(plan.Provenance.BuildDefinition, dbtProofTarget) {
+				t.Fatal("dbt target provenance is absent from non-portable delivery metadata")
 			}
 			plans = append(plans, plan)
 
-			// Bind the exact compiled semantic model to this target's two physical
-			// roots. Each environment gets its own runtime generation and target.
-			// Manifest returns a detached copy; keep each target's bound model
-			// independent so a failed replacement cannot mutate a live runtime.
-			targetManifest := artifact.Manifest()
-			model := targetManifest.SemanticModels["semantic-model:warehouse_sales"]
-			if model == nil {
-				t.Fatal("compiled warehouse_sales semantic model is missing")
-			}
-			// Exercise the already-qualified ADR-0017 runtime boundary over this
-			// exact dbt/CRM mapping. Portable policy lowering is covered by the
-			// semantic-access compiler suite; this proof owns only the composition.
-			model.AccessPolicy = dbtProofAccessPolicy(t)
+			// The factory consumes the model, target, serving state, and artifact
+			// derived together from the validated delivery plan above.
+			model := bound.Spec.compiled
 			if !semanticquery.ModelRequiresSemanticAccess(model) {
 				t.Fatal("dbt multi-source qualification model does not require semantic access")
-			}
-			for name, connection := range model.Connections {
-				switch name {
-				case "warehouse":
-					connection.Root = commerce
-				case "directory":
-					connection.Root = boundDirectory
-				default:
-					t.Fatalf("unexpected connection %q", name)
-				}
-				model.Connections[name] = connection
 			}
 			qualificationManifest := artifact.Manifest()
 			qualificationModel := qualificationManifest.SemanticModels["semantic-model:warehouse_sales"]
@@ -307,12 +313,15 @@ func TestDBTMultiSourceProjectClosure(t *testing.T) {
 			}
 			id := servingstate.ID(generation)
 			graph := artifact.Graph()
-			factory := &warehouseBoundaryFactory{admission: admission, specs: map[servingstate.ID]warehouseBoundarySpec{id: {root: t.TempDir(), compiled: model, graph: &graph, targetID: target}}}
+			factory := &warehouseBoundaryFactory{admission: admission, specs: map[servingstate.ID]warehouseBoundarySpec{id: bound.Spec}}
 			repo := &warehouseBoundaryRepo{
-				states:    map[servingstate.ID]servingstate.State{id: {ID: id, ProjectID: projectID, Environment: servingstate.Environment(environment), Status: servingstate.StatusValidated, Digest: artifact.Digest()}},
-				artifacts: map[servingstate.ID]servingstate.Artifact{id: {ID: "artifact-" + generation, ServingStateID: id, Digest: artifact.Digest()}},
+				states:    map[servingstate.ID]servingstate.State{id: bound.State},
+				artifacts: map[servingstate.ID]servingstate.Artifact{id: bound.Artifact},
 			}
-			host := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{Repo: repo, ProjectID: projectID, Environment: servingstate.Environment(environment), Factory: factory, Authorization: warehouseBoundaryAuthorization{}})
+			host := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{
+				Repo: repo, ProjectID: projectID, Environment: servingstate.Environment(environment), Factory: factory,
+				ManagedData: dbtProofManagedDataResolver{resolution: bound.ManagedData}, Authorization: warehouseBoundaryAuthorization{},
+			})
 			defer host.Close()
 			prepared, err := host.PrepareServingState(t.Context(), generation)
 			if err != nil {

--- a/internal/app/dbt_multi_source_proof_test.go
+++ b/internal/app/dbt_multi_source_proof_test.go
@@ -1,0 +1,548 @@
+//go:build duckdb_arrow
+
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/flidai/leapview/internal/access"
+	"github.com/flidai/leapview/internal/analytics/dataquery"
+	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	semanticquery "github.com/flidai/leapview/internal/analytics/query"
+	"github.com/flidai/leapview/internal/analytics/query/planir"
+	appruntimefactory "github.com/flidai/leapview/internal/app/runtimefactory"
+	"github.com/flidai/leapview/internal/deployment"
+	"github.com/flidai/leapview/internal/platform/cliapi"
+	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	projectcompiler "github.com/flidai/leapview/internal/project/compiler"
+	projectgraph "github.com/flidai/leapview/internal/project/graph"
+	"github.com/flidai/leapview/internal/release"
+	"github.com/flidai/leapview/internal/runtimehost"
+	"github.com/flidai/leapview/internal/semanticvalue"
+	"github.com/flidai/leapview/internal/servingstate"
+	"github.com/flidai/leapview/internal/workload"
+)
+
+// TestDBTMultiSourceProjectClosure runs actual pinned dbt outside LeapView,
+// then hands only two physical publications to the ordinary compiler/gates/
+// materializer/leased semantic query path. PostgreSQL registry durability is
+// separately covered by the deployment/postgres proof.
+func TestDBTMultiSourceProjectClosure(t *testing.T) {
+	dbt := os.Getenv("DBT_BIN")
+	if dbt == "" {
+		t.Skip("run task dbt:warehouse:proof with the pinned dbt toolchain")
+	}
+	if !filepath.IsAbs(dbt) {
+		t.Fatal("DBT_BIN must be an absolute path")
+	}
+	example := filepath.Join("..", "..", "examples", "dbt-warehouse-boundary")
+	producer := t.TempDir()
+	if err := os.CopyFS(producer, os.DirFS(filepath.Join(example, "multi-source"))); err != nil {
+		t.Fatal(err)
+	}
+	dbtRoot := filepath.Join(producer, "dbt")
+	if err := os.MkdirAll(filepath.Join(producer, "published", "commerce"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var invocation string
+	for _, command := range []string{"deps", "build"} {
+		cmd := exec.CommandContext(t.Context(), dbt, "--no-use-colors", "--log-format", "json", command, "--profiles-dir", ".", "--project-dir", ".")
+		cmd.Dir = dbtRoot
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("dbt %s: %v\n%s", command, err, out)
+		}
+		// Producer provenance comes only from CLI logs. The consumer never reads
+		// or imports dbt's manifest and run-results artifacts.
+		for _, line := range bytes.Split(out, []byte("\n")) {
+			var event struct {
+				Info struct {
+					Invocation string `json:"invocation_id"`
+					Message    string `json:"msg"`
+				} `json:"info"`
+			}
+			if json.Unmarshal(line, &event) == nil && event.Info.Invocation != "" {
+				if command == "build" {
+					invocation = event.Info.Invocation
+				}
+				t.Logf("dbt %s: %s", command, event.Info.Message)
+			}
+		}
+	}
+	if invocation == "" {
+		t.Fatal("dbt CLI logs omitted producer invocation provenance")
+	}
+	commit, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("producer-only provenance: repository=flidai/leapview commit=%s project=proof_consumer target=local invocation=%s manifest=target/manifest.json upstream=upstream_orders (local dbt package)", strings.TrimSpace(string(commit)), invocation)
+
+	// Handoff one dbt-produced Parquet file. No dbt metadata crosses this
+	// boundary.
+	commerce := t.TempDir()
+	orders, err := os.ReadFile(filepath.Join(producer, "published", "commerce", "fct_orders.parquet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commerce, "fct_orders.parquet"), orders, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Independently publish CRM data through a separate SQL producer. It has no
+	// dependency on the dbt package or the commerce publication.
+	directory := t.TempDir()
+	directorySQL, err := os.ReadFile(filepath.Join(producer, "customer-directory.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(t.Context(), fmt.Sprintf("COPY (%s) TO '%s' (FORMAT PARQUET)", directorySQL, strings.ReplaceAll(filepath.Join(directory, "dim_customers.parquet"), "'", "''"))); err != nil {
+		t.Fatal(err)
+	}
+
+	// Compile only the rootless consumer source tree, overlaying the ordinary
+	// second Connection and Source. The producer tree is intentionally absent.
+	consumer := t.TempDir()
+	if err := os.CopyFS(consumer, os.DirFS(filepath.Join(example, "leapview"))); err != nil {
+		t.Fatal(err)
+	}
+	for _, relative := range []string{"connections/directory.yaml", "sources/dim_customers.yaml"} {
+		content, err := os.ReadFile(filepath.Join(producer, "consumer-overlay", relative))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(consumer, relative), content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	semanticPath := filepath.Join(consumer, "semantic-models", "sales.yaml")
+	originalSemantic, err := os.ReadFile(semanticPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := projectcompiler.Compile(consumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := artifact.Manifest()
+	if len(manifest.Connections) != 2 || len(manifest.Sources) != 2 {
+		t.Fatalf("rootless consumer graph has %d connections and %d sources, want 2/2", len(manifest.Connections), len(manifest.Sources))
+	}
+	for _, resource := range artifact.Graph().Resources() {
+		if resource.Kind == projectgraph.KindProjectNamespace {
+			t.Fatalf("producer/control-plane Project escaped rootless graph: %#v", resource)
+		}
+	}
+
+	// Package-qualified, foreign-project, and unknown live references cannot be
+	// resolved against this consumer's authored Model namespace.
+	for _, reference := range []string{"upstream_orders.order_lines", "proof_consumer/fct_orders", "missing_model"} {
+		mutated := bytes.Replace(originalSemantic, []byte("model: orders"), []byte("model: "+reference), 1)
+		if bytes.Equal(mutated, originalSemantic) {
+			t.Fatalf("semantic fixture has no orders Model binding to mutate for %q", reference)
+		}
+		if err := os.WriteFile(semanticPath, mutated, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := projectcompiler.Compile(consumer); err == nil {
+			t.Fatalf("live upstream/foreign/unknown reference %q resolved", reference)
+		}
+		if err := os.WriteFile(semanticPath, originalSemantic, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Source references close over the authored LeapView graph. An absent
+	// physical Source and an ambiguous authored Source name both fail before
+	// delivery; neither may fall back to dbt's relation or package namespace.
+	ordersPath := filepath.Join(consumer, "models", "orders.yaml")
+	originalOrders, err := os.ReadFile(ordersPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unmappedOrders := bytes.Replace(originalOrders, []byte(`source."warehouse.fct_orders"`), []byte(`source."warehouse.missing"`), 1)
+	if bytes.Equal(unmappedOrders, originalOrders) {
+		t.Fatal("orders fixture has no Source binding to mutate")
+	}
+	if err := os.WriteFile(ordersPath, unmappedOrders, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := projectcompiler.Compile(consumer); err == nil || !strings.Contains(err.Error(), "warehouse.missing") {
+		t.Fatalf("unmapped Source did not fail closed: %v", err)
+	}
+	if err := os.WriteFile(ordersPath, originalOrders, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	directorySource, err := os.ReadFile(filepath.Join(consumer, "sources", "dim_customers.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ambiguousSource := bytes.Replace(directorySource, []byte("id: source:warehouse.dim_customers"), []byte("id: source:ambiguous.dim_customers"), 1)
+	if bytes.Equal(ambiguousSource, directorySource) {
+		t.Fatal("directory Source fixture has no stable ID to mutate")
+	}
+	ambiguousPath := filepath.Join(consumer, "sources", "ambiguous.yaml")
+	if err := os.WriteFile(ambiguousPath, ambiguousSource, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := projectcompiler.Compile(consumer); err == nil || !strings.Contains(err.Error(), "duplicate Source") {
+		t.Fatalf("ambiguous Source name did not fail closed: %v", err)
+	}
+	if err := os.Remove(ambiguousPath); err != nil {
+		t.Fatal(err)
+	}
+
+	profilePath := filepath.Join(t.TempDir(), "issuer.json")
+	validateID := func(value string) error { return projectgraph.ResourceID(value).Validate() }
+	authority, err := cliapi.NewProfileStore(profilePath).ResolveProjectAuthority("", validateID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := projectgraph.ResourceID(authority.ProjectUID)
+	restarted, err := cliapi.NewProfileStore(profilePath).ResolveProjectAuthority("", validateID)
+	if err != nil || restarted != authority {
+		t.Fatal("ProjectUID changed after issuer restart")
+	}
+	targets := []string{"lvinst_0123456789abcdefghijklmnopqrstuv", "lvinst_1123456789abcdefghijklmnopqrstuv"}
+	for _, forbidden := range []string{
+		authority.ProjectUID, authority.IssuerID, targets[0], targets[1], commerce, directory,
+		invocation, strings.TrimSpace(string(commit)), "flidai/leapview", "manifest.json",
+		"run_results.json", "proof_consumer", "upstream_orders", "resourceUid",
+	} {
+		if bytes.Contains(artifact.Canonical(), []byte(forbidden)) {
+			t.Fatalf("producer/target authority leaked into portable artifact: %q", forbidden)
+		}
+	}
+
+	admission := newTestExactExtensionAdmission(t, "ducklake")
+	var plans []deployment.DeliveryPlanRequest
+	for index, environment := range []string{"dev", "prod"} {
+		t.Run(environment, func(t *testing.T) {
+			generation := fmt.Sprintf("00000000-0000-4000-8000-%012d", index+1)
+			target := targets[index]
+			candidate := "candidate-" + environment
+			identity := projectgraph.ServingIdentity{ProjectID: projectID, Environment: environment, GenerationID: generation}
+			boundDirectory := directory
+			if environment == "prod" {
+				boundDirectory = t.TempDir()
+				if _, err := db.ExecContext(t.Context(), fmt.Sprintf("COPY (%s) TO '%s' (FORMAT PARQUET)", strings.ReplaceAll(string(directorySQL), "'north'", "'west'"), strings.ReplaceAll(filepath.Join(boundDirectory, "dim_customers.parquet"), "'", "''"))); err != nil {
+					t.Fatal(err)
+				}
+			}
+			directoryBytes, err := os.ReadFile(filepath.Join(boundDirectory, "dim_customers.parquet"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			pins := []release.ManagedDataPin{
+				{ConnectionID: "connection:warehouse", RevisionID: fmt.Sprintf("sha256:%x", sha256.Sum256(orders))},
+				{ConnectionID: "connection:directory", RevisionID: fmt.Sprintf("sha256:%x", sha256.Sum256(directoryBytes))},
+			}
+			dataRevision, err := release.CandidateSourcesDataRevision(artifact.Digest(), pins)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := appruntimefactory.CandidatePlanRequest(deployment.DeliveryCandidateBuildInput{
+				ProjectID: projectID, OwnerID: "publisher", ArtifactDigest: artifact.Digest(),
+				Candidate: deployment.Candidate{ID: candidate, TargetID: target, Scope: deployment.CandidateScope{ProjectID: projectID, Environment: environment}},
+			}, release.CandidateArtifactSet{
+				Artifact:   release.ProjectArtifactProvenance{SourceDigest: artifact.Digest(), ProjectDigest: artifact.Digest(), CompilerVersion: projectartifact.CompilerVersion, SchemaVersion: projectartifact.Version},
+				Generation: release.CandidateGenerationArtifact{Identity: identity, DataMode: release.GenerationDataRefreshSources, DataRevision: dataRevision, ManagedDataPins: pins, Deterministic: true},
+				Compiler:   release.CandidateCompilerEvidence{Graph: artifact.Graph(), Manifest: manifest, Artifact: artifact},
+			}, "runtime:v1", time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.ProjectID != projectID.String() || plan.TargetID != target || plan.Environment != environment || candidate == generation || plan.ID == candidate {
+				t.Fatal("delivery identities collapsed")
+			}
+			plans = append(plans, plan)
+
+			// Bind the exact compiled semantic model to this target's two physical
+			// roots. Each environment gets its own runtime generation and target.
+			// Manifest returns a detached copy; keep each target's bound model
+			// independent so a failed replacement cannot mutate a live runtime.
+			targetManifest := artifact.Manifest()
+			model := targetManifest.SemanticModels["semantic-model:warehouse_sales"]
+			if model == nil {
+				t.Fatal("compiled warehouse_sales semantic model is missing")
+			}
+			// Exercise the already-qualified ADR-0017 runtime boundary over this
+			// exact dbt/CRM mapping. Portable policy lowering is covered by the
+			// semantic-access compiler suite; this proof owns only the composition.
+			model.AccessPolicy = dbtProofAccessPolicy(t)
+			if !semanticquery.ModelRequiresSemanticAccess(model) {
+				t.Fatal("dbt multi-source qualification model does not require semantic access")
+			}
+			for name, connection := range model.Connections {
+				switch name {
+				case "warehouse":
+					connection.Root = commerce
+				case "directory":
+					connection.Root = boundDirectory
+				default:
+					t.Fatalf("unexpected connection %q", name)
+				}
+				model.Connections[name] = connection
+			}
+			qualificationManifest := artifact.Manifest()
+			qualificationModel := qualificationManifest.SemanticModels["semantic-model:warehouse_sales"]
+			if qualificationModel == nil {
+				t.Fatal("qualification semantic model is missing")
+			}
+			id := servingstate.ID(generation)
+			graph := artifact.Graph()
+			factory := &warehouseBoundaryFactory{admission: admission, specs: map[servingstate.ID]warehouseBoundarySpec{id: {root: t.TempDir(), compiled: model, graph: &graph, targetID: target}}}
+			repo := &warehouseBoundaryRepo{
+				states:    map[servingstate.ID]servingstate.State{id: {ID: id, ProjectID: projectID, Environment: servingstate.Environment(environment), Status: servingstate.StatusValidated, Digest: artifact.Digest()}},
+				artifacts: map[servingstate.ID]servingstate.Artifact{id: {ID: "artifact-" + generation, ServingStateID: id, Digest: artifact.Digest()}},
+			}
+			host := runtimehost.NewRegistryWithFactory(runtimehost.RegistryOptions{Repo: repo, ProjectID: projectID, Environment: servingstate.Environment(environment), Factory: factory, Authorization: warehouseBoundaryAuthorization{}})
+			defer host.Close()
+			prepared, err := host.PrepareServingState(t.Context(), generation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lease, err := host.Acquire(t.Context()); err == nil {
+				lease.Release()
+				t.Fatal("unactivated candidate became serving authority")
+			}
+			runtime := factory.runtime(id)
+			if len(runtime.SourceObservations()) != 2 {
+				t.Fatalf("one physical producer was dropped: %v", runtime.SourceObservations())
+			}
+			if err := qualifyWarehouseBoundary(t.Context(), runtime, qualificationModel, id); err != nil {
+				t.Fatal(err)
+			}
+			if err := host.ActivatePrepared(prepared, func() error { repo.active = id; return nil }); err != nil {
+				t.Fatal(err)
+			}
+			lease, err := host.Acquire(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer lease.Release()
+			if lease.Identity() != identity {
+				t.Fatalf("query lease identity = %#v, want %#v", lease.Identity(), identity)
+			}
+			queryLease, err := runtime.controller.Acquire(t.Context(), workload.Request{Class: workload.Interactive, PrincipalID: "reader", Operation: "semantic.query", EstimatedMemoryBytes: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer queryLease.Release()
+			query := dataquery.Query{ProjectID: projectID, PrincipalID: "reader", ModelID: "warehouse", Kind: dataquery.KindSemanticAggregate, Target: "orders", Fields: []dataquery.Field{{Field: "customer_region"}}, Metrics: []dataquery.Field{{Field: "revenue"}}}
+			if _, err := runtime.ExecuteDataQuery(queryLease.Context(), query); err == nil || !strings.Contains(err.Error(), "request-bound consumer") {
+				t.Fatalf("protected dbt output admitted an alternate execution path: %v", err)
+			}
+			planner, ok := runtime.Planner("warehouse")
+			if !ok {
+				t.Fatal("activation-owned semantic planner is unavailable")
+			}
+			if !planner.CompiledModel().MatchesModel(model) {
+				t.Fatalf("activation planner/model mismatch: planner=%s model=%s", planner.CompiledModel().SourceFingerprint(), semanticquery.SemanticModelFingerprint(model))
+			}
+			snapshot, semanticAuthority := dbtProofSemanticAuthority(t, target, "reader", "sales")
+			consumerConfig := semanticquery.SemanticAccessConsumerConfig{
+				InstanceID: target, ProjectID: projectID.String(), Environment: environment,
+				ModelID: "warehouse", Generation: generation, PrincipalID: "reader",
+				Authority: func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+					return snapshot, semanticAuthority, nil
+				},
+			}
+			semanticConsumer, err := semanticquery.NewSemanticAccessConsumer(planner, consumerConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			semanticPlan, err := semanticConsumer.Planner().Plan(semanticquery.Request{
+				Dataset: "orders", Dimensions: []semanticquery.Field{{Field: "customer_region"}}, Metrics: []semanticquery.Field{{Field: "revenue"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertDBTProofSecurityBarriers(t, semanticPlan.IR, "orders", "customers")
+			if err := semanticConsumer.ValidatePlan(semanticPlan); err != nil {
+				t.Fatalf("exact semantic-access plan was not admitted: %v", err)
+			}
+			if !semanticConsumer.Planner().CompiledModel().MatchesModel(model) {
+				t.Fatal("semantic consumer changed the activation model identity")
+			}
+			binding := semanticquery.SemanticAccessConsumerBinding{
+				InstanceID: target, ProjectID: projectID.String(), Environment: environment,
+				Generation: generation, ModelID: "warehouse", PrincipalID: "reader",
+			}
+			boundContext := semanticquery.WithSemanticAccessConsumer(queryLease.Context(), semanticConsumer, binding)
+			result, err := runtime.ExecuteDataQuery(boundContext, query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Rows) != 2 {
+				t.Fatalf("cross-producer regional query = %#v", result.Rows)
+			}
+			region := "north"
+			if environment == "prod" {
+				region = "west"
+			}
+			want := map[string]string{region: "62.24", "south": "75"}
+			for _, row := range result.Rows {
+				key := fmt.Sprint(row["customer_region"])
+				if expected, ok := want[key]; !ok || fmt.Sprint(row["revenue"]) != expected {
+					t.Fatalf("target-bound regional result = %#v, want %v", result.Rows, want)
+				}
+				delete(want, key)
+			}
+			if len(want) != 0 {
+				t.Fatalf("missing regional result: %v", want)
+			}
+			t.Logf("%s/%s: %v", environment, generation, result.Rows)
+
+			// A missing independent producer blocks a replacement candidate while
+			// the already active generation and its lease keep serving.
+			badID := servingstate.ID(fmt.Sprintf("00000000-0000-4000-8000-%012d", index+20))
+			badManifest := artifact.Manifest()
+			badModel := badManifest.SemanticModels["semantic-model:warehouse_sales"]
+			for name, connection := range badModel.Connections {
+				connection.Root = commerce
+				if name == "directory" {
+					connection.Root = t.TempDir()
+				}
+				badModel.Connections[name] = connection
+			}
+			repo.states[badID] = servingstate.State{ID: badID, ProjectID: projectID, Environment: servingstate.Environment(environment), Status: servingstate.StatusValidated, Digest: artifact.Digest()}
+			repo.artifacts[badID] = servingstate.Artifact{ID: "artifact-" + string(badID), ServingStateID: badID, Digest: artifact.Digest()}
+			factory.specs[badID] = warehouseBoundarySpec{root: t.TempDir(), compiled: badModel, graph: &graph, targetID: target}
+			if failed, err := host.PrepareServingState(t.Context(), string(badID)); err == nil {
+				_ = failed.Close()
+				t.Fatal("partial publication became a candidate")
+			}
+			assertWarehouseBoundaryGeneration(t, host, id)
+			if again, err := runtime.ExecuteDataQuery(boundContext, query); err != nil || len(again.Rows) != 2 {
+				t.Fatalf("failed candidate disrupted retained query: %v", err)
+			}
+			query.ProjectID = "project:foreign"
+			if _, err := runtime.ExecuteDataQuery(boundContext, query); err == nil {
+				t.Fatal("foreign Project consumed semantic state")
+			}
+			deniedSnapshot, deniedAuthority := dbtProofSemanticAuthority(t, target, "reader", "finance")
+			deniedConfig := consumerConfig
+			deniedConfig.Authority = func() (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority, error) {
+				return deniedSnapshot, deniedAuthority, nil
+			}
+			deniedConsumer, err := semanticquery.NewSemanticAccessConsumer(planner, deniedConfig)
+			if err == nil {
+				_, err = deniedConsumer.Planner().Plan(semanticquery.Request{Dataset: "orders", Metrics: []semanticquery.Field{{Field: "revenue"}}})
+			}
+			if err == nil || !strings.Contains(err.Error(), "semantic access denied") {
+				t.Fatalf("unauthorized dbt-backed semantic query did not fail closed: %v", err)
+			}
+		})
+	}
+	if len(plans) != 2 || plans[0].SourceDigest != plans[1].SourceDigest || plans[0].ID == plans[1].ID || plans[0].Execution.ConfigDigest == plans[1].Execution.ConfigDigest {
+		t.Fatal("promotion did not rebind the same portable source to distinct targets")
+	}
+}
+
+func dbtProofAccessPolicy(t *testing.T) semanticmodel.SemanticAccessPolicy {
+	t.Helper()
+	literal, err := semanticmodel.NewSemanticAccessLiteral("sales")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return semanticmodel.SemanticAccessPolicy{
+		AccessGrants: map[string]semanticmodel.SemanticAccessGrantSpec{
+			"canViewSales": {UserAttribute: "department", AllowedValues: []semanticmodel.SemanticAccessLiteral{literal}},
+		},
+		Datasets: map[string]semanticmodel.SemanticDatasetAccessSpec{
+			"orders":    {RequiredAccessGrants: []string{"canViewSales"}},
+			"customers": {RequiredAccessGrants: []string{"canViewSales"}},
+		},
+		Dimensions: map[string][]string{"customer_region": {"canViewSales"}},
+		Metrics:    map[string][]string{"revenue": {"canViewSales"}},
+	}
+}
+
+func dbtProofSemanticAuthority(t *testing.T, instanceID, principalID, department string) (semanticquery.SemanticAccessAttributeSnapshot, semanticquery.SemanticAccessAuthority) {
+	t.Helper()
+	definition := access.SemanticAttributeDefinition{
+		ID: "definition-department", Name: "department", Type: semanticvalue.TypeString,
+		Shape: access.SemanticAttributeScalar, Profile: semanticvalue.Profile, DefinitionVersion: 1,
+		Metadata:       access.SemanticAttributeMetadata{Owner: access.SemanticAttributeOwner{Kind: access.SemanticAttributeOwnerInstance}},
+		LifecycleState: access.SemanticAttributeActive, Enabled: true,
+	}
+	registry := access.SemanticAttributeRegistrySnapshot{Definitions: []access.SemanticAttributeDefinition{definition}}
+	registry.State = access.SemanticAttributeRegistryState{Profile: semanticvalue.Profile, Revision: 1}
+	var err error
+	registry.State.Digest, err = access.SemanticAttributeRegistryDigest(registry.State.Profile, registry.Definitions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, valueDigest, err := access.CanonicalSemanticAttributeValues(definition, department)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attribute := access.EffectiveSemanticAttribute{
+		DefinitionID: definition.ID, DefinitionName: definition.Name, DefinitionVersion: definition.DefinitionVersion,
+		Type: definition.Type, Shape: definition.Shape, CanonicalValues: values, ValueDigest: valueDigest, Source: "direct",
+	}
+	principal := access.SubjectRef{Kind: access.SubjectKindPrincipal, ID: principalID}
+	assignment := access.SemanticAttributeAssignment{
+		ID: "assignment-department", DefinitionID: definition.ID, DefinitionName: definition.Name,
+		DefinitionVersion: definition.DefinitionVersion, Type: definition.Type, Shape: definition.Shape,
+		Subject: principal, CanonicalValues: append([]string(nil), values...), ValueDigest: valueDigest, AssignmentVersion: 1,
+	}
+	control := access.SemanticAttributeControlSnapshot{Assignments: []access.SemanticAttributeAssignment{assignment}}
+	control.State = access.SemanticAttributeControlState{Profile: semanticvalue.Profile, Revision: 1}
+	control.State.Digest, err = access.SemanticAttributeControlDigest(control.Assignments, control.Mappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := access.SemanticAttributeResolution{
+		Subject: principal, Subjects: []access.SubjectRef{principal}, Registry: registry, Control: control,
+		Attributes: []access.EffectiveSemanticAttribute{attribute}, ObservedAt: time.Date(2026, 9, 12, 0, 0, 0, 0, time.UTC),
+	}
+	snapshot, authority, err := semanticquery.SemanticAccessResolutionSnapshot(instanceID, principalID, resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot, authority
+}
+
+func assertDBTProofSecurityBarriers(t *testing.T, graph *planir.Graph, datasets ...string) {
+	t.Helper()
+	want := make(map[string]bool, len(datasets))
+	for _, dataset := range datasets {
+		want[dataset] = true
+	}
+	for _, node := range graph.Nodes {
+		var barrier planir.SecurityBarrier
+		switch value := node.(type) {
+		case planir.SecurityBarrier:
+			barrier = value
+		case *planir.SecurityBarrier:
+			barrier = *value
+		default:
+			continue
+		}
+		if barrier.PolicyDigest == "" || barrier.DecisionDigest == "" {
+			t.Fatalf("semantic access barrier lacks authority evidence: %#v", barrier)
+		}
+		delete(want, barrier.Dataset)
+	}
+	if len(want) != 0 {
+		t.Fatalf("dbt multi-source plan lacks semantic access barriers for %v", want)
+	}
+}

--- a/internal/app/warehouse_boundary_qualification_integration_test.go
+++ b/internal/app/warehouse_boundary_qualification_integration_test.go
@@ -21,6 +21,7 @@ import (
 	analyticsducklake "github.com/flidai/leapview/internal/analytics/ducklake"
 	analyticsgates "github.com/flidai/leapview/internal/analytics/gates"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
+	"github.com/flidai/leapview/internal/analytics/resultidentity"
 	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	"github.com/flidai/leapview/internal/runtimehost"
@@ -34,6 +35,12 @@ type warehouseBoundarySpec struct {
 	root        string
 	multiSource bool
 	freshness   bool
+	// compiled and graph are optional so the legacy qualification fixtures can
+	// keep using their compact hand-built model while the end-to-end proof can
+	// pass the exact rootless compiler outputs into the candidate runtime.
+	compiled *semanticmodel.Model
+	graph    *projectgraph.ProjectGraph
+	targetID string
 }
 
 type warehouseBoundaryRuntime struct {
@@ -96,9 +103,25 @@ func (f *warehouseBoundaryFactory) Prepare(ctx context.Context, input runtimehos
 		return nil, err
 	}
 	model := warehouseBoundaryModel(spec)
+	var resultPartition resultidentity.Partition
+	if spec.targetID != "" {
+		resultPartition, err = resultidentity.NewPartition(resultidentity.PartitionInput{
+			Kind:        resultidentity.PartitionProduction,
+			TargetID:    spec.targetID,
+			ProjectID:   input.State.ProjectID,
+			Environment: string(input.State.Environment),
+		})
+		if err != nil {
+			lease.Release()
+			controller.Close()
+			_ = database.Close()
+			return nil, err
+		}
+	}
 	projectRuntime, err := analyticsduckdb.OpenProjectMaterializeRuntime(lease.Context(), analyticsduckdb.ProjectRuntimeConfig{
 		Models: map[string]*semanticmodel.Model{"warehouse": model}, Database: database,
 		ExtensionAdmission: f.admission, ProjectID: input.State.ProjectID, Environment: string(input.State.Environment),
+		ServingStateID: string(input.State.ID), ResultPartition: resultPartition,
 	})
 	lease.Release()
 	if err != nil {
@@ -114,6 +137,9 @@ func (f *warehouseBoundaryFactory) Prepare(ctx context.Context, input runtimehos
 		return nil, err
 	}
 	graph, err := projectgraph.NewProjectGraph(nil, nil)
+	if spec.graph != nil {
+		graph = *spec.graph
+	}
 	if err != nil {
 		_ = projectRuntime.Close()
 		controller.Close()
@@ -342,6 +368,9 @@ func assertWarehouseBoundaryGeneration(t *testing.T, registry *runtimehost.Regis
 }
 
 func warehouseBoundaryModel(spec warehouseBoundarySpec) *semanticmodel.Model {
+	if spec.compiled != nil {
+		return spec.compiled
+	}
 	ordersFields := map[string]semanticmodel.SourceField{
 		"order_id": {Datatype: semanticmodel.DataTypeString}, "customer_id": {Datatype: semanticmodel.DataTypeString},
 		"revenue": {Datatype: semanticmodel.DataTypeFloat}, "updated_at": {Datatype: semanticmodel.DataTypeDateTime},

--- a/internal/app/warehouse_boundary_qualification_integration_test.go
+++ b/internal/app/warehouse_boundary_qualification_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -22,6 +23,8 @@ import (
 	analyticsgates "github.com/flidai/leapview/internal/analytics/gates"
 	semanticmodel "github.com/flidai/leapview/internal/analytics/model"
 	"github.com/flidai/leapview/internal/analytics/resultidentity"
+	"github.com/flidai/leapview/internal/deployment"
+	projectbundle "github.com/flidai/leapview/internal/project/bundle"
 	projectcontracts "github.com/flidai/leapview/internal/project/contracts"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	"github.com/flidai/leapview/internal/runtimehost"
@@ -41,6 +44,11 @@ type warehouseBoundarySpec struct {
 	compiled *semanticmodel.Model
 	graph    *projectgraph.ProjectGraph
 	targetID string
+	// deliveryPlan is optional for the legacy fixtures. The FAI-678 proof uses
+	// it to ensure runtime inputs derive from one validated, durable plan.
+	deliveryPlan *deployment.DeliveryPlan
+	bundleBytes  []byte
+	managedData  runtimehost.ManagedDataResolution
 }
 
 type warehouseBoundaryRuntime struct {
@@ -83,6 +91,24 @@ func (f *warehouseBoundaryFactory) Prepare(ctx context.Context, input runtimehos
 	if !ok {
 		return nil, fmt.Errorf("warehouse-boundary specification is missing for %s", input.State.ID)
 	}
+	if spec.deliveryPlan != nil {
+		if err := spec.deliveryPlan.Validate(); err != nil {
+			return nil, fmt.Errorf("warehouse-boundary delivery plan: %w", err)
+		}
+		if spec.deliveryPlan.ProjectID != input.State.ProjectID || spec.deliveryPlan.Environment != string(input.State.Environment) || spec.deliveryPlan.TargetID != spec.targetID || spec.deliveryPlan.SourceDigest != input.State.ProjectDigest || spec.deliveryPlan.ServingArtifactDigest != input.Artifact.Digest {
+			return nil, fmt.Errorf("warehouse-boundary runtime inputs differ from validated delivery plan")
+		}
+		validation, _, err := projectbundle.ValidateArtifactBytes(spec.bundleBytes)
+		if err != nil {
+			return nil, fmt.Errorf("warehouse-boundary runtime artifact: %w", err)
+		}
+		if validation.Digest != input.Artifact.Digest {
+			return nil, fmt.Errorf("warehouse-boundary runtime artifact differs from validated delivery bytes")
+		}
+		if spec.managedData.RevisionID != input.ManagedData.RevisionID || !maps.Equal(spec.managedData.Roots, input.ManagedData.Roots) || !maps.Equal(spec.managedData.Revisions, input.ManagedData.Revisions) {
+			return nil, fmt.Errorf("warehouse-boundary managed-data inputs differ from delivery-bound resolution")
+		}
+	}
 	database, err := analyticsducklake.Open(ctx, analyticsducklake.Config{
 		RootDir: filepath.Join(spec.root, ".ducklake"), MaxConnections: 2, ExtensionAdmission: f.admission,
 	})
@@ -103,6 +129,32 @@ func (f *warehouseBoundaryFactory) Prepare(ctx context.Context, input runtimehos
 		return nil, err
 	}
 	model := warehouseBoundaryModel(spec)
+	if spec.deliveryPlan != nil {
+		connectionIDs := make(map[string]string)
+		for _, resource := range spec.graph.Resources() {
+			if resource.Kind == projectgraph.KindConnection {
+				connectionIDs[resource.Name] = resource.ID.String()
+			}
+		}
+		if len(input.ManagedData.Roots) != len(model.Connections) {
+			lease.Release()
+			controller.Close()
+			_ = database.Close()
+			return nil, fmt.Errorf("warehouse-boundary runtime roots are not an exact connection closure")
+		}
+		for name, connection := range model.Connections {
+			connectionID := connectionIDs[name]
+			root := strings.TrimSpace(input.ManagedData.Roots[connectionID])
+			if connectionID == "" || root == "" {
+				lease.Release()
+				controller.Close()
+				_ = database.Close()
+				return nil, fmt.Errorf("warehouse-boundary runtime root for connection %q is unavailable", name)
+			}
+			connection.Root = root
+			model.Connections[name] = connection
+		}
+	}
 	var resultPartition resultidentity.Partition
 	if spec.targetID != "" {
 		resultPartition, err = resultidentity.NewPartition(resultidentity.PartitionInput{

--- a/internal/deployment/postgres/resource_uid_qualification_test.go
+++ b/internal/deployment/postgres/resource_uid_qualification_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	platformbootstrappostgres "github.com/flidai/leapview/internal/platform/bootstrap/postgres"
 	project "github.com/flidai/leapview/internal/project"
 	projectartifact "github.com/flidai/leapview/internal/project/artifact"
+	projectcompiler "github.com/flidai/leapview/internal/project/compiler"
 	projectgraph "github.com/flidai/leapview/internal/project/graph"
 	projectmanifest "github.com/flidai/leapview/internal/project/manifest"
 	projectpostgres "github.com/flidai/leapview/internal/project/postgres"
@@ -29,6 +32,163 @@ import (
 )
 
 const resourceUIDQualificationInstance = "lvinst_0123456789abcdefghijklmnopqrstuv"
+
+const resourceUIDMultiSourceProject = "lvproject_0198f2c07c7a7f008a11000000006780"
+
+// TestPostgresResourceUIDMultiSourceProjectClosure compiles the maintained
+// dbt warehouse-boundary consumer and proves that one portable, rootless
+// graph receives one exact ResourceUID binding for every resource when the
+// current PostgreSQL delivery authority commits its generation.
+func TestPostgresResourceUIDMultiSourceProjectClosure(t *testing.T) {
+	db := deliveryTestDB(t)
+	installResourceUIDQualificationDependencies(t, db)
+	seedResourceUIDQualificationBootstrapForProject(t, db, resourceUIDMultiSourceProject)
+
+	bundle := compileResourceUIDMultiSourceBundle(t)
+	graph := bundle.Graph()
+	if len(bundle.Manifest().Connections) != 2 || len(bundle.Manifest().Sources) != 2 {
+		t.Fatalf("multi-source bundle connections=%d sources=%d, want two each", len(bundle.Manifest().Connections), len(bundle.Manifest().Sources))
+	}
+	inventory, err := project.NewResourceUIDInventory(bundle)
+	if err != nil {
+		t.Fatalf("seal multi-source ResourceUID inventory: %v", err)
+	}
+
+	adminRepository := New(db)
+	first := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 1, Bundle: &bundle, Inventory: &inventory, Graph: &graph, ProjectID: resourceUIDMultiSourceProject,
+	})
+	lineage := &testActivationLineage{expected: ActivationLineageInput{
+		TargetID: resourceUIDQualificationInstance, ProjectID: resourceUIDMultiSourceProject,
+		GenerationID: first.generationID, CompiledGraphDigest: graph.Digest(),
+	}}
+	repository := NewWithOptions(db, Options{
+		ActivationAudit: testActivationAudit{audit: accesspostgres.New()},
+		Lineage:         lineage,
+	})
+
+	var registryRows int
+	if err := db.QueryRow(t.Context(), `SELECT count(*) FROM project.resource_uid_registry WHERE instance_id=$1 AND project_id=$2`, resourceUIDQualificationInstance, resourceUIDMultiSourceProject).Scan(&registryRows); err != nil {
+		t.Fatal(err)
+	}
+	if registryRows != 0 {
+		t.Fatalf("pre-activation registry rows=%d, want zero", registryRows)
+	}
+
+	firstResult, err := repository.Activate(t.Context(), first.activation)
+	if err != nil {
+		t.Fatalf("activate multi-source generation: %v", err)
+	}
+	if firstResult.Replay || firstResult.Pointer.ActiveGenerationID != first.generationID {
+		t.Fatalf("multi-source activation result=%#v", firstResult)
+	}
+
+	projectRepository := projectpostgres.New(db)
+	firstBindings, err := projectRepository.ListGenerationResourceUIDs(t.Context(), resourceUIDQualificationInstance, resourceUIDMultiSourceProject, first.generationID)
+	if err != nil {
+		t.Fatalf("list first-generation ResourceUID bindings: %v", err)
+	}
+	assertResourceUIDMultiSourceBindings(t, firstBindings, graph, first.generationID)
+	firstUIDs := resourceUIDBindingMap(firstBindings)
+
+	second := prepareResourceUIDQualificationGeneration(t, adminRepository, resourceUIDQualificationGenerationSpec{
+		Number: 2, BaseGenerationID: first.generationID, Bundle: &bundle, Inventory: &inventory, Graph: &graph, ProjectID: resourceUIDMultiSourceProject,
+	})
+	lineage.expected.GenerationID = second.generationID
+	if result, err := repository.Activate(t.Context(), second.activation); err != nil {
+		t.Fatalf("activate compatible multi-source generation: %v", err)
+	} else if result.Replay || result.Pointer.ActiveGenerationID != second.generationID {
+		t.Fatalf("compatible multi-source activation result=%#v", result)
+	}
+	secondBindings, err := projectRepository.ListGenerationResourceUIDs(t.Context(), resourceUIDQualificationInstance, resourceUIDMultiSourceProject, second.generationID)
+	if err != nil {
+		t.Fatalf("list second-generation ResourceUID bindings: %v", err)
+	}
+	assertResourceUIDMultiSourceBindings(t, secondBindings, graph, second.generationID)
+	if got := resourceUIDBindingMap(secondBindings); !sameResourceUIDMap(got, firstUIDs) {
+		t.Fatalf("compatible generation changed ResourceUIDs: got=%v want=%v", got, firstUIDs)
+	}
+
+	for _, resource := range graph.Resources() {
+		uid := firstUIDs[resource.ID.String()]
+		if _, err := projectRepository.ResolveResourceUID(t.Context(), resourceUIDQualificationInstance, "project_foreign", resource.ID.String()); !errors.Is(err, project.ErrResourceUIDNotFound) {
+			t.Fatalf("foreign Project resolved %q: %v", resource.ID, err)
+		}
+		if _, err := projectRepository.ResolveResourceUIDByUID(t.Context(), "lvinst_1123456789abcdefghijklmnopqrstuv", resourceUIDMultiSourceProject, uid); !errors.Is(err, project.ErrResourceUIDNotFound) {
+			t.Fatalf("foreign instance resolved %q: %v", resource.ID, err)
+		}
+	}
+}
+
+func compileResourceUIDMultiSourceBundle(t *testing.T) projectartifact.SourceBundle {
+	t.Helper()
+	example := filepath.Join("..", "..", "..", "examples", "dbt-warehouse-boundary")
+	root := t.TempDir()
+	if err := os.CopyFS(root, os.DirFS(filepath.Join(example, "leapview"))); err != nil {
+		t.Fatalf("copy multi-source consumer fixture: %v", err)
+	}
+	for _, relative := range []string{"connections/directory.yaml", "sources/dim_customers.yaml"} {
+		contents, err := os.ReadFile(filepath.Join(example, "multi-source", "consumer-overlay", relative))
+		if err != nil {
+			t.Fatalf("read multi-source overlay %s: %v", relative, err)
+		}
+		if err := os.WriteFile(filepath.Join(root, relative), contents, 0o600); err != nil {
+			t.Fatalf("write multi-source overlay %s: %v", relative, err)
+		}
+	}
+	bundle, err := projectcompiler.Compile(root)
+	if err != nil {
+		t.Fatalf("compile multi-source consumer fixture: %v", err)
+	}
+	return bundle
+}
+
+func assertResourceUIDMultiSourceBindings(t *testing.T, bindings []project.ResourceUIDBinding, graph projectgraph.ProjectGraph, generationID string) {
+	t.Helper()
+	if len(bindings) != len(graph.Resources()) {
+		t.Fatalf("generation %s bindings=%d, want complete graph closure of %d", generationID, len(bindings), len(graph.Resources()))
+	}
+	wantKinds := map[projectgraph.Kind]int{
+		projectgraph.KindConnection:    2,
+		projectgraph.KindSource:        2,
+		projectgraph.KindModel:         2,
+		projectgraph.KindSemanticModel: 1,
+		projectgraph.KindDashboard:     1,
+	}
+	gotKinds := make(map[projectgraph.Kind]int, len(wantKinds))
+	seen := make(map[string]struct{}, len(bindings))
+	for _, binding := range bindings {
+		if binding.GenerationID != generationID || binding.InstanceID != resourceUIDQualificationInstance || binding.TargetID != resourceUIDQualificationInstance || binding.ProjectID != resourceUIDMultiSourceProject {
+			t.Fatalf("binding scope=%#v", binding)
+		}
+		if err := binding.Validate(); err != nil {
+			t.Fatalf("invalid ResourceUID binding %#v: %v", binding, err)
+		}
+		if _, duplicate := seen[binding.AuthoredID]; duplicate {
+			t.Fatalf("duplicate binding for %q", binding.AuthoredID)
+		}
+		seen[binding.AuthoredID] = struct{}{}
+		gotKinds[binding.Kind]++
+	}
+	for _, resource := range graph.Resources() {
+		if _, ok := seen[resource.ID.String()]; !ok {
+			t.Fatalf("graph resource %q (%s) has no generation binding", resource.ID, resource.Kind)
+		}
+	}
+	for kind, want := range wantKinds {
+		if gotKinds[kind] != want {
+			t.Fatalf("generation %s kind %s bindings=%d, want %d", generationID, kind, gotKinds[kind], want)
+		}
+	}
+}
+
+func resourceUIDBindingMap(bindings []project.ResourceUIDBinding) map[string]project.ResourceUID {
+	result := make(map[string]project.ResourceUID, len(bindings))
+	for _, binding := range bindings {
+		result[binding.AuthoredID] = binding.ResourceUID
+	}
+	return result
+}
 
 // TestPostgresResourceUIDAdmissionAndActivationQualification exercises the
 // complete PostgreSQL lifecycle against the canonical instance target. The
@@ -487,6 +647,10 @@ type resourceUIDQualificationGenerationSpec struct {
 	IncludeDashboard bool
 	BaseGenerationID string
 	KindMismatch     bool
+	ProjectID        string
+	Bundle           *projectartifact.SourceBundle
+	Inventory        *project.ResourceUIDInventory
+	Graph            *projectgraph.ProjectGraph
 }
 
 type resourceUIDQualificationGeneration struct {
@@ -520,6 +684,10 @@ func installResourceUIDQualificationDependencies(t *testing.T, db *pgxpool.Pool)
 }
 
 func seedResourceUIDQualificationBootstrap(t *testing.T, db *pgxpool.Pool) {
+	seedResourceUIDQualificationBootstrapForProject(t, db, "project_uid_qualification")
+}
+
+func seedResourceUIDQualificationBootstrapForProject(t *testing.T, db *pgxpool.Pool, projectID string) {
 	t.Helper()
 	bootstrap := platformbootstrappostgres.New(db)
 	if err := bootstrap.EnsureInstanceID(t.Context(), resourceUIDQualificationInstance); err != nil {
@@ -528,11 +696,11 @@ func seedResourceUIDQualificationBootstrap(t *testing.T, db *pgxpool.Pool) {
 	if err := bootstrap.BindInstanceEnvironment(t.Context(), "prod"); err != nil {
 		t.Fatalf("bind instance environment: %v", err)
 	}
-	if _, err := projectpostgres.New(db).Ensure(t.Context(), projectpostgres.EnsureInput{ID: "project_uid_qualification", Title: "Resource UID qualification"}); err != nil {
+	if _, err := projectpostgres.New(db).Ensure(t.Context(), projectpostgres.EnsureInput{ID: projectgraph.ResourceID(projectID), Title: "Resource UID qualification"}); err != nil {
 		t.Fatalf("ensure project identity: %v", err)
 	}
 	if _, err := bootstrap.ClaimProject(t.Context(), platformbootstrappostgres.ProjectClaimInput{
-		ProjectID: "project_uid_qualification", Environment: "prod", ClaimedBy: "qualification", ClaimedAt: time.Now().UTC().Truncate(time.Microsecond),
+		ProjectID: projectID, Environment: "prod", ClaimedBy: "qualification", ClaimedAt: time.Now().UTC().Truncate(time.Microsecond),
 	}); err != nil {
 		t.Fatalf("claim project: %v", err)
 	}
@@ -542,6 +710,9 @@ func prepareResourceUIDQualificationGeneration(t *testing.T, r *Repository, spec
 	t.Helper()
 	ctx := t.Context()
 	projectID := "project_uid_qualification"
+	if spec.ProjectID != "" {
+		projectID = spec.ProjectID
+	}
 	ids := fmt.Sprintf("%d", spec.Number)
 	planID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "01"
 	candidateID := "0198f2c0-7c7a-7f00-8a11-000000007" + ids + "02"
@@ -555,6 +726,12 @@ func prepareResourceUIDQualificationGeneration(t *testing.T, r *Repository, spec
 	catalogID := "uid-catalog-" + ids
 	artifactDigest := testDigest('e')
 	bundle, inventory, graph := resourceUIDQualificationBundle(t, spec.IncludeDashboard)
+	if spec.Bundle != nil || spec.Inventory != nil || spec.Graph != nil {
+		if spec.Bundle == nil || spec.Inventory == nil || spec.Graph == nil {
+			t.Fatal("resource UID generation fixture must provide bundle, inventory, and graph together")
+		}
+		bundle, inventory, graph = *spec.Bundle, *spec.Inventory, *spec.Graph
+	}
 	if spec.KindMismatch {
 		bundle, inventory, graph = resourceUIDQualificationKindMismatchBundle(t)
 	}

--- a/internal/deployment/postgres/resource_uid_qualification_test.go
+++ b/internal/deployment/postgres/resource_uid_qualification_test.go
@@ -145,40 +145,77 @@ func compileResourceUIDMultiSourceBundle(t *testing.T) projectartifact.SourceBun
 
 func assertResourceUIDMultiSourceBindings(t *testing.T, bindings []project.ResourceUIDBinding, graph projectgraph.ProjectGraph, generationID string) {
 	t.Helper()
+	if err := validateResourceUIDMultiSourceBindings(bindings, graph, generationID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateResourceUIDMultiSourceBindings(bindings []project.ResourceUIDBinding, graph projectgraph.ProjectGraph, generationID string) error {
 	if len(bindings) != len(graph.Resources()) {
-		t.Fatalf("generation %s bindings=%d, want complete graph closure of %d", generationID, len(bindings), len(graph.Resources()))
+		return fmt.Errorf("generation %s bindings=%d, want complete graph closure of %d", generationID, len(bindings), len(graph.Resources()))
 	}
-	wantKinds := map[projectgraph.Kind]int{
-		projectgraph.KindConnection:    2,
-		projectgraph.KindSource:        2,
-		projectgraph.KindModel:         2,
-		projectgraph.KindSemanticModel: 1,
-		projectgraph.KindDashboard:     1,
+	expectedKinds := make(map[string]projectgraph.Kind, len(graph.Resources()))
+	for _, resource := range graph.Resources() {
+		expectedKinds[resource.ID.String()] = resource.Kind
 	}
-	gotKinds := make(map[projectgraph.Kind]int, len(wantKinds))
 	seen := make(map[string]struct{}, len(bindings))
 	for _, binding := range bindings {
 		if binding.GenerationID != generationID || binding.InstanceID != resourceUIDQualificationInstance || binding.TargetID != resourceUIDQualificationInstance || binding.ProjectID != resourceUIDMultiSourceProject {
-			t.Fatalf("binding scope=%#v", binding)
+			return fmt.Errorf("binding scope=%#v", binding)
 		}
 		if err := binding.Validate(); err != nil {
-			t.Fatalf("invalid ResourceUID binding %#v: %v", binding, err)
+			return fmt.Errorf("invalid ResourceUID binding %#v: %v", binding, err)
+		}
+		wantKind, ok := expectedKinds[binding.AuthoredID]
+		if !ok {
+			return fmt.Errorf("binding authored ID %q is not in graph", binding.AuthoredID)
+		}
+		if binding.Kind != wantKind {
+			return fmt.Errorf("binding authored ID %q kind=%s, want graph kind %s", binding.AuthoredID, binding.Kind, wantKind)
 		}
 		if _, duplicate := seen[binding.AuthoredID]; duplicate {
-			t.Fatalf("duplicate binding for %q", binding.AuthoredID)
+			return fmt.Errorf("duplicate binding for %q", binding.AuthoredID)
 		}
 		seen[binding.AuthoredID] = struct{}{}
-		gotKinds[binding.Kind]++
 	}
 	for _, resource := range graph.Resources() {
 		if _, ok := seen[resource.ID.String()]; !ok {
-			t.Fatalf("graph resource %q (%s) has no generation binding", resource.ID, resource.Kind)
+			return fmt.Errorf("graph resource %q (%s) has no generation binding", resource.ID, resource.Kind)
 		}
 	}
-	for kind, want := range wantKinds {
-		if gotKinds[kind] != want {
-			t.Fatalf("generation %s kind %s bindings=%d, want %d", generationID, kind, gotKinds[kind], want)
-		}
+	return nil
+}
+
+func TestResourceUIDMultiSourceBindingsRequireExactGraphKinds(t *testing.T) {
+	graph, err := projectgraph.NewProjectGraph([]projectgraph.Resource{
+		{ID: "connection:warehouse", Kind: projectgraph.KindConnection, Name: "warehouse"},
+		{ID: "source:orders", Kind: projectgraph.KindSource, Name: "orders"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generationID := "0198f2c0-7c7a-7f00-8a11-000000001000"
+	valid := []project.ResourceUIDBinding{
+		{
+			ResourceUID: "0198f2c0-7c7a-7f00-8a11-000000001001", InstanceID: resourceUIDQualificationInstance, ProjectID: resourceUIDMultiSourceProject,
+			Environment: "prod", TargetID: resourceUIDQualificationInstance, GenerationID: generationID,
+			AuthoredID: "connection:warehouse", Kind: projectgraph.KindConnection, ContractStatus: "not_contract_bearing",
+		},
+		{
+			ResourceUID: "0198f2c0-7c7a-7f00-8a11-000000001002", InstanceID: resourceUIDQualificationInstance, ProjectID: resourceUIDMultiSourceProject,
+			Environment: "prod", TargetID: resourceUIDQualificationInstance, GenerationID: generationID,
+			AuthoredID: "source:orders", Kind: projectgraph.KindSource, ContractStatus: "unversioned",
+		},
+	}
+	if err := validateResourceUIDMultiSourceBindings(valid, graph, generationID); err != nil {
+		t.Fatalf("valid bindings rejected: %v", err)
+	}
+
+	swapped := append([]project.ResourceUIDBinding(nil), valid...)
+	swapped[0].Kind, swapped[1].Kind = swapped[1].Kind, swapped[0].Kind
+	swapped[0].ContractStatus, swapped[1].ContractStatus = swapped[1].ContractStatus, swapped[0].ContractStatus
+	if err := validateResourceUIDMultiSourceBindings(swapped, graph, generationID); err == nil || !strings.Contains(err.Error(), "want graph kind") {
+		t.Fatalf("swapped binding kinds error = %v, want exact graph-kind mismatch", err)
 	}
 }
 

--- a/internal/platform/architecture/dbt_boundary_test.go
+++ b/internal/platform/architecture/dbt_boundary_test.go
@@ -461,6 +461,13 @@ func TestDBTWarehouseBoundaryWorkflowIsRequiredByCIGate(t *testing.T) {
 	if !ok {
 		t.Fatal("CI workflow is missing dbt-warehouse-boundary-validation job")
 	}
+	proof := false
+	for _, step := range dbtJob.Steps {
+		proof = proof || strings.Contains(step.Run, "task dbt:warehouse:proof")
+	}
+	if !proof {
+		t.Fatal("CI dbt validation job does not run the multi-source Project proof")
+	}
 	qualifyFound := false
 	for _, step := range dbtJob.Steps {
 		if strings.Contains(step.Run, "task dbt:warehouse:qualify") {
@@ -606,5 +613,72 @@ func TestDBTExampleUsesExternalNonIncrementalMarts(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(text), "incremental") {
 		t.Error("dbt reference marts must remain non-incremental")
+	}
+}
+
+func TestDBTMultiSourceProofFixturePreservesProducerBoundary(t *testing.T) {
+	root := repoRoot(t)
+	fixture := filepath.Join(root, "examples/dbt-warehouse-boundary/multi-source")
+	for _, relative := range []string{
+		"README.md",
+		"customer-directory.sql",
+		"dbt/dbt_project.yml",
+		"dbt/models/fct_orders.sql",
+		"dbt/models/properties.yml",
+		"dbt/packages.yml",
+		"dbt/profiles.yml",
+		"upstream-orders/dbt_project.yml",
+		"upstream-orders/models/order_lines.sql",
+		"upstream-orders/seeds/raw_orders.csv",
+		"consumer-overlay/connections/directory.yaml",
+		"consumer-overlay/sources/dim_customers.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(fixture, relative)); err != nil {
+			t.Fatalf("multi-source proof fixture is missing %s: %v", relative, err)
+		}
+	}
+
+	read := func(relative string) string {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join(fixture, relative))
+		if err != nil {
+			t.Fatalf("read multi-source fixture file %s: %v", relative, err)
+		}
+		return string(body)
+	}
+	consumer := read("dbt/dbt_project.yml")
+	packages := read("dbt/packages.yml")
+	consumerModel := read("dbt/models/fct_orders.sql")
+	upstream := read("upstream-orders/models/order_lines.sql")
+	crm := read("customer-directory.sql")
+	connection := read("consumer-overlay/connections/directory.yaml")
+	source := read("consumer-overlay/sources/dim_customers.yaml")
+
+	for _, required := range []string{"name: proof_consumer", "+materialized: external", "+format: parquet"} {
+		if !strings.Contains(consumer, required) {
+			t.Errorf("consumer dbt project is missing %q", required)
+		}
+	}
+	if !strings.Contains(packages, "local: ../upstream-orders") {
+		t.Error("consumer dbt project must resolve its local upstream package")
+	}
+	if !strings.Contains(consumerModel, "ref('upstream_orders', 'order_lines')") {
+		t.Error("consumer dbt model must publish a consumer-owned mart from the upstream package")
+	}
+	if !strings.Contains(upstream, "ref('upstream_orders', 'raw_orders')") {
+		t.Error("upstream package model must resolve its own seed")
+	}
+	if strings.Contains(crm, "ref(") || strings.Contains(crm, "{{") {
+		t.Error("independent CRM producer must not read the dbt project")
+	}
+	for _, required := range []string{"id: connection:directory", "type: managed"} {
+		if !strings.Contains(connection, required) {
+			t.Errorf("CRM overlay connection is missing %q", required)
+		}
+	}
+	for _, required := range []string{"id: source:warehouse.dim_customers", "connection: directory", "path: dim_customers.parquet"} {
+		if !strings.Contains(source, required) {
+			t.Errorf("CRM overlay Source is missing %q", required)
+		}
 	}
 }

--- a/scripts/dbt-warehouse-boundary.sh
+++ b/scripts/dbt-warehouse-boundary.sh
@@ -27,8 +27,8 @@ prepare_dbt() {
   requirements_digest="$(sha256sum "$REQUIREMENTS" | awk '{print $1}')"
   marker="$VENV/.leapview-requirements.sha256"
   if [[ ! -x "$VENV/bin/dbt" || ! -f "$marker" || "$(<"$marker")" != "$requirements_digest" ]]; then
-    python3 -m venv --clear "$VENV"
-    "$VENV/bin/python" -m pip install --disable-pip-version-check --requirement "$REQUIREMENTS"
+    python3 -m venv --clear "$VENV" || return 1
+    "$VENV/bin/python" -m pip install --disable-pip-version-check --requirement "$REQUIREMENTS" >&2 || return 1
     printf '%s\n' "$requirements_digest" > "$marker"
   fi
   printf '%s\n' "$VENV/bin/dbt"
@@ -69,5 +69,10 @@ build() {
 case "${1:-}" in
   build) build ;;
   verify) verify_outputs ;;
-  *) echo "Usage: $0 build|verify" >&2; exit 2 ;;
+  proof)
+    dbt="$(prepare_dbt)"
+    cd "$ROOT"
+    DBT_BIN="$dbt" go test -tags duckdb_arrow ./internal/app -run '^TestDBTMultiSourceProjectClosure$' -count=1 -v
+    ;;
+  *) echo "Usage: $0 build|verify|proof" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
## Problem

Existing FAI-678 proof covered the physical dbt warehouse boundary, but review found that it assembled runtime state from incomplete candidate evidence, accepted ResourceUID kind-count equivalence, and did not prove dbt target provenance stayed outside portable bytes.

Linear: [FAI-678](https://linear.app/flid/issue/FAI-678/prove-dbt-and-multi-source-mapping-preserves-one-closed-leapview)

## Solution and evidence

- Prove a dbt package-derived consumer mart materializes physical Parquet before the LeapView boundary.
- Add an independently published CRM Parquet source through a second Connection and Source.
- Compile both into thin Models, one SemanticModel, and one dashboard under one issuer-assigned ProjectUID.
- Qualify Project-scoped ResourceUID allocation and exact generation closure in PostgreSQL.
- Exercise consumer traversal through existing SecurityBarrier enforcement and reject bypass, ambiguous mapping, and foreign-Project paths.

## Review findings addressed

### Production-shaped delivery binding

Root cause: the proof omitted authorization and connection requirements, then assembled serving state and physical roots independently of the delivery plan.

The proof now supplies the canonical authorization fingerprint, exact managed-data pins, compiler plan/evidence, and source attestation/revision. It packs the compiled project through the production bundle path, creates the request through `CandidatePlanRequest`, validates exact governance binding, constructs an immutable `DeliveryPlan`, and derives serving state, serving artifact, bundle bytes, and runtime managed-data inputs from that plan. Runtime preparation rejects drift between the plan, packed bytes, state, artifact, or connection closure.

Regressions reject a missing authorization fingerprint, missing connection requirements, and a valid-shaped but mismatched governance digest; the complete plan validates.

### Exact ResourceUID graph kinds

Root cause: the previous assertion compared authored IDs and aggregate kind counts, allowing two resources to exchange kinds.

The qualification now builds the exact `authored ID -> graph kind` map and validates every generation binding against it. A same-count swapped-kind regression is rejected.

### Portable dbt target provenance

Root cause: the fixture used generic target `local` and did not include it in portable-byte exclusions.

The dbt profile now uses `dbt-target-production-boundary-proof`. The value is retained only in non-execution delivery provenance, is explicitly absent from canonical portable bytes, and a portable payload containing it is rejected by the strict artifact decoder.

No runtime authorization, compiler, planner, cache, ProjectUID, ResourceUID, or semantic-access behavior changed.

## Tests added or updated

- Production-shaped delivery-plan success and fail-closed evidence regressions.
- Exact ResourceUID authored-ID/graph-kind validation and swapped-kind rejection.
- Distinct dbt target provenance separation and embedded-portable-payload rejection.
- Integrated multi-source dbt/CRM Project closure and semantic-access traversal proof.
- PostgreSQL ResourceUID generation-closure qualification.

## Verification performed

Review-fix tree before the final conflict-free main rebase:

- `task ci` — PASS, including PostgreSQL conformance, frontend shards, quality budgets, and generated checks.
- Pinned dbt Core 1.11.14 / dbt-duckdb 1.11.0: `./scripts/dbt-warehouse-boundary.sh proof` — PASS.
- PostgreSQL 18 ResourceUID multi-source closure qualification — PASS.
- `task test:go:packages` — PASS.
- `go test -tags duckdb_arrow ./... -run '^$' -count=0 -p 2` — PASS.

Exact current head after rebasing onto `5d6a6c9a68d75c0c67d82400a7e05734b37cd02a`:

- `task generate` — PASS.
- `task generated:check` — PASS.
- Focused delivery-plan, dbt closure, ResourceUID, semantic-access, and architecture tests — PASS.
- `task quality:budget:check` — PASS.
- `task quality:exceptions:check` — PASS.
- `git diff --check` — PASS.
- Hosted required checks are running against this exact head.

## Limitations

- Qualification is the local dbt-duckdb and physical Parquet profile only.
- No live dbt Cloud, dbt Mesh, or Azure qualification is claimed.
- FAI-679 and FAI-682 are unchanged.
- This PR does not claim final ADR-0018 closure.
