### PR TITLE
Polish login branding and add password visibility controls

### DIFF
--- a/web/components/login/login-page.dom.test.ts
+++ b/web/components/login/login-page.dom.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
         localAuth: url.searchParams.get('localAuth') === 'true',
         ssoAuth: url.searchParams.has('ssoAuth') ? url.searchParams.get('ssoAuth') === 'true' : true,
         mustChangePassword: url.searchParams.get('mustChangePassword') === 'true',
-        error: url.searchParams.get('error') ?? '',
+        error: url.searchParams.get('error') === 'invalid_credentials' ? 'The email or password is incorrect.' : '',
       }))
       return
     }
@@ -367,7 +367,7 @@ test('change-password authentication renders only the password recovery contract
 test('login errors stay visible in the local form contract', async () => {
   const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
   try {
-    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false&error=The%20email%20or%20password%20is%20incorrect.`)
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false&error=invalid_credentials`)
     await page.waitForFunction(() => customElements.get('lv-login-page'))
     await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
 

--- a/web/components/login/login-page.dom.test.ts
+++ b/web/components/login/login-page.dom.test.ts
@@ -17,7 +17,12 @@ beforeAll(async () => {
     const url = new URL(request.url ?? '/', 'http://127.0.0.1')
     if (url.pathname === '/') {
       response.setHeader('content-type', 'text/html')
-      response.end(testDocument())
+      response.end(testDocument({
+        localAuth: url.searchParams.get('localAuth') === 'true',
+        ssoAuth: url.searchParams.has('ssoAuth') ? url.searchParams.get('ssoAuth') === 'true' : true,
+        mustChangePassword: url.searchParams.get('mustChangePassword') === 'true',
+        error: url.searchParams.get('error') ?? '',
+      }))
       return
     }
     if (url.pathname === '/loader-test') {
@@ -30,7 +35,7 @@ beforeAll(async () => {
       response.end(`window.__loginBackgroundModuleLoaded = true`)
       return
     }
-    const fileRoot = url.pathname.startsWith('/static/vendor/') || url.pathname === '/static/login-background-loader.js' ? projectRoot : root
+    const fileRoot = url.pathname.startsWith('/static/vendor/') || url.pathname === '/static/app.css' || url.pathname === '/static/login-background-loader.js' ? projectRoot : root
     const file = normalize(join(fileRoot, url.pathname))
     if (!file.startsWith(fileRoot)) {
       response.writeHead(404)
@@ -38,7 +43,7 @@ beforeAll(async () => {
       return
     }
     try {
-      response.setHeader('content-type', 'text/javascript')
+      response.setHeader('content-type', url.pathname.endsWith('.css') ? 'text/css' : 'text/javascript')
       response.end(await readFile(file))
     } catch {
       response.writeHead(404)
@@ -57,7 +62,7 @@ afterAll(async () => {
   await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
 }, 15_000)
 
-test('login page composes route UI', async () => {
+test('login page composes branded route UI', async () => {
   const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
   try {
     await page.goto(baseURL)
@@ -73,6 +78,7 @@ test('login page composes route UI', async () => {
       const brandMark = root.querySelector('lv-brand-mark') as HTMLElement | null
       return {
         title: root.querySelector('h1')?.textContent?.trim(),
+        hasBrandName: root.textContent?.includes('LeapView') ?? false,
         brandMarkCount: root.querySelectorAll('lv-brand-mark').length,
         apertureCircleCount: brandMark?.shadowRoot?.querySelectorAll('circle[cx="12"][cy="12"][r="10"]').length,
         hasBackground: Boolean(root.querySelector('lv-topology-background[data-login-background]')),
@@ -81,15 +87,15 @@ test('login page composes route UI', async () => {
         hasThemeToggle: Boolean(root.querySelector('[data-theme-toggle]')),
         visibleThemeIcon: visibleThemeIcon?.getAttribute('data-theme-icon'),
         visibleThemeIconHasSvg: Boolean(visibleThemeIcon?.querySelector('svg')),
-        panelCenteredX: Math.abs((panelRect.left + panelRect.width / 2) - (hostRect.left + hostRect.width / 2)) <= 1,
-        panelCenteredY: Math.abs((panelRect.top + panelRect.height / 2) - (hostRect.top + hostRect.height / 2)) <= 1,
+        panelFitsViewport: panelRect.left >= hostRect.left - 1 && panelRect.right <= hostRect.right + 1,
         hostHeight: Math.round(hostRect.height),
         provider: root.querySelector('.provider')?.textContent?.trim(),
       }
     })
 
     expect(state).toEqual({
-      title: 'LeapView',
+      title: 'Welcome back',
+      hasBrandName: true,
       brandMarkCount: 1,
       apertureCircleCount: 1,
       hasBackground: true,
@@ -98,10 +104,290 @@ test('login page composes route UI', async () => {
       hasThemeToggle: true,
       visibleThemeIcon: 'system',
       visibleThemeIconHasSvg: true,
-      panelCenteredX: true,
-      panelCenteredY: true,
-      hostHeight: 820,
+      panelFitsViewport: true,
+      hostHeight: expect.any(Number),
       provider: 'Sign in with Azure Active Directory',
+    })
+    expect(state.hostHeight).toBeGreaterThanOrEqual(820)
+  } finally {
+    await page.close()
+  }
+})
+
+test('minimal form remains centred and preserves the original background overlay', async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false`)
+    await page.getByRole('heading', { name: 'Welcome back' }).waitFor()
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const panelElement = root.querySelector('.panel')
+      const panel = panelElement.getBoundingClientRect()
+      const brand = root.querySelector('.brand-lockup')
+      const brandRect = brand.getBoundingClientRect()
+      const themeRect = root.querySelector('.theme').getBoundingClientRect()
+      const tokenProbe = document.createElement('span')
+      tokenProbe.style.backgroundColor = 'var(--overlay-backdrop-bgColor)'
+      document.body.append(tokenProbe)
+      const expected = getComputedStyle(tokenProbe).backgroundColor
+      tokenProbe.remove()
+      return {
+        logoAtTopLeft: brandRect.left <= 24 && brandRect.top <= 24,
+        logoOutsideForm: !panelElement.contains(brand),
+        logoClearsControls: brandRect.bottom < panel.top && brandRect.right < themeRect.left,
+        centredX: Math.abs(panel.x + panel.width / 2 - innerWidth / 2) < 1,
+        centredY: Math.abs(panel.y + panel.height / 2 - innerHeight / 2) < 1,
+        originalOverlay: getComputedStyle(root.querySelector('.scrim')).backgroundColor === expected,
+        hasMarketing: Boolean(root.querySelector('.product-preview, .suggestion, .feature-options')),
+      }
+    })
+    expect(state).toEqual({ centredX: true, centredY: true, originalOverlay: true, hasMarketing: false, logoAtTopLeft: true, logoOutsideForm: true, logoClearsControls: true })
+  } finally {
+    await page.close()
+  }
+})
+
+test('login form remains reachable on a short mobile viewport without horizontal overflow', async () => {
+  const page = await browser.newPage({ viewport: { width: 320, height: 240 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const host = element as HTMLElement
+      const form = root.querySelector('form') as HTMLElement | null
+      const panel = root.querySelector('.panel') as HTMLElement | null
+      const hostRect = host.getBoundingClientRect()
+      const panelRect = panel?.getBoundingClientRect()
+      const documentWidth = Math.max(document.documentElement.scrollWidth, document.body.scrollWidth)
+      form?.scrollIntoView({ block: 'center', inline: 'nearest' })
+      const formRect = form?.getBoundingClientRect()
+      return {
+        hasForm: Boolean(form),
+        noHorizontalOverflow: documentWidth <= window.innerWidth && host.scrollWidth <= host.clientWidth,
+        panelFitsViewport: Boolean(panelRect && panelRect.left >= hostRect.left - 1 && panelRect.right <= hostRect.right + 1),
+        formIntersectsViewport: Boolean(formRect && formRect.bottom > 0 && formRect.top < window.innerHeight),
+      }
+    })
+
+    expect(state).toEqual({
+      hasForm: true,
+      noHorizontalOverflow: true,
+      panelFitsViewport: true,
+      formIntersectsViewport: true,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('login fits laptop and phone viewports without page scrolling', async () => {
+  const page = await browser.newPage()
+  try {
+    for (const viewport of [{ width: 1440, height: 900 }, { width: 1280, height: 720 }, { width: 900, height: 600 }, { width: 390, height: 700 }]) {
+      await page.setViewportSize(viewport)
+      await page.goto(`${baseURL}/?localAuth=true&ssoAuth=true`)
+      await page.getByRole('heading', { name: 'Welcome back' }).waitFor()
+      const size = await page.evaluate(() => ({ width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight }))
+      expect(size.width).toBeLessThanOrEqual(viewport.width)
+      expect(size.height).toBeLessThanOrEqual(viewport.height)
+      expect(await page.getByRole('button', { name: 'Sign in', exact: true }).isVisible()).toBe(true)
+    }
+  } finally {
+    await page.close()
+  }
+})
+
+test('mobile keyboard navigation moves directly through the sign-in form', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 740 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const focusedNames: Array<string | undefined> = []
+    for (let index = 0; index < 5; index += 1) {
+      await page.keyboard.press('Tab')
+      focusedNames.push(await page.locator('lv-login-page').evaluate((element: any) => {
+        const focused = element.shadowRoot.activeElement as HTMLElement | null
+        if (!focused) return undefined
+        if (focused.matches('[data-theme-toggle]')) return 'theme'
+        if (focused.matches('input')) return focused.getAttribute('name') ?? undefined
+        if (focused.matches('button')) return focused.getAttribute('aria-label') ?? focused.textContent?.replace(/\s+/g, ' ').trim()
+        return focused.tagName.toLowerCase()
+      }))
+    }
+
+    expect(focusedNames).toEqual([
+      'theme',
+      'email',
+      'password',
+      'Show password',
+      'Sign in',
+    ])
+  } finally {
+    await page.close()
+  }
+})
+
+test('local authentication renders the local login contract', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const form = root.querySelector('form') as HTMLFormElement | null
+      return {
+        title: root.querySelector('h1')?.textContent?.trim(),
+        action: form?.getAttribute('action'),
+        method: form?.getAttribute('method'),
+        email: form?.querySelector('input[name="email"]')?.getAttribute('autocomplete'),
+        password: form?.querySelector('input[name="password"]')?.getAttribute('autocomplete'),
+        submit: form?.querySelector('button[type="submit"]')?.textContent?.trim(),
+        providerCount: root.querySelectorAll('.provider').length,
+      }
+    })
+
+    expect(state).toEqual({
+      title: 'Welcome back',
+      action: '/auth/local/login',
+      method: 'post',
+      email: 'username',
+      password: 'current-password',
+      submit: 'Sign in',
+      providerCount: 0,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('password visibility toggles preserve values and never submit the form', async () => {
+  const page = await browser.newPage()
+  try {
+    for (const changePassword of [false, true]) {
+      await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false&mustChangePassword=${changePassword}`)
+      await page.locator('lv-login-page form').waitFor()
+      await page.locator('form').evaluate((form) => {
+        (window as any).__submissions = 0
+        form.addEventListener('submit', (event) => { event.preventDefault(); (window as any).__submissions++ })
+      })
+      const fields = changePassword ? ['Temporary password', 'New password'] : ['Password']
+      for (const label of fields) {
+        const input = page.getByLabel(label, { exact: true })
+        await input.fill('example-password-123')
+        expect(await input.getAttribute('type')).toBe('password')
+        const show = page.getByRole('button', { name: `Show ${label.toLowerCase()}`, exact: true })
+        await show.focus()
+        await page.keyboard.press('Space')
+        expect(await input.getAttribute('type')).toBe('text')
+        expect(await input.inputValue()).toBe('example-password-123')
+        const hide = page.getByRole('button', { name: `Hide ${label.toLowerCase()}`, exact: true })
+        expect(await hide.evaluate((button) => button === (button.getRootNode() as ShadowRoot).activeElement)).toBe(true)
+        await hide.click()
+        expect(await input.getAttribute('type')).toBe('password')
+        expect(await input.inputValue()).toBe('example-password-123')
+      }
+      expect(await page.evaluate(() => (window as any).__submissions)).toBe(0)
+    }
+  } finally {
+    await page.close()
+  }
+})
+
+test('SSO authentication renders the configured provider contract', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=false&ssoAuth=true`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const provider = root.querySelector('.provider') as HTMLAnchorElement | null
+      return {
+        title: root.querySelector('h1')?.textContent?.trim(),
+        href: provider?.getAttribute('href'),
+        label: provider?.textContent?.trim(),
+        formCount: root.querySelectorAll('form').length,
+      }
+    })
+
+    expect(state).toEqual({
+      title: 'Welcome back',
+      href: '/auth/azureadv2',
+      label: 'Sign in with Azure Active Directory',
+      formCount: 0,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('change-password authentication renders only the password recovery contract', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=true&mustChangePassword=true`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const form = root.querySelector('form') as HTMLFormElement | null
+      return {
+        title: root.querySelector('h1')?.textContent?.trim(),
+        action: form?.getAttribute('action'),
+        currentPassword: form?.querySelector('input[name="currentPassword"]')?.getAttribute('autocomplete'),
+        newPassword: form?.querySelector('input[name="newPassword"]')?.getAttribute('autocomplete'),
+        requirements: form?.querySelector('#new-password-requirements')?.textContent?.trim(),
+        submit: form?.querySelector('button[type="submit"]')?.textContent?.trim(),
+        providerCount: root.querySelectorAll('.provider').length,
+      }
+    })
+
+    expect(state).toEqual({
+      title: 'Set a new password',
+      action: '/auth/local/password',
+      currentPassword: 'current-password',
+      newPassword: 'new-password',
+      requirements: 'Use at least 12 characters.',
+      submit: 'Change password',
+      providerCount: 0,
+    })
+  } finally {
+    await page.close()
+  }
+})
+
+test('login errors stay visible in the local form contract', async () => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 820 } })
+  try {
+    await page.goto(`${baseURL}/?localAuth=true&ssoAuth=false&error=The%20email%20or%20password%20is%20incorrect.`)
+    await page.waitForFunction(() => customElements.get('lv-login-page'))
+    await page.locator('lv-login-page').evaluate((element: any) => element.updateComplete)
+
+    const state = await page.locator('lv-login-page').evaluate((element: any) => {
+      const root = element.shadowRoot
+      const error = root.querySelector('[role="alert"]') as HTMLElement | null
+      const form = root.querySelector('form') as HTMLFormElement | null
+      return {
+        title: root.querySelector('h1')?.textContent?.trim(),
+        error: error?.textContent?.trim(),
+        live: error?.getAttribute('aria-live'),
+        formAction: form?.getAttribute('action'),
+      }
+    })
+
+    expect(state).toEqual({
+      title: 'Welcome back',
+      error: 'The email or password is incorrect.',
+      live: 'assertive',
+      formAction: '/auth/local/login',
     })
   } finally {
     await page.close()
@@ -198,24 +484,36 @@ test('login theme toggle preserves an accessibility theme until the user changes
   }
 })
 
-function testDocument(): string {
+type TestDocumentOptions = {
+  localAuth?: boolean
+  ssoAuth?: boolean
+  mustChangePassword?: boolean
+  error?: string
+}
+
+function testDocument(options: TestDocumentOptions = {}): string {
   const page = {
     kind: 'login',
     title: 'LeapView',
+    localAuth: options.localAuth ?? false,
+    ssoAuth: options.ssoAuth ?? true,
+    mustChangePassword: options.mustChangePassword ?? false,
     providerLabel: 'Sign in with Azure Active Directory',
     backgroundModuleSrc: '/static/topology-background.js?v=dev',
   }
+  const status = { error: options.error ?? '' }
   return `
     <!doctype html>
     <html>
       <head>
+        <link rel="stylesheet" href="/static/app.css">
         <style>
           html, body { margin: 0; min-height: 100%; }
           body { ${typographyTestTokens} --lv-bg-app: #f6f8fa; --lv-bg-panel: #fff; --lv-bg-control: #f6f8fa; --lv-bg-control-hover: #f3f4f6; --lv-fg-default: #24292f; --lv-fg-muted: #57606a; --lv-accent: #0969da; --bgColor-accent-emphasis: #0969da; --bgColor-inverse: #0d1117; --lv-topology-bg: #0d1117; --lv-border-default: 1px solid #d0d7de; --lv-radius-default: 6px; --base-size-12: 12px; --base-size-16: 16px; --base-size-20: 20px; --base-size-24: 24px; --control-medium-size: 32px; --control-xlarge-size: 40px; --shadow-resting-small: 0 1px 2px rgb(0 0 0 / .08); }
         </style>
       </head>
       <body>
-        <main data-signals="${escapeHTML(JSON.stringify({ page }))}">
+        <main data-signals="${escapeHTML(JSON.stringify({ page, status }))}">
           <lv-login-page></lv-login-page>
         </main>
         <script type="module" src="/static/vendor/datastar-1.0.2.js?v=dev"></script>

--- a/web/components/login/login-page.ts
+++ b/web/components/login/login-page.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit'
-import { Monitor, Moon, Sun } from 'lucide'
+import { Eye, EyeOff, Monitor, Moon, Sun } from 'lucide'
+import { ifDefined } from 'lit/directives/if-defined.js'
 import type { DashboardStatus, LoginPageSignal } from '../../generated/signals'
 import { DatastarLit } from '../shared/datastar-lit'
 import { leapViewBrandName } from '../shared/brand-mark'
@@ -33,6 +34,7 @@ const themeLabels: Record<ThemePreference, string> = {
 }
 
 class LeapViewLoginPage extends DatastarLit(LitElement) {
+  private readonly revealedPasswords = new Set<string>()
   private themeMode: ThemePreference = currentThemeMode()
   private readonly handleThemeApplied = (event: Event) => {
     const detail = (event as CustomEvent<{ mode?: string }>).detail
@@ -41,19 +43,19 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
   }
 
   static styles = css`
-    :host {
+    :host { display: block; min-width: 0; }
+
+    .layout {
       position: relative;
       display: grid;
       width: 100%;
-      height: 100svh;
       min-height: 100svh;
       place-items: center;
-      place-content: center;
-      overflow: hidden;
+      overflow: clip;
       background: var(--lv-bg-app);
       color: var(--lv-fg-default);
       font-family: var(--fontStack-system);
-      padding: var(--base-size-24);
+      padding: var(--base-size-64) var(--base-size-24);
       box-sizing: border-box;
     }
 
@@ -76,8 +78,8 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
 
     .theme {
       position: absolute;
-      top: var(--base-size-16);
-      right: var(--base-size-16);
+      top: var(--base-size-24);
+      right: var(--base-size-24);
       z-index: var(--zIndex-modal, 30);
       display: inline-grid;
       width: var(--control-medium-size);
@@ -95,7 +97,8 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
     .theme:focus-visible {
       background: var(--lv-bg-control-hover);
       color: var(--lv-fg-default);
-      outline: 0;
+      outline: var(--focus-outline);
+      outline-offset: var(--base-size-4);
     }
 
     .theme [hidden] {
@@ -106,15 +109,16 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
       position: relative;
       z-index: var(--zIndex-modal, 30);
       display: grid;
-      width: min(100%, var(--lv-login-panel-width));
-      justify-items: center;
+      width: min(100%, calc(var(--lv-login-panel-width) + var(--base-size-32)));
+      align-self: center;
+      justify-items: stretch;
       gap: var(--base-size-20);
       border: var(--lv-border-default);
       border-radius: var(--lv-radius-default);
       background: var(--lv-bg-panel);
-      padding: var(--base-size-24);
-      text-align: center;
-      box-shadow: var(--shadow-resting-medium, var(--shadow-resting-small));
+      box-shadow: var(--shadow-resting-medium);
+      padding: var(--base-size-32);
+      text-align: left;
       box-sizing: border-box;
     }
 
@@ -125,13 +129,17 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
     }
 
     .brand-lockup {
+      position: absolute;
+      top: var(--base-size-24);
+      left: var(--base-size-24);
+      z-index: var(--zIndex-modal, 30);
       display: flex;
       align-items: center;
       gap: var(--base-size-12);
     }
 
     .brand-lockup lv-brand-mark {
-      --lv-brand-mark-size: var(--base-size-32);
+      --lv-brand-mark-size: calc(var(--base-size-32) + var(--base-size-4));
     }
 
     .provider {
@@ -214,6 +222,27 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
       outline-offset: var(--focus-outline-offset, var(--base-size-2));
     }
 
+    .password-field { display: grid; gap: var(--base-size-6); }
+    .password-control { position: relative; }
+    .password-control input { padding-right: var(--base-size-48); }
+    .password-toggle {
+      position: absolute;
+      inset-block: 0;
+      right: var(--base-size-2);
+      display: grid;
+      place-items: center;
+      width: var(--control-large-size);
+      padding: 0;
+      border: 0;
+      border-radius: var(--lv-radius-default);
+      background: transparent;
+      color: var(--lv-fg-muted);
+      cursor: pointer;
+    }
+    .password-toggle svg { width: var(--base-size-20); height: var(--base-size-20); }
+    .password-toggle:hover { color: var(--lv-fg-default); }
+    .password-toggle:focus-visible { outline: var(--focus-outline); outline-offset: var(--base-size-2); }
+
     .submit {
       display: inline-grid;
       min-height: var(--control-xlarge-size);
@@ -247,15 +276,19 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
       font: var(--lv-type-caption);
     }
 
-    @media (max-width: 520px) {
-      :host {
-        padding: var(--base-size-16);
-      }
-
-      .theme {
-        top: var(--base-size-12);
-        right: var(--base-size-12);
-      }
+    .brand-name { font: var(--lv-type-page-title); font-size: calc(var(--text-title-size-medium) * 1.1); }
+    .panel-heading { text-align: center; }
+    .panel-heading p { margin: var(--base-size-8) 0 0; color: var(--lv-fg-muted); font: var(--lv-type-body); }
+    .access-help { margin: 0; padding-top: var(--base-size-16); border-top: var(--lv-border-muted); color: var(--lv-fg-muted); font: var(--lv-type-caption); text-align: center; }
+    .submit:hover { background: var(--lv-button-accent-bg-hover); }
+    .submit:focus-visible { outline: var(--focus-outline); outline-offset: var(--base-size-4); }
+    .divider { display: flex; align-items: center; gap: var(--base-size-12); border: 0; color: var(--lv-fg-muted); font: var(--lv-type-caption); }
+    .divider::before, .divider::after { content: ''; flex: 1; border-top: var(--lv-border-muted); }
+    @media (max-height: 700px), (max-width: 520px) {
+      .layout { padding: var(--base-size-64) var(--base-size-16); }
+      .brand-lockup { top: var(--base-size-16); left: var(--base-size-16); }
+      .theme { top: var(--base-size-16); right: var(--base-size-16); }
+      .panel { padding: var(--base-size-24); gap: var(--base-size-16); }
     }
   `
 
@@ -290,11 +323,16 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
     const ssoAuth = page?.ssoAuth ?? true
     const mustChangePassword = page?.mustChangePassword ?? false
     return html`
+      <div class="layout">
       <lv-topology-background
         data-login-background
         data-module-src=${page?.backgroundModuleSrc ?? this.backgroundModuleSrc}
       ></lv-topology-background>
       <div class="scrim" aria-hidden="true"></div>
+        <header class="brand-lockup">
+          <lv-brand-mark aria-hidden="true"></lv-brand-mark>
+          <span class="brand-name">${page?.title ?? leapViewBrandName}</span>
+        </header>
       <button
         class="theme"
         type="button"
@@ -308,24 +346,19 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
         <span data-theme-icon="light" ?hidden=${!isLightTheme(this.themeMode)}>${lucideIcon(Sun)}</span>
         <span data-theme-icon="dark" ?hidden=${!isDarkTheme(this.themeMode)}>${lucideIcon(Moon)}</span>
       </button>
-      <section class="panel" aria-label="${leapViewBrandName} login">
-        <div class="brand-lockup">
-          <lv-brand-mark aria-hidden="true"></lv-brand-mark>
-          <h1>${page?.title ?? leapViewBrandName}</h1>
+      <section class="panel" aria-labelledby="login-heading">
+
+
+        <div class="panel-heading">
+          <h1 id="login-heading">${mustChangePassword ? 'Set a new password' : 'Welcome back'}</h1>
+          <p>${mustChangePassword ? 'Choose a new password to continue to your workspace.' : 'Sign in to your workspace.'}</p>
         </div>
         ${this.status.error ? html`<div class="error" role="alert" aria-live="assertive">${this.status.error}</div>` : ''}
         ${mustChangePassword ? html`
           <form method="post" action="/auth/local/password">
             <input type="hidden" name="gorilla.csrf.Token" value=${csrfToken()}>
-            <label>
-              Temporary password
-              <input name="currentPassword" type="password" autocomplete="current-password" maxlength="1024" required>
-            </label>
-            <label>
-              New password
-              <input name="newPassword" type="password" autocomplete="new-password" minlength="12" maxlength="1024" aria-describedby="new-password-requirements" required>
-              <span id="new-password-requirements" class="field-hint">Use at least 12 characters.</span>
-            </label>
+            ${this.passwordField('currentPassword', 'Temporary password')}
+            ${this.passwordField('newPassword', 'New password')}
             <button class="submit" type="submit">Change password</button>
           </form>
         ` : localAuth ? html`
@@ -333,23 +366,47 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
             <input type="hidden" name="gorilla.csrf.Token" value=${csrfToken()}>
             <label>
               Email
-              <input name="email" type="email" autocomplete="username" required>
+              <input name="email" type="email" autocomplete="username" placeholder="you@company.com" required>
             </label>
-            <label>
-              Password
-              <input name="password" type="password" autocomplete="current-password" required>
-            </label>
+            ${this.passwordField('password', 'Password')}
             <button class="submit" type="submit">Sign in</button>
           </form>
         ` : ''}
-        ${!mustChangePassword && localAuth && ssoAuth ? html`<div class="divider" aria-hidden="true"></div>` : ''}
+        ${!mustChangePassword && localAuth && ssoAuth ? html`<div class="divider" aria-hidden="true">or</div>` : ''}
         ${!mustChangePassword && ssoAuth ? html`
           <a class="provider" href="/auth/azureadv2">
             <span class="provider-mark" aria-hidden="true"><span></span><span></span><span></span><span></span></span>
             <span>${page?.providerLabel ?? 'Sign in with Azure Active Directory'}</span>
           </a>
         ` : ''}
-      </section>
+        <p class="access-help">Need access? Contact your workspace administrator.</p>
+        </section>
+      </div>
+    `
+  }
+
+  private passwordField(name: 'password' | 'currentPassword' | 'newPassword', label: string) {
+    const visible = this.revealedPasswords.has(name)
+    const id = `login-${name}`
+    const action = `${visible ? 'Hide' : 'Show'} ${label.toLowerCase()}`
+    return html`
+      <div class="password-field">
+        <label for=${id}>${label}</label>
+        <div class="password-control">
+          <input id=${id} name=${name} type=${visible ? 'text' : 'password'}
+            autocomplete=${name === 'newPassword' ? 'new-password' : 'current-password'}
+            minlength=${ifDefined(name === 'newPassword' ? 12 : undefined)}
+            maxlength=${ifDefined(name === 'password' ? undefined : 1024)}
+            aria-describedby=${ifDefined(name === 'newPassword' ? 'new-password-requirements' : undefined)} required>
+          <button class="password-toggle" type="button" aria-label=${action} title=${action} aria-controls=${id}
+            @click=${() => {
+              if (visible) this.revealedPasswords.delete(name)
+              else this.revealedPasswords.add(name)
+              this.requestUpdate()
+            }}>${lucideIcon(visible ? EyeOff : Eye)}</button>
+        </div>
+        ${name === 'newPassword' ? html`<span id="new-password-requirements" class="field-hint">Use at least 12 characters.</span>` : ''}
+      </div>
     `
   }
 

--- a/web/components/login/login-page.ts
+++ b/web/components/login/login-page.ts
@@ -351,7 +351,7 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
 
         <div class="panel-heading">
           <h1 id="login-heading">${mustChangePassword ? 'Set a new password' : 'Welcome back'}</h1>
-          <p>${mustChangePassword ? 'Choose a new password to continue to your workspace.' : 'Sign in to your workspace.'}</p>
+          <p>${mustChangePassword ? 'Choose a new password to continue.' : 'Sign in to LeapView.'}</p>
         </div>
         ${this.status.error ? html`<div class="error" role="alert" aria-live="assertive">${this.status.error}</div>` : ''}
         ${mustChangePassword ? html`
@@ -379,7 +379,7 @@ class LeapViewLoginPage extends DatastarLit(LitElement) {
             <span>${page?.providerLabel ?? 'Sign in with Azure Active Directory'}</span>
           </a>
         ` : ''}
-        <p class="access-help">Need access? Contact your workspace administrator.</p>
+        <p class="access-help">Need access? Contact your administrator.</p>
         </section>
       </div>
     `

--- a/web/components/login/topology-background.dom.test.ts
+++ b/web/components/login/topology-background.dom.test.ts
@@ -66,6 +66,10 @@ test('topology background renders and animates without external requests', async
     })
 
     const firstFrame = await canvasDataURL(page)
+    await page.waitForTimeout(300)
+    const animatedFrame = await canvasDataURL(page)
+    expect(animatedFrame).not.toBe(firstFrame)
+
     await page.setViewportSize({ width: 900, height: 600 })
     await page.waitForTimeout(150)
     const secondFrame = await canvasDataURL(page)


### PR DESCRIPTION
The login page now has a focused, centred form and larger LeapView branding in the top-left corner. Eye buttons let users show or hide each password independently without clearing input or submitting the form.

- Preserve native local login, SSO, password-change actions, CSRF fields, and autocomplete.
- Keep the original animated background and theme controls; the logo and wordmark follow light, dark, and system themes.
- Keep copy minimal and use administrator guidance for access.
- Cover keyboard navigation, viewport fit, logo placement, password visibility, and same-viewport animation frames. Error fixtures use a fixed error code rather than free-form query text.

Validation: all hosted frontend shards, cross-language quality, and security checks pass on the updated commit. Locally, 13 login DOM tests, the dashboard-page test command (82 tests), and the retired-terminology architecture check pass. Previously verified the frontend build, application typecheck, Primer alignment, and topology animation test. All required PR and merge-queue gates passed, including full merge validation and both security workflows. The reports job passed on a targeted rerun after a browser navigation interruption. The redundant full local run was stopped after hosted merge validation succeeded; no full local CI pass is claimed.
