### PR TITLE
feat(release): add postgres transition preflight evaluation

### DIFF
--- a/docs/articles/operate/upgrades.md
+++ b/docs/articles/operate/upgrades.md
@@ -57,6 +57,46 @@ not perform image upgrades or paired state rollback.
 
 Do not run two application versions against shared writable state unless the release explicitly declares mixed-version compatibility.
 
+### PostgreSQL-era transition preflight
+
+FAI-518 defines the transition boundary for a PostgreSQL-era predecessor and
+candidate. The pure preflight consumes exact immutable OCI artifact identities,
+the PostgreSQL control-schema projection, Goose ownership, River's upstream
+operational-schema and LeapView-owned job-history projections, the exact
+five-field DuckLake compatibility tuple, the release policy, and a mandatory
+recovery frontier reference. The frontier anchors the transition phases even
+when the decision permits binary rollback. A predecessor from the older
+SQLite-era architecture is outside this boundary and is unsupported. Admission
+and recovery references are owner-produced projections; this library does not
+query them live.
+
+The evaluator emits exactly one decision:
+
+- `binary-rollback-compatible` means every persistent domain is explicitly
+  backward compatible and the matching release policy permits returning to the
+  predecessor artifact through the deployment platform.
+- `provider-recovery-required` means at least one persistent domain is
+  explicitly incompatible, and a matching provider-recovery policy and valid
+  recovery frontier reference are present. Restore mutually consistent
+  PostgreSQL and DuckLake/object-provider state before starting the predecessor.
+- `unsupported` means the evidence is incomplete, unknown, ambiguous, has
+  mismatched ownership or policy metadata, or otherwise cannot prove either
+  path safely.
+
+This FAI-518 preflight is the eligibility boundary for the later FAI-519
+transition execution work. It is pure and read-only: it does not inspect live
+PostgreSQL, run Goose or River migrations, contact a provider, acquire a
+fence, select an image, or mutate persistent state. FAI-519 must revalidate the
+same immutable evidence at its execution boundary.
+
+The DuckLake compatibility value is the owner-produced verdict over the exact
+predecessor and candidate tuples recorded in the evidence. The preflight does
+not infer cross-version safety from tuple equality. A binary policy also binds
+the explicit candidate-to-predecessor rollback direction; authorizing only the
+forward pair is insufficient.
+
+This validates transition eligibility. It does not prove successful upgrade, rollback, or disaster recovery.
+
 ### Catalog compatibility boundary
 
 Production upgrades operate only on an admitted PostgreSQL-backed DuckLake

