### PR TITLE
Fix concurrent chat undo actions

### DIFF
--- a/internal/agent/pending.go
+++ b/internal/agent/pending.go
@@ -12,7 +12,7 @@ import (
 const (
 	PendingConversationArchive = "archive"
 	PendingConversationDelete  = "delete"
-	PendingConversationWindow  = 10 * time.Second
+	PendingConversationWindow  = 5 * time.Second
 )
 
 var (

--- a/internal/agent/repository.go
+++ b/internal/agent/repository.go
@@ -363,7 +363,7 @@ type ConversationManagementRepository interface {
 	BulkDeleteConversations(ctx context.Context, principalID string, conversationIDs []string) ([]Conversation, error)
 }
 
-// PendingConversationRepository persists the server-owned ten-second undo
+// PendingConversationRepository persists the server-owned five-second undo
 // lifecycle. Implementations must scope begin, cancel, and finalize by both
 // principal and conversation, and must make the request ID an equality check
 // rather than an authorization credential.

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -863,7 +863,7 @@ test('chat deletion requires confirmation and cancel sends no command', async ()
   await page.close()
 })
 
-test('archive persists before showing ten-second Undo and waits for cancellation acknowledgement', async () => {
+test('archive persists before showing five-second Undo and waits for cancellation acknowledgement', async () => {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } })
   try {
     await page.goto(`${baseURL}/sidebar-history`)
@@ -878,10 +878,10 @@ test('archive persists before showing ten-second Undo and waits for cancellation
     expect(await page.getByRole('button', { name: 'Undo', exact: true }).count()).toBe(0)
     await page.evaluate(async () => {
       const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
+      runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 5_000).toISOString(), archivedConversations: [] } })
     })
     await page.getByRole('status').filter({ hasText: 'Archived chat' }).waitFor()
-    expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lv-chat-manager.pending-undo')!)[0].deadline - Date.now())).toBeGreaterThan(9_000)
+    expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lv-chat-manager.pending-undo')!)[0].deadline - Date.now())).toBeGreaterThan(4_000)
     await page.locator('button.undo').click()
     expect(await page.evaluate(() => (window as any).chatActions.map((a: any) => a.action))).toEqual(['archive_pending', 'undo'])
     expect(await page.evaluate(() => (window as any).chatActions[0].requestId === (window as any).chatActions[1].requestId)).toBe(true)
@@ -910,7 +910,7 @@ test('chat actions keep independent Undo notifications without waiting for the f
     await page.waitForFunction(() => (window as any).chatActions.length === 1)
     await page.evaluate(async () => {
       const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
+      runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 5_000).toISOString(), archivedConversations: [] } })
     })
     await page.locator('button.undo[data-conversation-id="c1"]').waitFor()
 