--- a/internal/release/transitionpreflight/contract_test.go
+++ b/internal/release/transitionpreflight/contract_test.go
@@ -1,0 +1,419 @@
+package transitionpreflight
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/analytics/physicalpool"
+	"github.com/flidai/leapview/internal/platform/compatibility"
+)
+
+func TestEvaluateDecisionMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Input)
+		want   Decision
+		reason ReasonCode
+	}{
+		{name: "all persistent domains backward compatible", want: DecisionBinaryRollbackCompatible},
+		{name: "control incompatibility requires provider recovery", mutate: func(input *Input) {
+			input.Control.Compatibility = CompatibilityIncompatible
+		}, want: DecisionProviderRecoveryRequired, reason: ReasonControlIncompatible},
+		{name: "river schema incompatibility requires provider recovery", mutate: func(input *Input) {
+			input.River.SchemaCompatibility = CompatibilityIncompatible
+		}, want: DecisionProviderRecoveryRequired, reason: ReasonRiverIncompatible},
+		{name: "river job history incompatibility requires provider recovery", mutate: func(input *Input) {
+			input.River.JobHistoryCompatibility = CompatibilityIncompatible
+		}, want: DecisionProviderRecoveryRequired, reason: ReasonRiverIncompatible},
+		{name: "ducklake incompatibility requires provider recovery", mutate: func(input *Input) {
+			input.DuckLake.Compatibility = CompatibilityIncompatible
+		}, want: DecisionProviderRecoveryRequired, reason: ReasonDuckLakeIncompatible},
+		{name: "legacy predecessor is unsupported", mutate: func(input *Input) {
+			input.Predecessor.ArchitectureMarker = "sqlite"
+		}, want: DecisionUnsupported, reason: ReasonPredecessorNotPostgreSQL},
+		{name: "missing recovery frontier is unsupported", mutate: func(input *Input) {
+			input.Control.Compatibility = CompatibilityIncompatible
+			input.RecoveryFrontier = nil
+		}, want: DecisionUnsupported, reason: ReasonMissingRecoveryFrontier},
+		{name: "missing recovery frontier rejects binary decision too", mutate: func(input *Input) {
+			input.RecoveryFrontier = nil
+		}, want: DecisionUnsupported, reason: ReasonMissingRecoveryFrontier},
+		{name: "missing migration ownership is unsupported", mutate: func(input *Input) {
+			input.MigrationOwnership = MigrationOwnership{}
+		}, want: DecisionUnsupported, reason: ReasonMissingMigrationOwnership},
+		{name: "wrong Goose ownership is unsupported", mutate: func(input *Input) {
+			input.MigrationOwnership.GooseControlSchemaOwner = OwnerRiver
+		}, want: DecisionUnsupported, reason: ReasonGooseOwnershipMismatch},
+		{name: "unknown compatibility is unsupported", mutate: func(input *Input) {
+			input.DuckLake.Compatibility = CompatibilityUnknown
+		}, want: DecisionUnsupported, reason: ReasonUnknownDuckLakeCompatibility},
+		{name: "conflicting policy metadata is unsupported", mutate: func(input *Input) {
+			input.Control.Compatibility = CompatibilityIncompatible
+			input.ReleasePolicy.Rules[0].Decision = DecisionBinaryRollbackCompatible
+		}, want: DecisionUnsupported, reason: ReasonPolicyMismatch},
+		{name: "ambiguous matching policy is unsupported", mutate: func(input *Input) {
+			input.ReleasePolicy.Rules = append(input.ReleasePolicy.Rules, input.ReleasePolicy.Rules[0])
+		}, want: DecisionUnsupported, reason: ReasonMultiplePolicyRules},
+		{name: "forward-only policy is unsupported", mutate: func(input *Input) {
+			input.ReleasePolicy.Rules[0].RollbackToArtifactDigest = input.ReleasePolicy.Rules[0].CandidateArtifactDigest
+		}, want: DecisionUnsupported, reason: ReasonPolicyMismatch},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := testInput()
+			if test.mutate != nil {
+				test.mutate(&input)
+			}
+			if test.want == DecisionProviderRecoveryRequired {
+				input.ReleasePolicy.Rules[0].Decision = DecisionProviderRecoveryRequired
+				input.ReleasePolicy.Digest, _ = input.ReleasePolicy.ContentDigest()
+			}
+			evidence, err := Evaluate(input)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if evidence.Decision != test.want {
+				t.Fatalf("decision = %q, want %q; evidence = %#v", evidence.Decision, test.want, evidence)
+			}
+			if test.reason != "" && !containsReason(evidence.ReasonCodes, test.reason) {
+				t.Fatalf("reason codes = %v, want %q", evidence.ReasonCodes, test.reason)
+			}
+			if !sort.SliceIsSorted(evidence.ReasonCodes, func(i, j int) bool { return evidence.ReasonCodes[i] < evidence.ReasonCodes[j] }) {
+				t.Fatalf("reason codes are not sorted: %v", evidence.ReasonCodes)
+			}
+		})
+	}
+}
+
+func TestEvaluateRejectsStructurallyMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	input := testInput()
+	input.SchemaVersion = 0
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("missing schema version error = %v, want ErrInvalidInput", err)
+	}
+
+	input = testInput()
+	input.Candidate.Release.Image = "ghcr.io/flidai/leapview:latest"
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("invalid OCI image error = %v, want ErrInvalidInput", err)
+	}
+
+	input = testInput()
+	input.Candidate.Release.Image = input.Predecessor.Release.Image
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("same artifact error = %v, want ErrInvalidInput", err)
+	}
+
+	input = testInput()
+	input.RecoveryFrontier = &RecoveryFrontierRef{SetID: "not-a-uuid", Digest: "sha256:" + strings.Repeat("a", 64)}
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("invalid frontier error = %v, want ErrInvalidInput", err)
+	}
+
+	input = testInput()
+	input.Candidate.Release.ReleaseID = string([]byte{0xff})
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("invalid UTF-8 error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestEvaluateIsOrderIndependentAndDigestChangesOnMutation(t *testing.T) {
+	t.Parallel()
+
+	first := testInput()
+	second := testInput()
+	predecessorDigest, err := first.Predecessor.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateDigest, err := first.Candidate.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.ReleasePolicy.Rules = []ReleasePolicyRule{
+		first.ReleasePolicy.Rules[0],
+		{PredecessorArtifactDigest: candidateDigest, CandidateArtifactDigest: predecessorDigest, RollbackFromArtifactDigest: predecessorDigest, RollbackToArtifactDigest: candidateDigest, Decision: DecisionProviderRecoveryRequired},
+	}
+	first.ReleasePolicy.Digest, _ = first.ReleasePolicy.ContentDigest()
+	second.ReleasePolicy.Rules = []ReleasePolicyRule{
+		{PredecessorArtifactDigest: candidateDigest, CandidateArtifactDigest: predecessorDigest, RollbackFromArtifactDigest: predecessorDigest, RollbackToArtifactDigest: candidateDigest, Decision: DecisionProviderRecoveryRequired},
+		first.ReleasePolicy.Rules[0],
+	}
+	second.ReleasePolicy.Digest, _ = second.ReleasePolicy.ContentDigest()
+	left, err := Evaluate(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := Evaluate(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftJSON, err := left.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightJSON, err := right.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftDigest, err := left.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightDigest, err := right.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(leftJSON, rightJSON) || leftDigest != rightDigest {
+		t.Fatalf("reordered policy changed canonical identity:\n%s\n%s\n%s\n%s", leftJSON, rightJSON, leftDigest, rightDigest)
+	}
+
+	mutatedInput := testInput()
+	mutatedInput.Control.CandidateSchemaVersion = "control/v2"
+	mutated, err := Evaluate(mutatedInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutatedDigest, err := mutated.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutatedDigest == leftDigest {
+		t.Fatal("mutating evidence did not change digest")
+	}
+}
+
+func TestPhaseIdentitiesAreFixedOrderedAndDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := PhaseNames()
+	if len(first.PhaseIdentities) != len(wantNames) {
+		t.Fatalf("phase count = %d, want %d", len(first.PhaseIdentities), len(wantNames))
+	}
+	for i, phase := range first.PhaseIdentities {
+		if phase.Phase != wantNames[i] {
+			t.Fatalf("phase %d = %q, want %q", i, phase.Phase, wantNames[i])
+		}
+		if phase.Digest != second.PhaseIdentities[i].Digest || !strings.HasPrefix(phase.Digest, "sha256:") {
+			t.Fatalf("phase %q is not deterministic SHA-256 identity: %#v / %#v", phase.Phase, phase, second.PhaseIdentities[i])
+		}
+	}
+}
+
+func TestEvidenceValidationRecomputesDecisionReasonsAndPhaseIdentities(t *testing.T) {
+	t.Parallel()
+
+	evidence, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*Evidence){
+		func(value *Evidence) { value.Decision = DecisionUnsupported },
+		func(value *Evidence) { value.ReasonCodes = append(value.ReasonCodes, ReasonPolicyMismatch) },
+		func(value *Evidence) { value.PhaseIdentities[0].Digest = "sha256:" + strings.Repeat("f", 64) },
+		func(value *Evidence) { value.ReleasePolicy.Digest = "sha256:" + strings.Repeat("f", 64) },
+	}
+	for i, mutate := range mutations {
+		mutated := evidence
+		mutate(&mutated)
+		if err := mutated.Validate(); err == nil {
+			t.Fatalf("mutation %d was accepted", i)
+		}
+	}
+}
+
+func TestTargetBindingAndPolicyBindCompleteArtifacts(t *testing.T) {
+	t.Parallel()
+
+	input := testInput()
+	input.Control.TargetIdentityDigest = "sha256:" + strings.Repeat("0", 64)
+	evidence, err := Evaluate(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != DecisionUnsupported || !containsReason(evidence.ReasonCodes, ReasonTargetIdentityMismatch) {
+		t.Fatalf("cross-target projection was accepted: decision=%q reasons=%v", evidence.Decision, evidence.ReasonCodes)
+	}
+
+	input = testInput()
+	input.Candidate.Release.Version = "1.1.1"
+	evidence, err = Evaluate(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != DecisionUnsupported || !containsReason(evidence.ReasonCodes, ReasonPolicyMismatch) {
+		t.Fatalf("artifact metadata substitution was accepted: decision=%q reasons=%v", evidence.Decision, evidence.ReasonCodes)
+	}
+
+	input = testInput()
+	input.ReleasePolicy.Digest = "sha256:" + strings.Repeat("0", 64)
+	evidence, err = Evaluate(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != DecisionUnsupported || !containsReason(evidence.ReasonCodes, ReasonReleasePolicyDigestMismatch) {
+		t.Fatalf("policy digest mismatch was accepted: decision=%q reasons=%v", evidence.Decision, evidence.ReasonCodes)
+	}
+}
+
+func TestDuckLakeVerdictBindsBothExactTuples(t *testing.T) {
+	t.Parallel()
+
+	baseline, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedInput := testInput()
+	changedInput.DuckLake.Candidate.DuckDBRuntime = "duckdb:1.6.0"
+	changed, err := Evaluate(changedInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Decision != DecisionBinaryRollbackCompatible {
+		t.Fatalf("owner-qualified cross-version tuple decision = %q", changed.Decision)
+	}
+	baselineDigest, err := baseline.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedDigest, err := changed.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedDigest == baselineDigest {
+		t.Fatal("DuckLake tuple change was not bound into evidence")
+	}
+}
+
+func TestParseEvidenceIsStrictAndRevalidates(t *testing.T) {
+	t.Parallel()
+
+	evidence, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := evidence.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseEvidence(canonical); err != nil {
+		t.Fatalf("canonical evidence did not parse: %v", err)
+	}
+	text := string(canonical)
+	unknown := strings.TrimSuffix(text, "}") + ",\"unknown\":1}"
+	if _, err := ParseEvidence([]byte(unknown)); err == nil {
+		t.Fatal("unknown evidence field was accepted")
+	}
+	duplicate := strings.Replace(text, "{\"schemaVersion\":1,", "{\"schemaVersion\":1,\"schemaVersion\":1,", 1)
+	if _, err := ParseEvidence([]byte(duplicate)); err == nil {
+		t.Fatal("duplicate evidence field was accepted")
+	}
+	if _, err := ParseEvidence(append(append([]byte{}, canonical...), []byte(" {}")...)); err == nil {
+		t.Fatal("trailing evidence value was accepted")
+	}
+}
+
+func TestCanonicalGoldenVector(t *testing.T) {
+	t.Parallel()
+
+	evidence, err := Evaluate(testInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := evidence.CanonicalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := evidence.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtureBytes, err := os.ReadFile("testdata/golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		EvidenceDigest string   `json:"evidenceDigest"`
+		PolicyDigest   string   `json:"policyDigest"`
+		PhaseDigests   []string `json:"phaseDigests"`
+	}
+	if err := json.Unmarshal(fixtureBytes, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if len(canonical) == 0 || digest != fixture.EvidenceDigest || evidence.ReleasePolicy.Digest != fixture.PolicyDigest {
+		t.Fatalf("golden mismatch:\ncanonical = %s\nevidence digest = %s\npolicy digest = %s\nfixture = %#v", canonical, digest, evidence.ReleasePolicy.Digest, fixture)
+	}
+	if len(fixture.PhaseDigests) != len(evidence.PhaseIdentities) {
+		t.Fatalf("golden phase count = %d, want %d", len(fixture.PhaseDigests), len(evidence.PhaseIdentities))
+	}
+	for i, phase := range evidence.PhaseIdentities {
+		if phase.Digest != fixture.PhaseDigests[i] {
+			t.Fatalf("golden phase %q digest = %s, want %s", phase.Phase, phase.Digest, fixture.PhaseDigests[i])
+		}
+	}
+}
+
+func testInput() Input {
+	predecessorImage := "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("a", 64)
+	candidateImage := "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("b", 64)
+	tuples := physicalpool.Compatibility{
+		DuckDBRuntime:         "duckdb:1.5.4",
+		DuckLakeExtension:     "ducklake:0.3.0",
+		CatalogFormat:         "ducklake-catalog:v1",
+		StorageImplementation: "s3",
+		ObjectNamingContract:  "uuidv7:v1",
+	}
+	predecessor := ArtifactIdentity{Release: compatibility.ReleaseIdentity{
+		ReleaseID: "v1.0.0", Version: "1.0.0", SourceRevision: strings.Repeat("1", 40),
+		Image: predecessorImage, Distribution: "public", Platform: "linux/amd64",
+	}, ArchitectureMarker: ArchitecturePostgreSQL, ArtifactAdmissionDigest: "sha256:" + strings.Repeat("d", 64)}
+	candidate := ArtifactIdentity{Release: compatibility.ReleaseIdentity{
+		ReleaseID: "v1.1.0", Version: "1.1.0", SourceRevision: strings.Repeat("2", 40),
+		Image: candidateImage, Distribution: "public", Platform: "linux/amd64",
+	}, ArchitectureMarker: ArchitecturePostgreSQL, ArtifactAdmissionDigest: "sha256:" + strings.Repeat("e", 64)}
+	predecessorDigest, _ := predecessor.Digest()
+	candidateDigest, _ := candidate.Digest()
+	targetDigest := "sha256:" + strings.Repeat("f", 64)
+	policy := ReleasePolicy{Version: "release-policy/v1", Rules: []ReleasePolicyRule{{PredecessorArtifactDigest: predecessorDigest, CandidateArtifactDigest: candidateDigest, RollbackFromArtifactDigest: candidateDigest, RollbackToArtifactDigest: predecessorDigest, Decision: DecisionBinaryRollbackCompatible}}}
+	policy.Digest, _ = policy.ContentDigest()
+	return Input{
+		SchemaVersion: 1, TargetIdentityDigest: targetDigest,
+		Predecessor: predecessor, Candidate: candidate,
+		MigrationOwnership: MigrationOwnership{
+			GooseControlSchemaOwner: OwnerLeapView, RiverOperationalSchemaOwner: OwnerRiver, RiverJobHistoryOwner: OwnerLeapView,
+		},
+		Control:          PostgreSQLControlProjection{Compatibility: CompatibilityBackwardCompatible, PredecessorSchemaVersion: "goose/v1", CandidateSchemaVersion: "goose/v2", TargetIdentityDigest: targetDigest},
+		River:            RiverJobProjection{SchemaCompatibility: CompatibilityBackwardCompatible, JobHistoryCompatibility: CompatibilityBackwardCompatible, ExistingSchemaVersion: "river/v1", RequiredSchemaVersion: "river/v2", ExistingJobHistoryVersion: "jobs/v1", RequiredJobHistoryVersion: "jobs/v2", TargetIdentityDigest: targetDigest},
+		DuckLake:         DuckLakeProjection{Compatibility: CompatibilityBackwardCompatible, Predecessor: tuples, Candidate: tuples, TargetIdentityDigest: targetDigest},
+		RecoveryFrontier: &RecoveryFrontierRef{SetID: "018f3f83-7b2f-7b37-9f9e-000000000010", Digest: "sha256:" + strings.Repeat("c", 64), TargetIdentityDigest: targetDigest},
+		ReleasePolicy:    policy,
+	}
+}
+
+func containsReason(reasons []ReasonCode, want ReasonCode) bool {
+	for _, reason := range reasons {
+		if reason == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/release/transitionpreflight/contract_test.go
+++ b/internal/release/transitionpreflight/contract_test.go
@@ -3,6 +3,7 @@ package transitionpreflight
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"sort"
@@ -125,6 +126,125 @@ func TestEvaluateRejectsStructurallyMalformedInput(t *testing.T) {
 	input.Candidate.Release.ReleaseID = string([]byte{0xff})
 	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("invalid UTF-8 error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestReleasePolicyVersionGate(t *testing.T) {
+	t.Parallel()
+
+	for _, version := range []string{"release-policy/v2", "release-policy/v999", "release-policy/future"} {
+		input := testInput()
+		input.ReleasePolicy.Version = version
+		if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("version %q error = %v, want ErrInvalidInput", version, err)
+		}
+	}
+
+	// An empty policy remains a valid, explicitly missing policy so the
+	// evaluator preserves its existing unsupported evidence behavior.
+	input := testInput()
+	input.ReleasePolicy = ReleasePolicy{}
+	evidence, err := Evaluate(input)
+	if err != nil {
+		t.Fatalf("missing policy error = %v", err)
+	}
+	if evidence.Decision != DecisionUnsupported || !containsReason(evidence.ReasonCodes, ReasonMissingReleasePolicy) {
+		t.Fatalf("missing policy result = decision %q reasons %v", evidence.Decision, evidence.ReasonCodes)
+	}
+}
+
+func TestEvaluateRejectsOversizedPreflightFields(t *testing.T) {
+	t.Parallel()
+
+	for _, mutate := range []func(*Input){
+		func(input *Input) {
+			input.Control.PredecessorSchemaVersion = strings.Repeat("s", MaxSchemaVersionBytes+1)
+		},
+		func(input *Input) {
+			input.Control.CandidateSchemaVersion = strings.Repeat("s", MaxSchemaVersionBytes+1)
+		},
+		func(input *Input) { input.River.ExistingSchemaVersion = strings.Repeat("s", MaxSchemaVersionBytes+1) },
+		func(input *Input) { input.River.RequiredSchemaVersion = strings.Repeat("s", MaxSchemaVersionBytes+1) },
+		func(input *Input) {
+			input.River.ExistingJobHistoryVersion = strings.Repeat("s", MaxSchemaVersionBytes+1)
+		},
+		func(input *Input) {
+			input.River.RequiredJobHistoryVersion = strings.Repeat("s", MaxSchemaVersionBytes+1)
+		},
+		func(input *Input) { input.ReleasePolicy.Rules = make([]ReleasePolicyRule, MaxReleasePolicyRules+1) },
+		func(input *Input) {
+			input.ReleasePolicy.Rules[0].Decision = Decision(strings.Repeat("d", MaxReleasePolicyDecisionBytes+1))
+		},
+	} {
+		input := testInput()
+		mutate(&input)
+		if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("oversized input error = %v, want ErrInvalidInput", err)
+		}
+	}
+}
+
+func TestEvaluateRejectsCanonicalEvidenceOverLimit(t *testing.T) {
+	t.Parallel()
+
+	input := testInput()
+	// physicalpool compatibility strings are valid opaque owner values, so the
+	// producer-wide evidence bound must protect this otherwise valid input.
+	input.DuckLake.Predecessor.DuckDBRuntime = strings.Repeat("d", MaxCanonicalEvidenceBytes)
+	if _, err := Evaluate(input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("oversized canonical evidence error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestMaximumAcceptedCanonicalEvidenceRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	input := testInput()
+	maxSchemaVersion := strings.Repeat("s", MaxSchemaVersionBytes)
+	input.Control.PredecessorSchemaVersion = maxSchemaVersion
+	input.Control.CandidateSchemaVersion = maxSchemaVersion
+	input.River.ExistingSchemaVersion = maxSchemaVersion
+	input.River.RequiredSchemaVersion = maxSchemaVersion
+	input.River.ExistingJobHistoryVersion = maxSchemaVersion
+	input.River.RequiredJobHistoryVersion = maxSchemaVersion
+
+	rules := make([]ReleasePolicyRule, 0, MaxReleasePolicyRules)
+	rules = append(rules, input.ReleasePolicy.Rules[0])
+	for i := 1; i < MaxReleasePolicyRules; i++ {
+		predecessor := fmt.Sprintf("sha256:%064x", i)
+		candidate := fmt.Sprintf("sha256:%064x", i+MaxReleasePolicyRules)
+		rules = append(rules, ReleasePolicyRule{
+			PredecessorArtifactDigest:  predecessor,
+			CandidateArtifactDigest:    candidate,
+			RollbackFromArtifactDigest: candidate,
+			RollbackToArtifactDigest:   predecessor,
+			Decision:                   Decision(strings.Repeat("d", MaxReleasePolicyDecisionBytes)),
+		})
+	}
+	input.ReleasePolicy.Rules = rules
+	input.ReleasePolicy.Digest, _ = input.ReleasePolicy.ContentDigest()
+
+	evidence, err := Evaluate(input)
+	if err != nil {
+		t.Fatalf("maximum accepted Evaluate() error = %v", err)
+	}
+	canonical, err := evidence.CanonicalJSON()
+	if err != nil {
+		t.Fatalf("maximum accepted CanonicalJSON() error = %v", err)
+	}
+	if len(canonical) > MaxCanonicalEvidenceBytes {
+		t.Fatalf("canonical evidence size = %d, want <= %d", len(canonical), MaxCanonicalEvidenceBytes)
+	}
+	parsed, err := ParseEvidence(canonical)
+	if err != nil {
+		t.Fatalf("maximum accepted canonical evidence did not parse: %v", err)
+	}
+	parsedCanonical, err := parsed.CanonicalJSON()
+	if err != nil {
+		t.Fatalf("parsed maximum accepted CanonicalJSON() error = %v", err)
+	}
+	if !reflect.DeepEqual(canonical, parsedCanonical) {
+		t.Fatalf("maximum accepted evidence was not canonical after round trip:\n%s\n%s", canonical, parsedCanonical)
 	}
 }
 
@@ -393,7 +513,7 @@ func testInput() Input {
 	predecessorDigest, _ := predecessor.Digest()
 	candidateDigest, _ := candidate.Digest()
 	targetDigest := "sha256:" + strings.Repeat("f", 64)
-	policy := ReleasePolicy{Version: "release-policy/v1", Rules: []ReleasePolicyRule{{PredecessorArtifactDigest: predecessorDigest, CandidateArtifactDigest: candidateDigest, RollbackFromArtifactDigest: candidateDigest, RollbackToArtifactDigest: predecessorDigest, Decision: DecisionBinaryRollbackCompatible}}}
+	policy := ReleasePolicy{Version: ReleasePolicyVersion, Rules: []ReleasePolicyRule{{PredecessorArtifactDigest: predecessorDigest, CandidateArtifactDigest: candidateDigest, RollbackFromArtifactDigest: candidateDigest, RollbackToArtifactDigest: predecessorDigest, Decision: DecisionBinaryRollbackCompatible}}}
 	policy.Digest, _ = policy.ContentDigest()
 	return Input{
 		SchemaVersion: 1, TargetIdentityDigest: targetDigest,

--- a/internal/release/transitionpreflight/evidence.go
+++ b/internal/release/transitionpreflight/evidence.go
@@ -75,13 +75,31 @@ func (e Evidence) Normalize() (Evidence, error) {
 	if err != nil {
 		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
 	}
-	e.Control.PredecessorSchemaVersion = normalizeText(e.Control.PredecessorSchemaVersion)
-	e.Control.CandidateSchemaVersion = normalizeText(e.Control.CandidateSchemaVersion)
+	e.Control.PredecessorSchemaVersion, err = normalizeSchemaVersion(e.Control.PredecessorSchemaVersion, "control.predecessorSchemaVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	e.Control.CandidateSchemaVersion, err = normalizeSchemaVersion(e.Control.CandidateSchemaVersion, "control.candidateSchemaVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
 	e.Control.TargetIdentityDigest = normalizeText(e.Control.TargetIdentityDigest)
-	e.River.ExistingSchemaVersion = normalizeText(e.River.ExistingSchemaVersion)
-	e.River.RequiredSchemaVersion = normalizeText(e.River.RequiredSchemaVersion)
-	e.River.ExistingJobHistoryVersion = normalizeText(e.River.ExistingJobHistoryVersion)
-	e.River.RequiredJobHistoryVersion = normalizeText(e.River.RequiredJobHistoryVersion)
+	e.River.ExistingSchemaVersion, err = normalizeSchemaVersion(e.River.ExistingSchemaVersion, "river.existingSchemaVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	e.River.RequiredSchemaVersion, err = normalizeSchemaVersion(e.River.RequiredSchemaVersion, "river.requiredSchemaVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	e.River.ExistingJobHistoryVersion, err = normalizeSchemaVersion(e.River.ExistingJobHistoryVersion, "river.existingJobHistoryVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	e.River.RequiredJobHistoryVersion, err = normalizeSchemaVersion(e.River.RequiredJobHistoryVersion, "river.requiredJobHistoryVersion")
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
 	e.River.TargetIdentityDigest = normalizeText(e.River.TargetIdentityDigest)
 	e.DuckLake.TargetIdentityDigest = normalizeText(e.DuckLake.TargetIdentityDigest)
 	for field, value := range map[string]string{
@@ -199,7 +217,11 @@ func (e Evidence) CanonicalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(normalized)
+	encoded, err := marshalEvidence(normalized)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidEvidence, err)
+	}
+	return encoded, nil
 }
 
 // CanonicalBytes is a convenience alias for CanonicalJSON.

--- a/internal/release/transitionpreflight/evidence.go
+++ b/internal/release/transitionpreflight/evidence.go
@@ -1,0 +1,219 @@
+package transitionpreflight
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/flidai/leapview/internal/analytics/physicalpool"
+	platformdigest "github.com/flidai/leapview/internal/platform/digest"
+)
+
+type phaseMaterial struct {
+	SchemaVersion        int                         `json:"schemaVersion"`
+	TargetIdentityDigest string                      `json:"targetIdentityDigest"`
+	Phase                string                      `json:"phase"`
+	Predecessor          ArtifactIdentity            `json:"predecessor"`
+	Candidate            ArtifactIdentity            `json:"candidate"`
+	Decision             Decision                    `json:"decision"`
+	ReasonCodes          []ReasonCode                `json:"reasonCodes"`
+	MigrationOwnership   MigrationOwnership          `json:"migrationOwnership"`
+	Control              PostgreSQLControlProjection `json:"control"`
+	River                RiverJobProjection          `json:"river"`
+	DuckLake             DuckLakeProjection          `json:"ducklake"`
+	RecoveryFrontier     *RecoveryFrontierRef        `json:"recoveryFrontier"`
+	ReleasePolicy        ReleasePolicy               `json:"releasePolicy"`
+}
+
+func phaseIdentities(input Input, decision Decision, reasons []ReasonCode) ([]PhaseIdentity, error) {
+	identities := make([]PhaseIdentity, 0, len(phaseOrder))
+	for _, phase := range phaseOrder {
+		material := phaseMaterial{
+			SchemaVersion: input.SchemaVersion, TargetIdentityDigest: input.TargetIdentityDigest, Phase: phase,
+			Predecessor: input.Predecessor, Candidate: input.Candidate,
+			Decision: decision, ReasonCodes: append([]ReasonCode{}, reasons...),
+			MigrationOwnership: input.MigrationOwnership, Control: input.Control,
+			River: input.River, DuckLake: input.DuckLake,
+			RecoveryFrontier: cloneFrontier(input.RecoveryFrontier), ReleasePolicy: input.ReleasePolicy,
+		}
+		encoded, err := json.Marshal(material)
+		if err != nil {
+			return nil, fmt.Errorf("encode %s phase identity: %w", phase, err)
+		}
+		hash := sha256.Sum256([]byte(DigestDomain + "phase/" + phase + "\n" + string(encoded)))
+		identities = append(identities, PhaseIdentity{Phase: phase, Digest: "sha256:" + hex.EncodeToString(hash[:])})
+	}
+	return identities, nil
+}
+
+// Normalize returns a validated, deterministic evidence copy. It re-evaluates
+// the decision, reasons, and phase identities so a structurally valid but
+// inconsistent persisted document still fails closed.
+func (e Evidence) Normalize() (Evidence, error) {
+	if e.SchemaVersion != SchemaVersion {
+		return Evidence{}, fmt.Errorf("%w: schemaVersion", ErrInvalidEvidence)
+	}
+	if err := platformdigest.ValidateSHA256Identity(e.TargetIdentityDigest); err != nil {
+		return Evidence{}, fmt.Errorf("%w: targetIdentityDigest", ErrInvalidEvidence)
+	}
+	if err := e.Predecessor.validate("predecessor"); err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	if err := e.Candidate.validate("candidate"); err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	if e.Predecessor.Release.Image == e.Candidate.Release.Image {
+		return Evidence{}, fmt.Errorf("%w: artifacts must differ", ErrInvalidEvidence)
+	}
+	if e.Decision != DecisionBinaryRollbackCompatible && e.Decision != DecisionProviderRecoveryRequired && e.Decision != DecisionUnsupported {
+		return Evidence{}, fmt.Errorf("%w: decision", ErrInvalidEvidence)
+	}
+	var err error
+	e.MigrationOwnership, err = e.MigrationOwnership.normalize()
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	e.Control.PredecessorSchemaVersion = normalizeText(e.Control.PredecessorSchemaVersion)
+	e.Control.CandidateSchemaVersion = normalizeText(e.Control.CandidateSchemaVersion)
+	e.Control.TargetIdentityDigest = normalizeText(e.Control.TargetIdentityDigest)
+	e.River.ExistingSchemaVersion = normalizeText(e.River.ExistingSchemaVersion)
+	e.River.RequiredSchemaVersion = normalizeText(e.River.RequiredSchemaVersion)
+	e.River.ExistingJobHistoryVersion = normalizeText(e.River.ExistingJobHistoryVersion)
+	e.River.RequiredJobHistoryVersion = normalizeText(e.River.RequiredJobHistoryVersion)
+	e.River.TargetIdentityDigest = normalizeText(e.River.TargetIdentityDigest)
+	e.DuckLake.TargetIdentityDigest = normalizeText(e.DuckLake.TargetIdentityDigest)
+	for field, value := range map[string]string{
+		"control.targetIdentityDigest":  e.Control.TargetIdentityDigest,
+		"river.targetIdentityDigest":    e.River.TargetIdentityDigest,
+		"ducklake.targetIdentityDigest": e.DuckLake.TargetIdentityDigest,
+	} {
+		if value != "" {
+			if err := platformdigest.ValidateSHA256Identity(value); err != nil {
+				return Evidence{}, fmt.Errorf("%w: %s", ErrInvalidEvidence, field)
+			}
+		}
+	}
+	for _, tuple := range []physicalpool.Compatibility{e.DuckLake.Predecessor, e.DuckLake.Candidate} {
+		if tuple != (physicalpool.Compatibility{}) {
+			if err := tuple.Validate(); err != nil {
+				return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+			}
+		}
+	}
+	if e.RecoveryFrontier != nil {
+		if err := e.RecoveryFrontier.Validate(); err != nil {
+			return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+		}
+	}
+	e.ReleasePolicy, err = e.ReleasePolicy.normalize()
+	if err != nil {
+		return Evidence{}, errors.Join(ErrInvalidEvidence, err)
+	}
+	seenReasons := make(map[ReasonCode]struct{}, len(e.ReasonCodes))
+	for _, reason := range e.ReasonCodes {
+		if reason == "" {
+			return Evidence{}, fmt.Errorf("%w: empty reason code", ErrInvalidEvidence)
+		}
+		seenReasons[reason] = struct{}{}
+	}
+	e.ReasonCodes = sortedReasons(seenReasons)
+	if len(e.PhaseIdentities) != len(phaseOrder) {
+		return Evidence{}, fmt.Errorf("%w: phase identities", ErrInvalidEvidence)
+	}
+	phaseMap := make(map[string]PhaseIdentity, len(e.PhaseIdentities))
+	for _, phase := range e.PhaseIdentities {
+		if err := platformdigest.ValidateSHA256Identity(phase.Digest); err != nil {
+			return Evidence{}, fmt.Errorf("%w: phase identity digest", ErrInvalidEvidence)
+		}
+		if _, exists := phaseMap[phase.Phase]; exists {
+			return Evidence{}, fmt.Errorf("%w: duplicate phase identity", ErrInvalidEvidence)
+		}
+		phaseMap[phase.Phase] = phase
+	}
+	e.PhaseIdentities = make([]PhaseIdentity, 0, len(phaseOrder))
+	for _, phaseName := range phaseOrder {
+		phase, exists := phaseMap[phaseName]
+		if !exists {
+			return Evidence{}, fmt.Errorf("%w: missing phase identity", ErrInvalidEvidence)
+		}
+		e.PhaseIdentities = append(e.PhaseIdentities, phase)
+	}
+	expected, evalErr := Evaluate(Input{
+		SchemaVersion:        e.SchemaVersion,
+		TargetIdentityDigest: e.TargetIdentityDigest,
+		Predecessor:          e.Predecessor,
+		Candidate:            e.Candidate,
+		MigrationOwnership:   e.MigrationOwnership,
+		Control:              e.Control,
+		River:                e.River,
+		DuckLake:             e.DuckLake,
+		RecoveryFrontier:     cloneFrontier(e.RecoveryFrontier),
+		ReleasePolicy:        e.ReleasePolicy,
+	})
+	if evalErr != nil {
+		return Evidence{}, fmt.Errorf("%w: evidence inputs are invalid: %v", ErrInvalidEvidence, evalErr)
+	}
+	if expected.Decision != e.Decision || !sameReasons(expected.ReasonCodes, e.ReasonCodes) || !samePhases(expected.PhaseIdentities, e.PhaseIdentities) {
+		return Evidence{}, fmt.Errorf("%w: decision, reasons, or phase identities do not match evaluated inputs", ErrInvalidEvidence)
+	}
+	return e, nil
+}
+
+func sameReasons(left, right []ReasonCode) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func samePhases(left, right []PhaseIdentity) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Validate checks the evidence contract without performing any external
+// operation.
+func (e Evidence) Validate() error {
+	_, err := e.Normalize()
+	return err
+}
+
+// CanonicalJSON emits compact JSON in struct field order. Slices are copied,
+// sorted, and normalized before encoding.
+func (e Evidence) CanonicalJSON() ([]byte, error) {
+	normalized, err := e.Normalize()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(normalized)
+}
+
+// CanonicalBytes is a convenience alias for CanonicalJSON.
+func (e Evidence) CanonicalBytes() ([]byte, error) { return e.CanonicalJSON() }
+
+// Digest computes the domain-separated SHA-256 identity of canonical evidence.
+func (e Evidence) Digest() (string, error) {
+	canonical, err := e.CanonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(append([]byte(DigestDomain), canonical...))
+	return "sha256:" + hex.EncodeToString(hash[:]), nil
+}
+
+// CanonicalDigest is a convenience alias for Digest.
+func (e Evidence) CanonicalDigest() (string, error) { return e.Digest() }

--- a/internal/release/transitionpreflight/preflight.go
+++ b/internal/release/transitionpreflight/preflight.go
@@ -31,6 +31,27 @@ const (
 	// SchemaVersion is the version of the preflight evidence contract.
 	SchemaVersion = 1
 
+	// ReleasePolicyVersion is the only release-policy contract version this
+	// evaluator understands. Future versions must be rejected until their
+	// semantics are explicitly implemented here.
+	ReleasePolicyVersion = "release-policy/v1"
+
+	// MaxCanonicalEvidenceBytes is shared by the producer and ParseEvidence so
+	// canonical evidence can always be consumed by the bounded parser.
+	MaxCanonicalEvidenceBytes = 1 << 20
+
+	// MaxSchemaVersionBytes bounds the owner-provided schema version labels
+	// retained in evidence. Both the supplied and normalized values are measured
+	// in UTF-8 bytes.
+	MaxSchemaVersionBytes = 128
+
+	// MaxReleasePolicyRules bounds the number of artifact-pair rules retained in
+	// one policy. MaxReleasePolicyRuleBytes bounds each rule's encoded JSON and
+	// MaxReleasePolicyDecisionBytes bounds its decision vocabulary extension.
+	MaxReleasePolicyRules         = 128
+	MaxReleasePolicyRuleBytes     = 1024
+	MaxReleasePolicyDecisionBytes = 128
+
 	// DigestDomain is prepended to canonical evidence before hashing. Keeping
 	// the newline in the domain makes this identity unambiguous when the
 	// canonical JSON begins with a JSON string or number in a future version.
@@ -438,23 +459,18 @@ func Evaluate(input Input) (Evidence, error) {
 	if err != nil {
 		return Evidence{}, err
 	}
+	if _, err := marshalEvidence(evidence); err != nil {
+		return Evidence{}, malformed("canonicalEvidence", err)
+	}
 	return evidence, nil
 }
-
-// EvaluatePreflight is an explicit spelling for call sites at the release
-// admission boundary.
-func EvaluatePreflight(input Input) (Evidence, error) { return Evaluate(input) }
-
-// EvaluateTransition is an explicit spelling for callers that own transition
-// orchestration.
-func EvaluateTransition(input Input) (Evidence, error) { return Evaluate(input) }
 
 // ParseEvidence decodes one bounded evidence document through the repository's
 // strict JSON owner, rejects unknown/duplicate/trailing fields, and returns its
 // normalized value. Parsing remains pure and never verifies live state.
 func ParseEvidence(document []byte) (Evidence, error) {
 	var evidence Evidence
-	if err := strictjson.DecodeWithOptions(document, &evidence, strictjson.Options{MaxBytes: 1 << 20, MaxDepth: 32, DuplicateKeys: strictjson.CaseFoldedKeys}); err != nil {
+	if err := strictjson.DecodeWithOptions(document, &evidence, strictjson.Options{MaxBytes: MaxCanonicalEvidenceBytes, MaxDepth: 32, DuplicateKeys: strictjson.CaseFoldedKeys}); err != nil {
 		return Evidence{}, fmt.Errorf("%w: decode evidence: %v", ErrInvalidEvidence, err)
 	}
 	// Keep this explicit even though strictjson currently rejects trailing
@@ -472,6 +488,17 @@ func ParseEvidence(document []byte) (Evidence, error) {
 		return Evidence{}, err
 	}
 	return normalized, nil
+}
+
+func marshalEvidence(evidence Evidence) ([]byte, error) {
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical evidence: %w", err)
+	}
+	if len(encoded) > MaxCanonicalEvidenceBytes {
+		return nil, fmt.Errorf("canonical evidence exceeds %d bytes", MaxCanonicalEvidenceBytes)
+	}
+	return encoded, nil
 }
 
 // Normalize validates structural identity and returns a deep-normalized copy.
@@ -496,13 +523,31 @@ func (input Input) Normalize() (Input, error) {
 	if err != nil {
 		return Input{}, err
 	}
-	input.Control.PredecessorSchemaVersion = normalizeText(input.Control.PredecessorSchemaVersion)
-	input.Control.CandidateSchemaVersion = normalizeText(input.Control.CandidateSchemaVersion)
+	input.Control.PredecessorSchemaVersion, err = normalizeSchemaVersion(input.Control.PredecessorSchemaVersion, "control.predecessorSchemaVersion")
+	if err != nil {
+		return Input{}, err
+	}
+	input.Control.CandidateSchemaVersion, err = normalizeSchemaVersion(input.Control.CandidateSchemaVersion, "control.candidateSchemaVersion")
+	if err != nil {
+		return Input{}, err
+	}
 	input.Control.TargetIdentityDigest = normalizeText(input.Control.TargetIdentityDigest)
-	input.River.ExistingSchemaVersion = normalizeText(input.River.ExistingSchemaVersion)
-	input.River.RequiredSchemaVersion = normalizeText(input.River.RequiredSchemaVersion)
-	input.River.ExistingJobHistoryVersion = normalizeText(input.River.ExistingJobHistoryVersion)
-	input.River.RequiredJobHistoryVersion = normalizeText(input.River.RequiredJobHistoryVersion)
+	input.River.ExistingSchemaVersion, err = normalizeSchemaVersion(input.River.ExistingSchemaVersion, "river.existingSchemaVersion")
+	if err != nil {
+		return Input{}, err
+	}
+	input.River.RequiredSchemaVersion, err = normalizeSchemaVersion(input.River.RequiredSchemaVersion, "river.requiredSchemaVersion")
+	if err != nil {
+		return Input{}, err
+	}
+	input.River.ExistingJobHistoryVersion, err = normalizeSchemaVersion(input.River.ExistingJobHistoryVersion, "river.existingJobHistoryVersion")
+	if err != nil {
+		return Input{}, err
+	}
+	input.River.RequiredJobHistoryVersion, err = normalizeSchemaVersion(input.River.RequiredJobHistoryVersion, "river.requiredJobHistoryVersion")
+	if err != nil {
+		return Input{}, err
+	}
 	input.River.TargetIdentityDigest = normalizeText(input.River.TargetIdentityDigest)
 	input.DuckLake.TargetIdentityDigest = normalizeText(input.DuckLake.TargetIdentityDigest)
 	for field, value := range map[string]string{
@@ -573,6 +618,17 @@ func canonicalText(value string) error {
 
 func normalizeText(value string) string { return strings.TrimSpace(value) }
 
+func normalizeSchemaVersion(value, field string) (string, error) {
+	if len(value) > MaxSchemaVersionBytes {
+		return "", malformed(field, fmt.Errorf("schema version is not bounded canonical text"))
+	}
+	value = normalizeText(value)
+	if len(value) > MaxSchemaVersionBytes || !utf8.ValidString(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return "", malformed(field, fmt.Errorf("schema version is not bounded canonical text"))
+	}
+	return value, nil
+}
+
 func (f RecoveryFrontierRef) Validate() error {
 	u, err := uuid.Parse(f.SetID)
 	if err != nil || u.String() != f.SetID {
@@ -613,11 +669,17 @@ func (m MigrationOwnership) normalize() (MigrationOwnership, error) {
 
 func (p ReleasePolicy) normalize() (ReleasePolicy, error) {
 	p.Version = normalizeText(p.Version)
+	if p.Version != "" && p.Version != ReleasePolicyVersion {
+		return ReleasePolicy{}, malformed("releasePolicy.version", fmt.Errorf("unsupported version"))
+	}
 	p.Digest = normalizeText(p.Digest)
 	if p.Digest != "" {
 		if err := platformdigest.ValidateSHA256Identity(p.Digest); err != nil {
 			return ReleasePolicy{}, malformed("releasePolicy.digest", err)
 		}
+	}
+	if len(p.Rules) > MaxReleasePolicyRules {
+		return ReleasePolicy{}, malformed("releasePolicy.rules", fmt.Errorf("too many rules"))
 	}
 	p.Rules = append([]ReleasePolicyRule(nil), p.Rules...)
 	for i := range p.Rules {
@@ -636,7 +698,21 @@ func (p ReleasePolicy) normalize() (ReleasePolicy, error) {
 		rule.CandidateArtifactDigest = normalizeText(rule.CandidateArtifactDigest)
 		rule.RollbackFromArtifactDigest = normalizeText(rule.RollbackFromArtifactDigest)
 		rule.RollbackToArtifactDigest = normalizeText(rule.RollbackToArtifactDigest)
-		rule.Decision = Decision(normalizeText(string(rule.Decision)))
+		rawDecision := string(rule.Decision)
+		if len(rawDecision) > MaxReleasePolicyDecisionBytes {
+			return ReleasePolicy{}, malformed(fmt.Sprintf("releasePolicy.rules[%d].decision", i), fmt.Errorf("decision is not bounded canonical text"))
+		}
+		rule.Decision = Decision(normalizeText(rawDecision))
+		if len(rule.Decision) > MaxReleasePolicyDecisionBytes || !utf8.ValidString(string(rule.Decision)) || strings.IndexFunc(string(rule.Decision), unicode.IsControl) >= 0 {
+			return ReleasePolicy{}, malformed(fmt.Sprintf("releasePolicy.rules[%d].decision", i), fmt.Errorf("decision is not bounded canonical text"))
+		}
+		encoded, err := json.Marshal(rule)
+		if err != nil {
+			return ReleasePolicy{}, fmt.Errorf("encode release policy rule %d: %w", i, err)
+		}
+		if len(encoded) > MaxReleasePolicyRuleBytes {
+			return ReleasePolicy{}, malformed(fmt.Sprintf("releasePolicy.rules[%d]", i), fmt.Errorf("rule exceeds bounded size"))
+		}
 	}
 	sort.Slice(p.Rules, func(i, j int) bool {
 		left, right := p.Rules[i], p.Rules[j]

--- a/internal/release/transitionpreflight/preflight.go
+++ b/internal/release/transitionpreflight/preflight.go
@@ -1,0 +1,753 @@
+// Package transitionpreflight evaluates whether an exact PostgreSQL-era
+// release transition may use a binary rollback or needs provider recovery.
+//
+// The package is deliberately a pure value evaluator. It does not connect to
+// PostgreSQL, inspect migration tables, acquire locks, or mutate a release,
+// migration, job, or recovery record. Callers supply immutable projections
+// obtained from their owning authorities.
+package transitionpreflight
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/flidai/leapview/internal/analytics/physicalpool"
+	"github.com/flidai/leapview/internal/platform/compatibility"
+	platformdigest "github.com/flidai/leapview/internal/platform/digest"
+	"github.com/flidai/leapview/internal/platform/ociref"
+	"github.com/flidai/leapview/pkg/strictjson"
+	"github.com/google/uuid"
+)
+
+const (
+	// SchemaVersion is the version of the preflight evidence contract.
+	SchemaVersion = 1
+
+	// DigestDomain is prepended to canonical evidence before hashing. Keeping
+	// the newline in the domain makes this identity unambiguous when the
+	// canonical JSON begins with a JSON string or number in a future version.
+	DigestDomain = "leapview/release-transition-preflight/v1\n"
+
+	// ArchitecturePostgreSQL is the architecture marker admitted by this
+	// bounded transition contract. Earlier SQLite-era artifacts are not an
+	// upgrade predecessor for this evaluator.
+	ArchitecturePostgreSQL = "postgresql"
+
+	// The phase names and order are part of the evidence contract. They are
+	// returned as hashes, rather than timestamps, so repeated evaluations are
+	// comparable and replayable.
+	PhasePreflight          = "preflight"
+	PhaseMigration          = "migration"
+	PhaseCandidateStartup   = "candidate-startup"
+	PhaseRollbackOrRecovery = "rollback-or-recovery"
+)
+
+var phaseOrder = []string{
+	PhasePreflight,
+	PhaseMigration,
+	PhaseCandidateStartup,
+	PhaseRollbackOrRecovery,
+}
+
+// Decision is the only outcome vocabulary emitted by the evaluator.
+type Decision string
+
+const (
+	DecisionBinaryRollbackCompatible = Decision("binary-rollback-compatible")
+	DecisionProviderRecoveryRequired = Decision("provider-recovery-required")
+	DecisionUnsupported              = Decision("unsupported")
+)
+
+// CompatibilityState is an explicit, caller-owned assessment of one
+// persistent domain. Unknown is intentionally distinct from incompatible:
+// neither permits the evaluator to infer a migration or rollback outcome.
+type CompatibilityState string
+
+const (
+	CompatibilityBackwardCompatible = CompatibilityState("backward-compatible")
+	CompatibilityIncompatible       = CompatibilityState("incompatible")
+	CompatibilityUnknown            = CompatibilityState("unknown")
+)
+
+// ReasonCode is stable evidence vocabulary. Values do not contain release
+// identifiers, SQL, paths, or provider details.
+type ReasonCode string
+
+const (
+	ReasonLegacyPredecessor            ReasonCode = "legacy_predecessor"
+	ReasonPredecessorNotPostgreSQL     ReasonCode = "predecessor_not_postgresql_era"
+	ReasonCandidateNotPostgreSQL       ReasonCode = "candidate_not_postgresql_era"
+	ReasonMissingMigrationOwnership    ReasonCode = "missing_migration_ownership"
+	ReasonGooseOwnershipMismatch       ReasonCode = "goose_ownership_mismatch"
+	ReasonRiverSchemaOwnershipMismatch ReasonCode = "river_schema_ownership_mismatch"
+	ReasonRiverJobHistoryOwnership     ReasonCode = "river_job_history_ownership_mismatch"
+	ReasonUnknownControlCompatibility  ReasonCode = "unknown_control_compatibility"
+	ReasonControlIncompatible          ReasonCode = "control_incompatible"
+	ReasonUnknownRiverCompatibility    ReasonCode = "unknown_river_compatibility"
+	ReasonRiverIncompatible            ReasonCode = "river_incompatible"
+	ReasonUnknownDuckLakeCompatibility ReasonCode = "unknown_ducklake_compatibility"
+	ReasonDuckLakeIncompatible         ReasonCode = "ducklake_incompatible"
+	ReasonMissingReleasePolicy         ReasonCode = "missing_release_policy"
+	ReasonReleasePolicyDigestMismatch  ReasonCode = "release_policy_digest_mismatch"
+	ReasonMultiplePolicyRules          ReasonCode = "multiple_policy_rules"
+	ReasonPolicyMismatch               ReasonCode = "policy_mismatch"
+	ReasonUnknownPolicyDecision        ReasonCode = "unknown_policy_decision"
+	ReasonMissingRecoveryFrontier      ReasonCode = "missing_recovery_frontier"
+	ReasonIncompleteControlProjection  ReasonCode = "incomplete_control_projection"
+	ReasonIncompleteRiverProjection    ReasonCode = "incomplete_river_projection"
+	ReasonIncompleteDuckLakeProjection ReasonCode = "incomplete_ducklake_projection"
+	ReasonUnknownArchitecture          ReasonCode = "unknown_architecture"
+	ReasonMissingTargetIdentityBinding ReasonCode = "missing_target_identity_binding"
+	ReasonTargetIdentityMismatch       ReasonCode = "target_identity_mismatch"
+)
+
+var (
+	// ErrInvalidInput means the supplied value cannot be a structurally valid
+	// preflight request. A complete but unsafe request returns evidence with an
+	// unsupported decision instead.
+	ErrInvalidInput    = errors.New("transition preflight input is malformed")
+	ErrInvalidEvidence = errors.New("transition preflight evidence is malformed")
+)
+
+// StructuralError identifies a malformed field without including its value.
+type StructuralError struct {
+	Cause error
+	Field string
+}
+
+func (e *StructuralError) Error() string {
+	if e == nil {
+		return ErrInvalidInput.Error()
+	}
+	if e.Field == "" {
+		return ErrInvalidInput.Error()
+	}
+	return fmt.Sprintf("%s: %s", ErrInvalidInput, e.Field)
+}
+
+func (e *StructuralError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	if e.Cause != nil {
+		return errors.Join(ErrInvalidInput, e.Cause)
+	}
+	return ErrInvalidInput
+}
+
+// ArtifactIdentity is the exact immutable artifact projection used by the
+// transition contract. ReleaseIdentity remains owned by compatibility; the
+// architecture marker is transition metadata and is deliberately separate.
+type ArtifactIdentity struct {
+	Release                 compatibility.ReleaseIdentity `json:"release"`
+	ArchitectureMarker      string                        `json:"architectureMarker"`
+	ArtifactAdmissionDigest string                        `json:"artifactAdmissionDigest"`
+}
+
+// Digest computes the immutable artifact identity over all release metadata,
+// including its admission digest. The digest is domain-separated so it cannot
+// be confused with preflight or policy identities.
+func (a ArtifactIdentity) Digest() (string, error) {
+	if err := a.validate("artifact"); err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(a)
+	if err != nil {
+		return "", fmt.Errorf("encode artifact identity: %w", err)
+	}
+	hash := sha256.Sum256([]byte("leapview/release-artifact/v1\n" + string(encoded)))
+	return "sha256:" + hex.EncodeToString(hash[:]), nil
+}
+
+// PostgreSQLControlProjection is the immutable control-schema comparison
+// supplied by the PostgreSQL authority.
+type PostgreSQLControlProjection struct {
+	Compatibility            CompatibilityState `json:"compatibility"`
+	PredecessorSchemaVersion string             `json:"predecessorSchemaVersion"`
+	CandidateSchemaVersion   string             `json:"candidateSchemaVersion"`
+	TargetIdentityDigest     string             `json:"targetIdentityDigest"`
+}
+
+// RiverJobProjection separately represents River's upstream operational
+// schema and LeapView's product-owned job history. They may not be collapsed
+// into a generic "database compatible" flag because ownership differs.
+type RiverJobProjection struct {
+	SchemaCompatibility       CompatibilityState `json:"schemaCompatibility"`
+	JobHistoryCompatibility   CompatibilityState `json:"jobHistoryCompatibility"`
+	ExistingSchemaVersion     string             `json:"existingSchemaVersion"`
+	RequiredSchemaVersion     string             `json:"requiredSchemaVersion"`
+	ExistingJobHistoryVersion string             `json:"existingJobHistoryVersion"`
+	RequiredJobHistoryVersion string             `json:"requiredJobHistoryVersion"`
+	TargetIdentityDigest      string             `json:"targetIdentityDigest"`
+}
+
+// DuckLakeProjection retains the exact five-field tuple owned by physicalpool
+// alongside the caller's explicit comparison result.
+type DuckLakeProjection struct {
+	Compatibility        CompatibilityState         `json:"compatibility"`
+	Predecessor          physicalpool.Compatibility `json:"predecessor"`
+	Candidate            physicalpool.Compatibility `json:"candidate"`
+	TargetIdentityDigest string                     `json:"targetIdentityDigest"`
+}
+
+// RecoveryFrontierRef is intentionally narrower than recoveryset.RecoverySet:
+// preflight needs only the canonical set identity and its content digest.
+type RecoveryFrontierRef struct {
+	SetID                string `json:"setId"`
+	Digest               string `json:"digest"`
+	TargetIdentityDigest string `json:"targetIdentityDigest"`
+}
+
+// MigrationOwnership names the owners of each migration/job boundary. The
+// expected values are exported so adapters can normalize their own source
+// representation without copying string literals.
+type MigrationOwnership struct {
+	GooseControlSchemaOwner     string `json:"gooseControlSchemaOwner"`
+	RiverOperationalSchemaOwner string `json:"riverOperationalSchemaOwner"`
+	RiverJobHistoryOwner        string `json:"riverJobHistoryOwner"`
+}
+
+const (
+	OwnerLeapView = "leapview"
+	OwnerRiver    = "river"
+
+	GooseControlSchemaOwnerLeapView  = OwnerLeapView
+	RiverOperationalSchemaOwnerRiver = OwnerRiver
+	RiverJobHistoryOwnerLeapView     = OwnerLeapView
+)
+
+// ReleasePolicyRule is one exact artifact-pair policy. A rule's decision is
+// checked against the persistent-domain projections; it is never treated as
+// permission to ignore contradictory evidence.
+type ReleasePolicyRule struct {
+	PredecessorArtifactDigest  string   `json:"predecessorArtifactDigest"`
+	CandidateArtifactDigest    string   `json:"candidateArtifactDigest"`
+	RollbackFromArtifactDigest string   `json:"rollbackFromArtifactDigest"`
+	RollbackToArtifactDigest   string   `json:"rollbackToArtifactDigest"`
+	Decision                   Decision `json:"decision"`
+}
+
+// ReleasePolicy is immutable release transition metadata. Rules are sorted
+// by Normalize so source map/loader order cannot alter evidence identity.
+type ReleasePolicy struct {
+	Version string              `json:"version"`
+	Digest  string              `json:"digest"`
+	Rules   []ReleasePolicyRule `json:"rules"`
+}
+
+type releasePolicyContent struct {
+	Version string              `json:"version"`
+	Rules   []ReleasePolicyRule `json:"rules"`
+}
+
+// ContentDigest computes the immutable policy identity over policy metadata
+// without including the supplied Digest field itself.
+func (p ReleasePolicy) ContentDigest() (string, error) {
+	normalized, err := p.normalizeWithoutDigest()
+	if err != nil {
+		return "", err
+	}
+	encoded, err := json.Marshal(releasePolicyContent{Version: normalized.Version, Rules: normalized.Rules})
+	if err != nil {
+		return "", fmt.Errorf("encode release policy: %w", err)
+	}
+	hash := sha256.Sum256([]byte("leapview/release-policy/v1\n" + string(encoded)))
+	return "sha256:" + hex.EncodeToString(hash[:]), nil
+}
+
+// Input is the complete immutable request for one PostgreSQL-era transition.
+// It contains projections only; no field is a database handle or operation
+// request.
+type Input struct {
+	SchemaVersion        int                         `json:"schemaVersion"`
+	TargetIdentityDigest string                      `json:"targetIdentityDigest"`
+	Predecessor          ArtifactIdentity            `json:"predecessor"`
+	Candidate            ArtifactIdentity            `json:"candidate"`
+	MigrationOwnership   MigrationOwnership          `json:"migrationOwnership"`
+	Control              PostgreSQLControlProjection `json:"control"`
+	River                RiverJobProjection          `json:"river"`
+	DuckLake             DuckLakeProjection          `json:"ducklake"`
+	RecoveryFrontier     *RecoveryFrontierRef        `json:"recoveryFrontier"`
+	ReleasePolicy        ReleasePolicy               `json:"releasePolicy"`
+}
+
+// PhaseIdentity binds one fixed phase name to a deterministic identity.
+type PhaseIdentity struct {
+	Phase  string `json:"phase"`
+	Digest string `json:"digest"`
+}
+
+// Evidence is the complete immutable result. It intentionally has no Digest
+// field: Digest() hashes canonical bytes that cannot contain their own digest.
+type Evidence struct {
+	SchemaVersion        int                         `json:"schemaVersion"`
+	TargetIdentityDigest string                      `json:"targetIdentityDigest"`
+	Predecessor          ArtifactIdentity            `json:"predecessor"`
+	Candidate            ArtifactIdentity            `json:"candidate"`
+	Decision             Decision                    `json:"decision"`
+	ReasonCodes          []ReasonCode                `json:"reasonCodes"`
+	MigrationOwnership   MigrationOwnership          `json:"migrationOwnership"`
+	Control              PostgreSQLControlProjection `json:"control"`
+	River                RiverJobProjection          `json:"river"`
+	DuckLake             DuckLakeProjection          `json:"ducklake"`
+	RecoveryFrontier     *RecoveryFrontierRef        `json:"recoveryFrontier"`
+	ReleasePolicy        ReleasePolicy               `json:"releasePolicy"`
+	PhaseIdentities      []PhaseIdentity             `json:"phaseIdentities"`
+}
+
+// PhaseNames returns the fixed phase order as a defensive copy.
+func PhaseNames() []string {
+	return append([]string(nil), phaseOrder...)
+}
+
+// Evaluate normalizes immutable inputs and returns one deterministic decision.
+// Structural errors return no evidence; safety uncertainty returns an
+// unsupported evidence document with stable reason codes.
+func Evaluate(input Input) (Evidence, error) {
+	normalized, err := input.Normalize()
+	if err != nil {
+		return Evidence{}, err
+	}
+
+	reasons := make(map[ReasonCode]struct{})
+	if normalized.Predecessor.ArchitectureMarker != ArchitecturePostgreSQL {
+		reasons[ReasonPredecessorNotPostgreSQL] = struct{}{}
+		reasons[ReasonLegacyPredecessor] = struct{}{}
+	}
+	if normalized.Candidate.ArchitectureMarker != ArchitecturePostgreSQL {
+		reasons[ReasonCandidateNotPostgreSQL] = struct{}{}
+		reasons[ReasonUnknownArchitecture] = struct{}{}
+	}
+
+	evaluateOwnership(normalized.MigrationOwnership, reasons)
+	if normalized.RecoveryFrontier == nil {
+		reasons[ReasonMissingRecoveryFrontier] = struct{}{}
+	}
+	for _, targetDigest := range []string{
+		normalized.Control.TargetIdentityDigest,
+		normalized.River.TargetIdentityDigest,
+		normalized.DuckLake.TargetIdentityDigest,
+	} {
+		if targetDigest == "" {
+			reasons[ReasonMissingTargetIdentityBinding] = struct{}{}
+		} else if targetDigest != normalized.TargetIdentityDigest {
+			reasons[ReasonTargetIdentityMismatch] = struct{}{}
+		}
+	}
+	if normalized.RecoveryFrontier != nil && normalized.RecoveryFrontier.TargetIdentityDigest != normalized.TargetIdentityDigest {
+		reasons[ReasonTargetIdentityMismatch] = struct{}{}
+	}
+	controlIncompatible, controlUnknown := evaluateControl(normalized.Control, reasons)
+	riverIncompatible, riverUnknown := evaluateRiver(normalized.River, reasons)
+	ducklakeIncompatible, ducklakeUnknown := evaluateDuckLake(normalized.DuckLake, reasons)
+
+	if normalized.DuckLake.Compatibility != CompatibilityUnknown && (normalized.DuckLake.Predecessor == (physicalpool.Compatibility{}) || normalized.DuckLake.Candidate == (physicalpool.Compatibility{})) {
+		reasons[ReasonIncompleteDuckLakeProjection] = struct{}{}
+	}
+	if normalized.Control.Compatibility != CompatibilityUnknown && (strings.TrimSpace(normalized.Control.PredecessorSchemaVersion) == "" || strings.TrimSpace(normalized.Control.CandidateSchemaVersion) == "") {
+		reasons[ReasonIncompleteControlProjection] = struct{}{}
+	}
+	if normalized.River.SchemaCompatibility != CompatibilityUnknown && normalized.River.JobHistoryCompatibility != CompatibilityUnknown && (strings.TrimSpace(normalized.River.ExistingSchemaVersion) == "" || strings.TrimSpace(normalized.River.RequiredSchemaVersion) == "" || strings.TrimSpace(normalized.River.ExistingJobHistoryVersion) == "" || strings.TrimSpace(normalized.River.RequiredJobHistoryVersion) == "") {
+		reasons[ReasonIncompleteRiverProjection] = struct{}{}
+	}
+
+	predecessorDigest, _ := normalized.Predecessor.Digest()
+	candidateDigest, _ := normalized.Candidate.Digest()
+	rule, ruleCount, policyProblem := matchingPolicyRule(normalized.ReleasePolicy, predecessorDigest, candidateDigest)
+	if policyProblem != "" {
+		switch policyProblem {
+		case "missing":
+			reasons[ReasonMissingReleasePolicy] = struct{}{}
+		case "multiple":
+			reasons[ReasonMultiplePolicyRules] = struct{}{}
+		case "mismatch":
+			reasons[ReasonPolicyMismatch] = struct{}{}
+		}
+	}
+	if ruleCount == 1 && rule.Decision != DecisionBinaryRollbackCompatible && rule.Decision != DecisionProviderRecoveryRequired {
+		reasons[ReasonUnknownPolicyDecision] = struct{}{}
+	}
+	if normalized.ReleasePolicy.Digest == "" {
+		reasons[ReasonMissingReleasePolicy] = struct{}{}
+	} else if expectedDigest, digestErr := normalized.ReleasePolicy.ContentDigest(); digestErr != nil || expectedDigest != normalized.ReleasePolicy.Digest {
+		reasons[ReasonReleasePolicyDigestMismatch] = struct{}{}
+	}
+
+	unknown := controlUnknown || riverUnknown || ducklakeUnknown
+	incompatible := controlIncompatible || riverIncompatible || ducklakeIncompatible
+	decision := DecisionUnsupported
+	// Domain incompatibility is an expected provider-recovery input, not a
+	// blocker by itself. All other reason codes are gates that must be absent
+	// before the policy can select a decision.
+	blockingReasons := len(reasons)
+	for _, reason := range []ReasonCode{ReasonControlIncompatible, ReasonRiverIncompatible, ReasonDuckLakeIncompatible} {
+		if _, exists := reasons[reason]; exists {
+			blockingReasons--
+		}
+	}
+	if blockingReasons == 0 && !unknown {
+		expected := DecisionBinaryRollbackCompatible
+		frontierMissing := false
+		if incompatible {
+			expected = DecisionProviderRecoveryRequired
+			if normalized.RecoveryFrontier == nil {
+				reasons[ReasonMissingRecoveryFrontier] = struct{}{}
+				frontierMissing = true
+			}
+		} else if normalized.RecoveryFrontier == nil {
+			frontierMissing = true
+		}
+		if ruleCount != 1 || rule.Decision != expected {
+			reasons[ReasonPolicyMismatch] = struct{}{}
+		} else if !frontierMissing && (len(reasons) == 0 || (incompatible && blockingReasons == 0)) {
+			decision = expected
+		}
+	}
+	if unknown || (incompatible && normalized.RecoveryFrontier == nil) {
+		decision = DecisionUnsupported
+	}
+	if incompatible && normalized.RecoveryFrontier == nil {
+		// Keep this explicit in case a future evaluator changes the ordering
+		// above or gains another provider-recovery gate.
+		reasons[ReasonMissingRecoveryFrontier] = struct{}{}
+	}
+
+	evidence := Evidence{
+		SchemaVersion:        normalized.SchemaVersion,
+		TargetIdentityDigest: normalized.TargetIdentityDigest,
+		Predecessor:          normalized.Predecessor,
+		Candidate:            normalized.Candidate,
+		Decision:             decision,
+		ReasonCodes:          sortedReasons(reasons),
+		MigrationOwnership:   normalized.MigrationOwnership,
+		Control:              normalized.Control,
+		River:                normalized.River,
+		DuckLake:             normalized.DuckLake,
+		RecoveryFrontier:     cloneFrontier(normalized.RecoveryFrontier),
+		ReleasePolicy:        normalized.ReleasePolicy,
+	}
+	evidence.PhaseIdentities, err = phaseIdentities(normalized, evidence.Decision, evidence.ReasonCodes)
+	if err != nil {
+		return Evidence{}, err
+	}
+	return evidence, nil
+}
+
+// EvaluatePreflight is an explicit spelling for call sites at the release
+// admission boundary.
+func EvaluatePreflight(input Input) (Evidence, error) { return Evaluate(input) }
+
+// EvaluateTransition is an explicit spelling for callers that own transition
+// orchestration.
+func EvaluateTransition(input Input) (Evidence, error) { return Evaluate(input) }
+
+// ParseEvidence decodes one bounded evidence document through the repository's
+// strict JSON owner, rejects unknown/duplicate/trailing fields, and returns its
+// normalized value. Parsing remains pure and never verifies live state.
+func ParseEvidence(document []byte) (Evidence, error) {
+	var evidence Evidence
+	if err := strictjson.DecodeWithOptions(document, &evidence, strictjson.Options{MaxBytes: 1 << 20, MaxDepth: 32, DuplicateKeys: strictjson.CaseFoldedKeys}); err != nil {
+		return Evidence{}, fmt.Errorf("%w: decode evidence: %v", ErrInvalidEvidence, err)
+	}
+	// Keep this explicit even though strictjson currently rejects trailing
+	// values; it documents that exactly one JSON value is part of the contract.
+	decoder := json.NewDecoder(strings.NewReader(string(document)))
+	var trailing any
+	if err := decoder.Decode(&evidence); err != nil {
+		return Evidence{}, fmt.Errorf("%w: decode evidence: %v", ErrInvalidEvidence, err)
+	}
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return Evidence{}, fmt.Errorf("%w: trailing evidence data", ErrInvalidEvidence)
+	}
+	normalized, err := evidence.Normalize()
+	if err != nil {
+		return Evidence{}, err
+	}
+	return normalized, nil
+}
+
+// Normalize validates structural identity and returns a deep-normalized copy.
+func (input Input) Normalize() (Input, error) {
+	if input.SchemaVersion != SchemaVersion {
+		return Input{}, malformed("schemaVersion", fmt.Errorf("unsupported version"))
+	}
+	if err := platformdigest.ValidateSHA256Identity(input.TargetIdentityDigest); err != nil {
+		return Input{}, malformed("targetIdentityDigest", err)
+	}
+	if err := input.Predecessor.validate("predecessor"); err != nil {
+		return Input{}, err
+	}
+	if err := input.Candidate.validate("candidate"); err != nil {
+		return Input{}, err
+	}
+	if input.Predecessor.Release.Image == input.Candidate.Release.Image {
+		return Input{}, malformed("candidate", fmt.Errorf("predecessor and candidate artifacts must differ"))
+	}
+	var err error
+	input.MigrationOwnership, err = input.MigrationOwnership.normalize()
+	if err != nil {
+		return Input{}, err
+	}
+	input.Control.PredecessorSchemaVersion = normalizeText(input.Control.PredecessorSchemaVersion)
+	input.Control.CandidateSchemaVersion = normalizeText(input.Control.CandidateSchemaVersion)
+	input.Control.TargetIdentityDigest = normalizeText(input.Control.TargetIdentityDigest)
+	input.River.ExistingSchemaVersion = normalizeText(input.River.ExistingSchemaVersion)
+	input.River.RequiredSchemaVersion = normalizeText(input.River.RequiredSchemaVersion)
+	input.River.ExistingJobHistoryVersion = normalizeText(input.River.ExistingJobHistoryVersion)
+	input.River.RequiredJobHistoryVersion = normalizeText(input.River.RequiredJobHistoryVersion)
+	input.River.TargetIdentityDigest = normalizeText(input.River.TargetIdentityDigest)
+	input.DuckLake.TargetIdentityDigest = normalizeText(input.DuckLake.TargetIdentityDigest)
+	for field, value := range map[string]string{
+		"control.targetIdentityDigest":  input.Control.TargetIdentityDigest,
+		"river.targetIdentityDigest":    input.River.TargetIdentityDigest,
+		"ducklake.targetIdentityDigest": input.DuckLake.TargetIdentityDigest,
+	} {
+		if value != "" {
+			if err := platformdigest.ValidateSHA256Identity(value); err != nil {
+				return Input{}, malformed(field, err)
+			}
+		}
+	}
+	for field, tuple := range map[string]physicalpool.Compatibility{"ducklake.predecessor": input.DuckLake.Predecessor, "ducklake.candidate": input.DuckLake.Candidate} {
+		if tuple != (physicalpool.Compatibility{}) {
+			if err := tuple.Validate(); err != nil {
+				return Input{}, malformed(field, err)
+			}
+		}
+	}
+	input.RecoveryFrontier = cloneFrontier(input.RecoveryFrontier)
+	if input.RecoveryFrontier != nil {
+		if err := input.RecoveryFrontier.Validate(); err != nil {
+			return Input{}, malformed("recoveryFrontier", err)
+		}
+	}
+	input.ReleasePolicy, err = input.ReleasePolicy.normalize()
+	if err != nil {
+		return Input{}, err
+	}
+	return input, nil
+}
+
+func malformed(field string, cause error) error {
+	return &StructuralError{Field: field, Cause: cause}
+}
+
+func (a ArtifactIdentity) validate(field string) error {
+	identity := a.Release
+	for name, value := range map[string]string{
+		"releaseId":               identity.ReleaseID,
+		"version":                 identity.Version,
+		"sourceRevision":          identity.SourceRevision,
+		"distribution":            identity.Distribution,
+		"platform":                identity.Platform,
+		"architectureMarker":      a.ArchitectureMarker,
+		"artifactAdmissionDigest": a.ArtifactAdmissionDigest,
+	} {
+		if err := canonicalText(value); err != nil {
+			return malformed(field+"."+name, err)
+		}
+	}
+	if err := ociref.ValidateImmutable(identity.Image); err != nil {
+		return malformed(field+".release.image", err)
+	}
+	if err := platformdigest.ValidateSHA256Identity(a.ArtifactAdmissionDigest); err != nil {
+		return malformed(field+".artifactAdmissionDigest", err)
+	}
+	return nil
+}
+
+func canonicalText(value string) error {
+	if value == "" || strings.TrimSpace(value) != value || len(value) > 1024 || !utf8.ValidString(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return fmt.Errorf("text is not canonical")
+	}
+	return nil
+}
+
+func normalizeText(value string) string { return strings.TrimSpace(value) }
+
+func (f RecoveryFrontierRef) Validate() error {
+	u, err := uuid.Parse(f.SetID)
+	if err != nil || u.String() != f.SetID {
+		return fmt.Errorf("setId must be a canonical UUID")
+	}
+	if err := platformdigest.ValidateSHA256Identity(f.Digest); err != nil {
+		return fmt.Errorf("digest must be a canonical SHA-256 identity")
+	}
+	if err := platformdigest.ValidateSHA256Identity(f.TargetIdentityDigest); err != nil {
+		return fmt.Errorf("targetIdentityDigest must be a canonical SHA-256 identity")
+	}
+	return nil
+}
+
+func cloneFrontier(frontier *RecoveryFrontierRef) *RecoveryFrontierRef {
+	if frontier == nil {
+		return nil
+	}
+	copy := *frontier
+	return &copy
+}
+
+func (m MigrationOwnership) normalize() (MigrationOwnership, error) {
+	for field, value := range map[string]string{
+		"gooseControlSchemaOwner":     m.GooseControlSchemaOwner,
+		"riverOperationalSchemaOwner": m.RiverOperationalSchemaOwner,
+		"riverJobHistoryOwner":        m.RiverJobHistoryOwner,
+	} {
+		if len(value) > 128 || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+			return MigrationOwnership{}, malformed("migrationOwnership."+field, fmt.Errorf("owner is not canonical"))
+		}
+	}
+	m.GooseControlSchemaOwner = normalizeText(m.GooseControlSchemaOwner)
+	m.RiverOperationalSchemaOwner = normalizeText(m.RiverOperationalSchemaOwner)
+	m.RiverJobHistoryOwner = normalizeText(m.RiverJobHistoryOwner)
+	return m, nil
+}
+
+func (p ReleasePolicy) normalize() (ReleasePolicy, error) {
+	p.Version = normalizeText(p.Version)
+	p.Digest = normalizeText(p.Digest)
+	if p.Digest != "" {
+		if err := platformdigest.ValidateSHA256Identity(p.Digest); err != nil {
+			return ReleasePolicy{}, malformed("releasePolicy.digest", err)
+		}
+	}
+	p.Rules = append([]ReleasePolicyRule(nil), p.Rules...)
+	for i := range p.Rules {
+		rule := &p.Rules[i]
+		for field, value := range map[string]string{
+			"predecessorArtifactDigest":  rule.PredecessorArtifactDigest,
+			"candidateArtifactDigest":    rule.CandidateArtifactDigest,
+			"rollbackFromArtifactDigest": rule.RollbackFromArtifactDigest,
+			"rollbackToArtifactDigest":   rule.RollbackToArtifactDigest,
+		} {
+			if err := platformdigest.ValidateSHA256Identity(value); err != nil {
+				return ReleasePolicy{}, malformed(fmt.Sprintf("releasePolicy.rules[%d].%s", i, field), err)
+			}
+		}
+		rule.PredecessorArtifactDigest = normalizeText(rule.PredecessorArtifactDigest)
+		rule.CandidateArtifactDigest = normalizeText(rule.CandidateArtifactDigest)
+		rule.RollbackFromArtifactDigest = normalizeText(rule.RollbackFromArtifactDigest)
+		rule.RollbackToArtifactDigest = normalizeText(rule.RollbackToArtifactDigest)
+		rule.Decision = Decision(normalizeText(string(rule.Decision)))
+	}
+	sort.Slice(p.Rules, func(i, j int) bool {
+		left, right := p.Rules[i], p.Rules[j]
+		if left.PredecessorArtifactDigest != right.PredecessorArtifactDigest {
+			return left.PredecessorArtifactDigest < right.PredecessorArtifactDigest
+		}
+		if left.CandidateArtifactDigest != right.CandidateArtifactDigest {
+			return left.CandidateArtifactDigest < right.CandidateArtifactDigest
+		}
+		if left.RollbackFromArtifactDigest != right.RollbackFromArtifactDigest {
+			return left.RollbackFromArtifactDigest < right.RollbackFromArtifactDigest
+		}
+		if left.RollbackToArtifactDigest != right.RollbackToArtifactDigest {
+			return left.RollbackToArtifactDigest < right.RollbackToArtifactDigest
+		}
+		return left.Decision < right.Decision
+	})
+	return p, nil
+}
+
+func (p ReleasePolicy) normalizeWithoutDigest() (ReleasePolicy, error) {
+	p.Digest = ""
+	return p.normalize()
+}
+
+func matchingPolicyRule(policy ReleasePolicy, predecessor, candidate string) (ReleasePolicyRule, int, string) {
+	if policy.Version == "" || len(policy.Rules) == 0 {
+		return ReleasePolicyRule{}, 0, "missing"
+	}
+	var matching []ReleasePolicyRule
+	for _, rule := range policy.Rules {
+		if rule.PredecessorArtifactDigest == predecessor &&
+			rule.CandidateArtifactDigest == candidate &&
+			rule.RollbackFromArtifactDigest == candidate &&
+			rule.RollbackToArtifactDigest == predecessor {
+			matching = append(matching, rule)
+		}
+	}
+	if len(matching) == 0 {
+		return ReleasePolicyRule{}, 0, "mismatch"
+	}
+	if len(matching) > 1 {
+		return matching[0], len(matching), "multiple"
+	}
+	return matching[0], 1, ""
+}
+
+func evaluateOwnership(ownership MigrationOwnership, reasons map[ReasonCode]struct{}) {
+	if ownership.GooseControlSchemaOwner == "" || ownership.RiverOperationalSchemaOwner == "" || ownership.RiverJobHistoryOwner == "" {
+		reasons[ReasonMissingMigrationOwnership] = struct{}{}
+	}
+	if ownership.GooseControlSchemaOwner != "" && ownership.GooseControlSchemaOwner != GooseControlSchemaOwnerLeapView {
+		reasons[ReasonGooseOwnershipMismatch] = struct{}{}
+	}
+	if ownership.RiverOperationalSchemaOwner != "" && ownership.RiverOperationalSchemaOwner != RiverOperationalSchemaOwnerRiver {
+		reasons[ReasonRiverSchemaOwnershipMismatch] = struct{}{}
+	}
+	if ownership.RiverJobHistoryOwner != "" && ownership.RiverJobHistoryOwner != RiverJobHistoryOwnerLeapView {
+		reasons[ReasonRiverJobHistoryOwnership] = struct{}{}
+	}
+}
+
+func evaluateControl(projection PostgreSQLControlProjection, reasons map[ReasonCode]struct{}) (incompatible, unknown bool) {
+	switch projection.Compatibility {
+	case CompatibilityBackwardCompatible:
+		return false, false
+	case CompatibilityIncompatible:
+		reasons[ReasonControlIncompatible] = struct{}{}
+		return true, false
+	case CompatibilityUnknown, "":
+		reasons[ReasonUnknownControlCompatibility] = struct{}{}
+		return false, true
+	default:
+		reasons[ReasonUnknownControlCompatibility] = struct{}{}
+		return false, true
+	}
+}
+
+func evaluateRiver(projection RiverJobProjection, reasons map[ReasonCode]struct{}) (incompatible, unknown bool) {
+	if projection.SchemaCompatibility == CompatibilityIncompatible || projection.JobHistoryCompatibility == CompatibilityIncompatible {
+		reasons[ReasonRiverIncompatible] = struct{}{}
+		incompatible = true
+	}
+	if projection.SchemaCompatibility == CompatibilityUnknown || projection.SchemaCompatibility == "" || projection.JobHistoryCompatibility == CompatibilityUnknown || projection.JobHistoryCompatibility == "" || (projection.SchemaCompatibility != CompatibilityBackwardCompatible && projection.SchemaCompatibility != CompatibilityIncompatible) || (projection.JobHistoryCompatibility != CompatibilityBackwardCompatible && projection.JobHistoryCompatibility != CompatibilityIncompatible) {
+		reasons[ReasonUnknownRiverCompatibility] = struct{}{}
+		unknown = true
+	}
+	return incompatible, unknown
+}
+
+func evaluateDuckLake(projection DuckLakeProjection, reasons map[ReasonCode]struct{}) (incompatible, unknown bool) {
+	switch projection.Compatibility {
+	case CompatibilityBackwardCompatible:
+		return false, false
+	case CompatibilityIncompatible:
+		reasons[ReasonDuckLakeIncompatible] = struct{}{}
+		return true, false
+	case CompatibilityUnknown, "":
+		reasons[ReasonUnknownDuckLakeCompatibility] = struct{}{}
+		return false, true
+	default:
+		reasons[ReasonUnknownDuckLakeCompatibility] = struct{}{}
+		return false, true
+	}
+}
+
+func sortedReasons(reasons map[ReasonCode]struct{}) []ReasonCode {
+	values := make([]ReasonCode, 0, len(reasons))
+	for reason := range reasons {
+		values = append(values, reason)
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	return values
+}

--- a/internal/release/transitionpreflight/testdata/golden.json
+++ b/internal/release/transitionpreflight/testdata/golden.json
@@ -1,0 +1,10 @@
+{
+  "evidenceDigest": "sha256:e0034612b542eaf5bf52d8e0b5f01b63a0f6aa4b0c10df551caef86ccb4811fb",
+  "policyDigest": "sha256:bbc0d28dc4a4d7589cb6c2c634dcfe83e031c741b5d5d2e577d805be76bdaf56",
+  "phaseDigests": [
+    "sha256:9ff7f1c6f353b190ecb93c71f30e93f595ab8ef21f46a518d4e401244dc1e7a0",
+    "sha256:f34cc8e94b0aba8b4828f231bf0b2acf38337152ff802dddcd0f4427adaa8879",
+    "sha256:ce8927fdcd064c6344c44c08f3e1c5a93a9ec84fd906027d66cad2a46b3f6d7f",
+    "sha256:07b57e1050b70a0098cf62a5c1502b83756940ab4a342819e4ac0b0bf676321e"
+  ]
+}


### PR DESCRIPTION
## Problem

FAI-518 still relied on removed pre-PostgreSQL transition assumptions. Current release qualification needs a read-only eligibility boundary that binds immutable release artifacts to PostgreSQL, River/job, DuckLake, policy, and recovery-frontier compatibility evidence before any transition can execute.

## Solution

- Add a pure PostgreSQL-era transition preflight evaluator.
- Emit exactly one decision: binary-rollback-compatible, provider-recovery-required, or unsupported.
- Bind admitted predecessor/candidate artifact identities, control-schema compatibility, Goose/River/job ownership, River/job compatibility, exact DuckLake tuples and owner verdict, release policy, rollback direction, and recovery frontier.
- Produce canonical transition evidence with stable ordering, deterministic phase identities, domain-separated SHA-256 digests, strict parsing, and golden vectors.
- Re-evaluate parsed evidence to reject tampered decisions, reasons, policies, phases, and target identities.
- Document the FAI-518 eligibility boundary and the later FAI-519 execution responsibility.

## Compatibility boundaries

- Legacy pre-PostgreSQL predecessors are unsupported.
- Missing ownership, missing recovery frontier, unknown compatibility, mutable artifact identities, and ambiguous rollback behavior fail closed.
- Binary rollback requires every persistent domain to be explicitly backward compatible and policy to bind the candidate-to-predecessor direction.
- Explicit persistent incompatibility requires matching provider-recovery policy and a valid frontier.
- No migrations, release transitions, rollback, restore, provider recovery, startup, admission, or traffic activation are performed.

## Tests added

Coverage includes compatible binary rollback, provider-recovery-required decisions across each persistent domain, legacy predecessor rejection, missing ownership/frontier, unsupported migration states, conflicting policy metadata, deterministic ordering and digests, strict JSON parsing, tamper rejection, cross-target rejection, and golden compatibility vectors.

## Verification

Passed:

- go test ./internal/release/transitionpreflight -count=2
- go test -race ./internal/release/transitionpreflight -count=1
- go test ./internal/release/... -count=1
- go test ./internal/platform/architecture/... -count=1
- go vet ./internal/release/transitionpreflight
- task generate
- task generated:check
- task docs:check
- task quality:budget:check
- git diff --check
- full task ci, exit code 0

The first full-CI attempt identified only a slice-owned source-file quality-budget overage. A behavior-preserving file split resolved it; the final quality budget and full CI are green.

## Limitation

This validates transition eligibility. It does not prove successful upgrade, rollback, or disaster recovery.

Remaining work includes live artifact/frontier resolution, durable preflight evidence wiring, migration execution and fencing, candidate restart verification, policy-directed rollback or provider recovery execution, and FAI-519 interruption qualification.