@@ -922,7 +922,7 @@ test('chat actions keep independent Undo notifications without waiting for the f
     await page.waitForFunction(() => (window as any).chatActions.length === 2)
     await page.evaluate(async () => {
       const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
-      runtime.mergePatch({ chatManagement: { action: 'delete_pending', completedRequestId: (window as any).chatActions[1].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
+      runtime.mergePatch({ chatManagement: { action: 'delete_pending', completedRequestId: (window as any).chatActions[1].requestId, undoDeadline: new Date(Date.now() + 5_000).toISOString(), archivedConversations: [] } })
     })
 
     await page.locator('button.undo[data-conversation-id="c2"]').waitFor()

--- a/web/components/app/app-shell.dom.test.ts
+++ b/web/components/app/app-shell.dom.test.ts
@@ -881,8 +881,8 @@ test('archive persists before showing ten-second Undo and waits for cancellation
       runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
     })
     await page.getByRole('status').filter({ hasText: 'Archived chat' }).waitFor()
-    expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lv-chat-manager.pending-undo')!).deadline - Date.now())).toBeGreaterThan(9_000)
-    await page.getByRole('button', { name: 'Undo', exact: true }).click()
+    expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lv-chat-manager.pending-undo')!)[0].deadline - Date.now())).toBeGreaterThan(9_000)
+    await page.locator('button.undo').click()
     expect(await page.evaluate(() => (window as any).chatActions.map((a: any) => a.action))).toEqual(['archive_pending', 'undo'])
     expect(await page.evaluate(() => (window as any).chatActions[0].requestId === (window as any).chatActions[1].requestId)).toBe(true)
     await page.evaluate(async () => {
@@ -891,6 +891,56 @@ test('archive persists before showing ten-second Undo and waits for cancellation
     })
     await page.getByRole('status').filter({ hasText: 'Conversation action canceled.' }).waitFor()
     expect(await page.evaluate(() => sessionStorage.getItem('lv-chat-manager.pending-undo'))).toBeNull()
+  } finally {
+    await page.close()
+  }
+})
+
+test('chat actions keep independent Undo notifications without waiting for the first window', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } })
+  try {
+    await page.goto(`${baseURL}/sidebar-history`)
+    await page.locator('lv-chat-manager').waitFor({ state: 'attached' })
+    await page.evaluate(() => {
+      sessionStorage.removeItem('lv-chat-manager.pending-undo')
+      ;(window as any).chatActions = []
+      document.addEventListener('lv-chat-management', (event: Event) => (window as any).chatActions.push((event as CustomEvent).detail))
+      document.querySelector('lv-app-shell')!.dispatchEvent(new CustomEvent('lv-chat-action', { detail: { action: 'archive', conversationId: 'c1', title: 'Revenue check' } }))
+    })
+    await page.waitForFunction(() => (window as any).chatActions.length === 1)
+    await page.evaluate(async () => {
+      const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
+      runtime.mergePatch({ chatManagement: { action: 'archive_pending', completedRequestId: (window as any).chatActions[0].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
+    })
+    await page.locator('button.undo[data-conversation-id="c1"]').waitFor()
+
+    await page.evaluate(() => {
+      document.querySelector('lv-app-shell')!.dispatchEvent(new CustomEvent('lv-chat-action', { detail: { action: 'delete', conversationId: 'c2', title: 'Inventory status' } }))
+    })
+    await page.getByRole('dialog', { name: 'Delete chat?' }).waitFor()
+    await page.getByRole('button', { name: 'Delete', exact: true }).click()
+    await page.waitForFunction(() => (window as any).chatActions.length === 2)
+    await page.evaluate(async () => {
+      const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
+      runtime.mergePatch({ chatManagement: { action: 'delete_pending', completedRequestId: (window as any).chatActions[1].requestId, undoDeadline: new Date(Date.now() + 10_000).toISOString(), archivedConversations: [] } })
+    })
+
+    await page.locator('button.undo[data-conversation-id="c2"]').waitFor()
+    expect(await page.locator('button.undo').count()).toBe(2)
+    expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lv-chat-manager.pending-undo')!).length)).toBe(2)
+    expect(await page.locator('a[href="/chats/c1"], a[href="/chats/c2"]').count()).toBe(0)
+
+    await page.locator('button.undo[data-conversation-id="c1"]').click()
+    await page.waitForFunction(() => (window as any).chatActions.length === 3)
+    await page.evaluate(async () => {
+      const runtime = await import('/static/vendor/datastar-1.0.2.js?v=dev')
+      runtime.mergePatch({ chatManagement: { action: 'undo', completedRequestId: (window as any).chatActions[2].requestId, message: '', archivedConversations: [] } })
+    })
+
+    await page.locator('button.undo[data-conversation-id="c2"]').waitFor()
+    expect(await page.locator('button.undo').count()).toBe(1)
+    expect(await page.locator('a[href="/chats/c1"]').count()).toBe(1)
+    expect(await page.locator('a[href="/chats/c2"]').count()).toBe(0)
   } finally {
     await page.close()
   }

--- a/web/components/app/app-shell.ts
+++ b/web/components/app/app-shell.ts
@@ -25,7 +25,7 @@ const emptyChrome: ChromeSignal = {
 
 class LeapViewAppShell extends DatastarLit(LitElement) {
   @state() private productSearchOpen = false
-  @state() private pendingRemovalId = ''
+  @state() private pendingRemovalIds: string[] = []
 
   static styles = css`
     :host {
@@ -129,11 +129,11 @@ class LeapViewAppShell extends DatastarLit(LitElement) {
 
   render() {
     return html`
-      ${this.isAppDashboard ? null : html`<lv-sidebar .config=${this.chrome.sidebar} .pendingRemovalId=${this.pendingRemovalId}></lv-sidebar>`}
+      ${this.isAppDashboard ? null : html`<lv-sidebar .config=${this.chrome.sidebar} .pendingRemovalIds=${this.pendingRemovalIds}></lv-sidebar>`}
       <main>
         <slot name="page"></slot>
       </main>
-      <lv-chat-manager @lv-chat-removal-pending=${(event: CustomEvent<{ conversationId: string }>) => { this.pendingRemovalId = event.detail.conversationId }}></lv-chat-manager>
+      <lv-chat-manager @lv-chat-removal-pending=${(event: CustomEvent<{ conversationIds: string[] }>) => { this.pendingRemovalIds = event.detail.conversationIds }}></lv-chat-manager>
       <lv-product-search
         .open=${this.productSearchOpen}
         @product-search-close=${this.closeProductSearch}

--- a/web/components/chat/chat-manager.ts
+++ b/web/components/chat/chat-manager.ts
@@ -31,25 +31,30 @@ function isUndoableAction(detail: ChatAction | null | undefined): detail is Chat
   return Boolean(detail && (detail.action === 'archive' || detail.action === 'delete') && detail.conversationId)
 }
 
-function readStoredUndo(): StoredUndo | null {
+function readStoredUndos(): StoredUndo[] {
   try {
     const raw = window.sessionStorage.getItem(pendingUndoStorageKey)
-    if (!raw) return null
-    const value = JSON.parse(raw) as Partial<StoredUndo>
-    if (!value || value.phase !== 'waiting' || typeof value.requestId !== 'string' || !value.requestId || typeof value.deadline !== 'number' || !Number.isFinite(value.deadline) || !value.action || !isUndoableAction(value.action)) {
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as Partial<StoredUndo> | Partial<StoredUndo>[]
+    const values = Array.isArray(parsed) ? parsed : [parsed]
+    const stored = values.filter((value): value is StoredUndo => Boolean(
+      value && value.phase === 'waiting' && typeof value.requestId === 'string' && value.requestId &&
+      typeof value.deadline === 'number' && Number.isFinite(value.deadline) && value.action && isUndoableAction(value.action),
+    ))
+    if (stored.length !== values.length) {
       window.sessionStorage.removeItem(pendingUndoStorageKey)
-      return null
+      return []
     }
-    const { phase, requestId, deadline, action } = value
-    return { phase, requestId, deadline, action }
+    return stored
   } catch {
-    return null
+    return []
   }
 }
 
-function writeStoredUndo(value: StoredUndo): void {
+function writeStoredUndos(values: StoredUndo[]): void {
   try {
-    window.sessionStorage.setItem(pendingUndoStorageKey, JSON.stringify(value))
+    if (values.length) window.sessionStorage.setItem(pendingUndoStorageKey, JSON.stringify(values))
+    else window.sessionStorage.removeItem(pendingUndoStorageKey)
   } catch {
     // The in-memory timer still provides Undo when storage is unavailable.
   }
@@ -57,7 +62,11 @@ function writeStoredUndo(value: StoredUndo): void {
 
 function clearStoredUndo(requestId?: string): void {
   try {
-    if (!requestId || readStoredUndo()?.requestId === requestId) window.sessionStorage.removeItem(pendingUndoStorageKey)
+    if (!requestId) {
+      window.sessionStorage.removeItem(pendingUndoStorageKey)
+      return
+    }
+    writeStoredUndos(readStoredUndos().filter(pending => pending.requestId !== requestId))
   } catch {
     // Storage can be unavailable in privacy-restricted browsing contexts.
   }
@@ -70,11 +79,11 @@ export class ChatManager extends DatastarLit(LitElement) {
   @state() private query = ''
   @state() private feedback = ''
   @state() private failure = ''
-  @state() private undoPending: PendingUndo | null = null
+  @state() private undoPendings: PendingUndo[] = []
   private pendingAction: ChatAction | null = null
   private archivesOpen = false
   private lastFocus: HTMLElement | null = null
-  private undoTimer: number | null = null
+  private undoTimers = new Map<string, number>()
 
   static styles = css`
     :host { display: contents; color: var(--lv-fg-default); font: var(--lv-type-body); }
@@ -102,7 +111,8 @@ export class ChatManager extends DatastarLit(LitElement) {
     .chat-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .empty { padding: 26px 0; text-align: center; color: var(--lv-fg-muted); }
     .error { color: var(--lv-fg-danger); line-height: 1.5; }
-    .toast { position: fixed; z-index: 100; top: max(16px, env(safe-area-inset-top)); left: 50%; transform: translateX(-50%); display: flex; align-items: center; gap: 10px; box-sizing: border-box; width: max-content; max-width: calc(100vw - 32px); padding: 8px 12px; border: 0; border-radius: var(--lv-radius-large); background: var(--lv-bg-panel-muted); box-shadow: none; font: var(--lv-type-caption); }
+    .toast-stack { position: fixed; z-index: 100; top: max(16px, env(safe-area-inset-top)); left: 50%; transform: translateX(-50%); display: grid; justify-items: center; gap: 8px; width: max-content; max-width: calc(100vw - 32px); }
+    .toast { display: flex; align-items: center; gap: 10px; box-sizing: border-box; width: max-content; max-width: 100%; padding: 8px 12px; border: 0; border-radius: var(--lv-radius-large); background: var(--lv-bg-panel-muted); box-shadow: none; font: var(--lv-type-caption); }
     .toast-label { font-weight: var(--base-text-weight-semibold); }
     .toast svg { flex-shrink: 0; }
     .toast button { border: 0; padding: 5px 10px; font: inherit; }
@@ -134,16 +144,19 @@ export class ChatManager extends DatastarLit(LitElement) {
     this.pendingAction = null
     if (isUndoableAction(action)) {
       clearStoredUndo(requestId)
-      this.emitRemovalPending('')
+      this.emitRemovalPending()
     }
     this.failure = failure.message
-    if (action?.action === 'undo' && this.undoPending) this.scheduleUndo(this.undoPending)
+    if (action?.action === 'undo') {
+      const undoPending = this.undoPendings.find(pending => pending.requestId === requestId)
+      if (undoPending) this.scheduleUndo(undoPending)
+    }
   }
 
   private get management(): ChatManagementSignal { return this.signal('chatManagement', emptyManagement) }
 
   public openArchives() {
-    if (this.pending || this.undoPending) return
+    if (this.pending) return
     this.archivesOpen = true
     this.confirmation = null
     this.query = ''
@@ -154,7 +167,7 @@ export class ChatManager extends DatastarLit(LitElement) {
   }
 
   public requestAction(detail: ChatAction) {
-    if (this.pending || this.undoPending) return
+    if (this.pending) return
     this.failure = ''
     this.feedback = ''
     if (detail.action === 'delete' || detail.action.endsWith('_all')) {
@@ -183,16 +196,16 @@ export class ChatManager extends DatastarLit(LitElement) {
   }
 
   private restorePendingUndo() {
-    const stored = readStoredUndo()
-    if (this.undoPending) {
-      this.emitRemovalPending(this.undoPending.action.conversationId)
-      this.scheduleUndo(this.undoPending)
+    if (this.undoPendings.length) {
+      this.emitRemovalPending()
+      this.undoPendings.forEach(pending => this.scheduleUndo(pending))
       return
     }
-    if (this.pending || !stored) return
-    this.undoPending = stored
-    this.emitRemovalPending(stored.action.conversationId)
-    this.scheduleUndo(stored)
+    const stored = readStoredUndos()
+    if (this.pending || !stored.length) return
+    this.undoPendings = stored
+    this.emitRemovalPending()
+    stored.forEach(pending => this.scheduleUndo(pending))
   }
 
   private beginUndo(detail: ChatAction) {
@@ -202,44 +215,48 @@ export class ChatManager extends DatastarLit(LitElement) {
   }
 
   private scheduleUndo(pending: PendingUndo) {
-    this.clearUndoTimer()
+    this.clearUndoTimer(pending.requestId)
     const delay = Math.max(0, pending.deadline - Date.now())
-    this.undoTimer = window.setTimeout(() => this.commitUndo(pending.requestId), delay)
+    this.undoTimers.set(pending.requestId, window.setTimeout(() => this.commitUndo(pending.requestId), delay))
     if (delay === 0) this.requestUpdate()
   }
 
-  private clearUndoTimer() {
-    if (this.undoTimer !== null) window.clearTimeout(this.undoTimer)
-    this.undoTimer = null
+  private clearUndoTimer(requestId?: string) {
+    if (requestId) {
+      const timer = this.undoTimers.get(requestId)
+      if (timer !== undefined) window.clearTimeout(timer)
+      this.undoTimers.delete(requestId)
+      return
+    }
+    this.undoTimers.forEach(timer => window.clearTimeout(timer))
+    this.undoTimers.clear()
   }
 
   private commitUndo(requestId: string) {
-    const pending = this.undoPending
-    if (!pending || pending.requestId !== requestId) return
-    this.clearUndoTimer()
-    this.undoPending = null
+    const pending = this.undoPendings.find(value => value.requestId === requestId)
+    if (!pending) return
+    this.clearUndoTimer(requestId)
+    this.undoPendings = this.undoPendings.filter(value => value.requestId !== requestId)
     clearStoredUndo(requestId)
+    this.emitRemovalPending()
     // Expiry only refreshes the view. Closing this tab cannot cancel the
     // persisted operation, and no second mutation is needed from the browser.
     const current = window.location.pathname.match(/^\/chats\/([^/]+)$/)?.[1]
     if (current && decodeURIComponent(current) === pending.action.conversationId) {
       window.location.assign('/chats/new')
-      return
     }
-    this.pending = crypto.randomUUID()
-    this.pendingAction = null
-    this.dispatchEvent(new CustomEvent('lv-chat-management-load', { bubbles: true, composed: true, detail: { requestId: this.pending } }))
   }
 
-  private undo = () => {
-    const pending = this.undoPending
+  private undo = (requestId: string) => {
+    const pending = this.undoPendings.find(value => value.requestId === requestId)
     if (!pending || this.pending) return
-    this.clearUndoTimer()
+    this.clearUndoTimer(requestId)
     this.perform({ action: 'undo', conversationId: pending.action.conversationId }, pending.requestId)
   }
 
-  private emitRemovalPending(conversationId: string) {
-    this.dispatchEvent(new CustomEvent('lv-chat-removal-pending', { bubbles: true, composed: true, detail: { conversationId } }))
+  private emitRemovalPending() {
+    const conversationIds = this.undoPendings.map(pending => pending.action.conversationId)
+    this.dispatchEvent(new CustomEvent('lv-chat-removal-pending', { bubbles: true, composed: true, detail: { conversationIds } }))
   }
 
   protected updated() {
@@ -256,10 +273,13 @@ export class ChatManager extends DatastarLit(LitElement) {
     this.pendingAction = null
     if (isUndoableAction(action)) {
       clearStoredUndo(completedRequestId)
-      this.emitRemovalPending('')
+      this.emitRemovalPending()
     }
     if (this.failure) {
-      if (action?.action === 'undo' && this.undoPending) this.scheduleUndo(this.undoPending)
+      if (action?.action === 'undo') {
+        const undoPending = this.undoPendings.find(pending => pending.requestId === completedRequestId)
+        if (undoPending) this.scheduleUndo(undoPending)
+      }
       return
     }
     if (action?.action === 'archive_pending' || action?.action === 'delete_pending') {
@@ -269,19 +289,20 @@ export class ChatManager extends DatastarLit(LitElement) {
         return
       }
       const originalAction = action.action === 'archive_pending' ? 'archive' : 'delete'
-      this.undoPending = { action: { ...action, action: originalAction }, requestId: completedRequestId, deadline }
-      writeStoredUndo({ ...this.undoPending, phase: 'waiting' })
-      this.emitRemovalPending(action.conversationId)
-      this.scheduleUndo(this.undoPending)
+      const pendingUndo = { action: { ...action, action: originalAction }, requestId: completedRequestId, deadline }
+      this.undoPendings = [...this.undoPendings.filter(pending => pending.requestId !== completedRequestId), pendingUndo]
+      writeStoredUndos(this.undoPendings.map(pending => ({ ...pending, phase: 'waiting' })))
+      this.emitRemovalPending()
+      this.scheduleUndo(pendingUndo)
       this.feedback = ''
       return
     }
     if (action?.action === 'undo') {
-      this.undoPending = null
+      this.undoPendings = this.undoPendings.filter(pending => pending.requestId !== completedRequestId)
       clearStoredUndo(completedRequestId)
-      this.emitRemovalPending('')
+      this.emitRemovalPending()
     }
-    if (!action) this.emitRemovalPending('')
+    if (!action) this.emitRemovalPending()
     this.feedback = result.message || ''
     this.confirmation = null
     if (!this.archivesOpen) this.close()
@@ -330,9 +351,13 @@ export class ChatManager extends DatastarLit(LitElement) {
           `}
         </div>
       </dialog>
-      ${!this.opened && this.undoPending ? html`<div class="toast" role="status">${lucideIcon(this.undoPending.action.action === 'archive' ? Archive : Trash2, { size: 16 })}<span class="toast-label">${this.undoPending.action.action === 'archive' ? 'Archived chat' : 'Deleted chat'}</span><button class="undo" ?disabled=${Boolean(this.pending)} @click=${this.undo}>Undo</button></div>` : nothing}
-      ${!this.opened && !this.undoPending && this.pending ? html`<div class="toast" role="status">Updating chat…</div>` : nothing}
-      ${!this.opened && (this.failure || this.feedback) ? html`<div class=${`toast ${this.failure ? 'error' : ''}`} role=${this.failure ? 'alert' : 'status'}>${this.failure || this.feedback}<button class="icon" aria-label="Dismiss" @click=${() => { this.failure = ''; this.feedback = '' }}>${lucideIcon(X, { size: 14 })}</button></div>` : nothing}
+      ${!this.opened && (this.undoPendings.length || this.pending || this.failure || this.feedback) ? html`
+        <div class="toast-stack">
+          ${this.undoPendings.map(pending => html`<div class="toast" role="status">${lucideIcon(pending.action.action === 'archive' ? Archive : Trash2, { size: 16 })}<span class="toast-label">${pending.action.action === 'archive' ? 'Archived chat' : 'Deleted chat'}</span><button class="undo" data-conversation-id=${pending.action.conversationId} aria-label=${`Undo ${pending.action.action} of ${pending.action.title || 'chat'}`} ?disabled=${Boolean(this.pending)} @click=${() => this.undo(pending.requestId)}>Undo</button></div>`)}
+          ${!this.undoPendings.length && this.pending ? html`<div class="toast" role="status">Updating chat…</div>` : nothing}
+          ${this.failure || this.feedback ? html`<div class=${`toast ${this.failure ? 'error' : ''}`} role=${this.failure ? 'alert' : 'status'}>${this.failure || this.feedback}<button class="icon" aria-label="Dismiss" @click=${() => { this.failure = ''; this.feedback = '' }}>${lucideIcon(X, { size: 14 })}</button></div>` : nothing}
+        </div>
+      ` : nothing}
     `
   }
 }

--- a/web/components/chat/chat-manager.ts
+++ b/web/components/chat/chat-manager.ts
@@ -8,7 +8,7 @@ import type { ChatManagementSignal } from '../../generated/signals'
 
 export type ChatAction = { action: string; conversationId: string; title?: string }
 
-export const CHAT_UNDO_WINDOW_MS = 10_000
+export const CHAT_UNDO_WINDOW_MS = 5_000
 const pendingUndoStorageKey = 'lv-chat-manager.pending-undo'
 
 type PendingUndo = {

--- a/web/components/navigation/sidebar-chat-history.ts
+++ b/web/components/navigation/sidebar-chat-history.ts
@@ -94,12 +94,13 @@ export const sidebarChatHistoryStyles = css`
 
 export function renderSidebarChatHistory(
   history: SidebarHistory | undefined,
-  pendingRemovalId: string,
+  pendingRemovalIds: readonly string[],
   followInternalLink: (event: MouseEvent, href: string) => void,
   chatAction: (action: string, item: SidebarHistoryItem) => void,
 ) {
   if (!history) return null
-  const items = (Array.isArray(history.items) ? history.items : []).filter(item => item.id !== pendingRemovalId)
+  const pending = new Set(pendingRemovalIds)
+  const items = (Array.isArray(history.items) ? history.items : []).filter(item => !pending.has(item.id))
   return html`
     <section class="history" aria-label=${history.label || 'Chats'}>
       <strong class="history-label">${history.label || 'Chats'}</strong>

--- a/web/components/navigation/sidebar.ts
+++ b/web/components/navigation/sidebar.ts
@@ -172,7 +172,7 @@ const statusConverter = {
 class LeapViewSidebar extends LitElement {
   @property({ attribute: 'config', converter: configConverter }) config: SidebarConfig = defaultConfig
   @property({ attribute: 'status', converter: statusConverter }) status: SidebarStatus = {}
-  @property({ attribute: false }) pendingRemovalId = ''
+  @property({ attribute: false }) pendingRemovalIds: string[] = []
   @state() private collapsed = storedCollapsed()
   @state() private peeking = false
   @state() private mobileOpen = false
@@ -1657,7 +1657,7 @@ class LeapViewSidebar extends LitElement {
   }
 
   private renderHistory() {
-    return renderSidebarChatHistory(this.config.history, this.pendingRemovalId, (event, href) => this.followInternalLink(event, href), (action, item) => this.chatAction(action, item))
+    return renderSidebarChatHistory(this.config.history, this.pendingRemovalIds, (event, href) => this.followInternalLink(event, href), (action, item) => this.chatAction(action, item))
   }
 
   private chatAction(action: string, item: SidebarHistoryItem) {


### PR DESCRIPTION
Users were blocked from managing another chat for the full Undo window because the client kept only one pending action. This change tracks pending archive/delete actions independently, stacks a compact Undo notification for each chat, and hides every pending chat from the sidebar until its own action is undone or expires.

Each chat has an independent 5-second server-owned safety window. Stored single-action state is migrated on read, and each Undo button has a chat-specific accessible name.

Validation:
- `bun run test:app-shell` (32 pass)
- `bun run typecheck:app`
- `bun run typecheck:tests`
- `git diff --check`
