### PR TITLE
FAI-779: pin verified local Docker endpoints

### DIFF
--- a/internal/app/cli/authoring.go
+++ b/internal/app/cli/authoring.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	accessgen "github.com/flidai/leapview/internal/access/api/gen"
+	"github.com/flidai/leapview/internal/app/cli/localdocker"
 	deploymentgen "github.com/flidai/leapview/internal/deployment/api/gen"
 	"github.com/flidai/leapview/internal/platform/cliapi"
 	"github.com/flidai/leapview/internal/platform/digest"
@@ -36,7 +37,7 @@ func devCommand(ctx context.Context) *cobra.Command {
 		httpClient:        authoringRefreshingHTTPClient(http.DefaultClient),
 		validateAuthoring: true,
 	}
-	return projectcli.DevCommand(
+	remote := projectcli.DevCommand(
 		ctx,
 		client,
 		projectcli.NewCandidateCheckpointStore(candidateCheckpointPath()),
@@ -44,6 +45,71 @@ func devCommand(ctx context.Context) *cobra.Command {
 		openSystemBrowser,
 		projectDeliveryPlanOperations{client: client, remotes: projectDevRemoteFactory{client: client}, checkpoints: projectcli.NewCandidateCheckpointStore(candidateCheckpointPath())},
 	)
+	return dispatchLocalDevCommand(ctx, remote, localdocker.Resolve, unavailableLocalDevRuntime)
+}
+
+type localDockerResolver func(context.Context, localdocker.Options) (localdocker.Endpoint, error)
+type localDevRuntime func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error
+
+// dispatchLocalDevCommand makes explicit --target the only route to the
+// existing remote workflow. Bare dev is decided here, before target profiles,
+// stored logins, or LEAPVIEW_TARGET can be resolved by the remote command.
+func dispatchLocalDevCommand(
+	ctx context.Context,
+	command *cobra.Command,
+	resolve localDockerResolver,
+	start localDevRuntime,
+) *cobra.Command {
+	remoteRun := command.RunE
+	var dockerContext, dockerHost string
+	command.Flags().StringVar(&dockerContext, "docker-context", "", "explicit local Docker context")
+	command.Flags().StringVar(&dockerHost, "docker-host", "", "explicit local Docker Unix socket")
+	command.RunE = func(command *cobra.Command, args []string) error {
+		if command.Flags().Changed("target") {
+			target, err := command.Flags().GetString("target")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(target) == "" {
+				return fmt.Errorf("explicit remote --target must not be empty")
+			}
+			if command.Flags().Changed("docker-context") || command.Flags().Changed("docker-host") {
+				return fmt.Errorf("Docker endpoint flags cannot be combined with remote --target")
+			}
+			return remoteRun(command, args)
+		}
+		for _, name := range []string{"token", "project-id", "bootstrap"} {
+			if flag := command.Flags().Lookup(name); flag != nil && command.Flags().Changed(name) {
+				return fmt.Errorf("--%s requires an explicit remote --target", name)
+			}
+		}
+		if len(args) == 1 {
+			if flag := command.Flags().Lookup("source-root"); flag != nil && command.Flags().Changed("source-root") {
+				return fmt.Errorf("choose either --source-root or positional source root, not both")
+			}
+		}
+		if resolve == nil || start == nil {
+			return fmt.Errorf("local development runtime is not configured")
+		}
+		endpoint, err := resolve(ctx, localdocker.Options{
+			ExplicitContext: dockerContext,
+			ExplicitHost:    dockerHost,
+		})
+		if err != nil {
+			return err
+		}
+		return start(ctx, endpoint, command, args)
+	}
+	return command
+}
+
+func unavailableLocalDevRuntime(
+	_ context.Context,
+	_ localdocker.Endpoint,
+	_ *cobra.Command,
+	_ []string,
+) error {
+	return fmt.Errorf("this build does not include the local development runtime yet; use an explicit --target for remote development")
 }
 
 func (factory projectDevRemoteFactory) Remote(

--- a/internal/app/cli/composectl/controller.go
+++ b/internal/app/cli/composectl/controller.go
@@ -44,6 +44,7 @@ type Options struct {
 	Now                     func() time.Time
 	Sleep                   func(context.Context, time.Duration) error
 	DockerPlatform          string
+	DockerEndpoint          PinnedDockerEndpoint
 	qualificationExecutor   qualificationCommandExecutor
 	qualificationContainers qualificationContainerRuntime
 }
@@ -57,6 +58,7 @@ type Controller struct {
 	now                     func() time.Time
 	sleep                   func(context.Context, time.Duration) error
 	dockerPlatform          string
+	dockerEndpoint          PinnedDockerEndpoint
 	qualificationExecutor   qualificationCommandExecutor
 	qualificationContainers qualificationContainerRuntime
 	startOverride           func(context.Context) error
@@ -112,13 +114,17 @@ func New(options Options) (*Controller, error) {
 		executor = osQualificationCommandExecutor{}
 	}
 	containers := options.qualificationContainers
+	if options.DockerEndpoint != nil && strings.TrimSpace(options.DockerEndpoint.Host()) == "" {
+		return nil, fmt.Errorf("pinned Docker endpoint host is required")
+	}
 	if containers == nil {
-		containers = newDockerCLIQualificationRuntime(root, dockerBin, executor)
+		containers = newDockerCLIQualificationRuntime(root, dockerBin, executor, options.DockerEndpoint)
 	}
 	return &Controller{
 		root: root, dockerBin: dockerBin, stdin: stdin, stdout: stdout,
 		stderr: stderr, now: now, sleep: sleep,
 		dockerPlatform:          strings.TrimSpace(options.DockerPlatform),
+		dockerEndpoint:          options.DockerEndpoint,
 		qualificationExecutor:   executor,
 		qualificationContainers: containers,
 	}, nil
@@ -152,6 +158,7 @@ func (c *Controller) scoped(root string, stdout io.Writer) (*Controller, error) 
 			absoluteRoot,
 			c.dockerBin,
 			c.qualificationExecutor,
+			c.dockerEndpoint,
 		)
 	}
 	return &Controller{
@@ -163,6 +170,7 @@ func (c *Controller) scoped(root string, stdout io.Writer) (*Controller, error) 
 		now:                     c.now,
 		sleep:                   c.sleep,
 		dockerPlatform:          c.dockerPlatform,
+		dockerEndpoint:          c.dockerEndpoint,
 		qualificationExecutor:   c.qualificationExecutor,
 		qualificationContainers: containers,
 		startOverride:           c.startOverride,
@@ -515,9 +523,13 @@ func (c *Controller) docker(ctx context.Context, stdin io.Reader, stdout, stderr
 }
 
 func (c *Controller) dockerWithEnvironment(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, environment []string, args ...string) error {
+	if err := c.verifyDockerEndpoint(ctx); err != nil {
+		return err
+	}
+	args = c.dockerArguments(args...)
 	command := exec.CommandContext(ctx, c.dockerBin, args...)
 	command.Dir = c.root
-	command.Env = environment
+	command.Env = c.dockerEnvironment(environment)
 	command.Stdin = stdin
 	command.Stdout = stdout
 	command.Stderr = stderr

--- a/internal/app/cli/composectl/docker_endpoint.go
+++ b/internal/app/cli/composectl/docker_endpoint.go
@@ -1,0 +1,39 @@
+package composectl
+
+import (
+	"context"
+	"fmt"
+)
+
+// PinnedDockerEndpoint is supplied by the local-development endpoint verifier.
+// It keeps every Docker and Compose subprocess on the qualified daemon.
+type PinnedDockerEndpoint interface {
+	Host() string
+	Environment([]string) []string
+	DockerArguments(...string) []string
+	Verify(context.Context) error
+}
+
+func (c *Controller) verifyDockerEndpoint(ctx context.Context) error {
+	if c.dockerEndpoint == nil {
+		return nil
+	}
+	if err := c.dockerEndpoint.Verify(ctx); err != nil {
+		return fmt.Errorf("verify pinned Docker endpoint: %w", err)
+	}
+	return nil
+}
+
+func (c *Controller) dockerArguments(arguments ...string) []string {
+	if c.dockerEndpoint == nil {
+		return arguments
+	}
+	return c.dockerEndpoint.DockerArguments(arguments...)
+}
+
+func (c *Controller) dockerEnvironment(environment []string) []string {
+	if c.dockerEndpoint == nil {
+		return environment
+	}
+	return c.dockerEndpoint.Environment(environment)
+}

--- a/internal/app/cli/composectl/docker_endpoint_test.go
+++ b/internal/app/cli/composectl/docker_endpoint_test.go
@@ -1,0 +1,116 @@
+package composectl
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type pinnedEndpointStub struct {
+	host      string
+	verifyErr error
+	verified  *int
+}
+
+func (endpoint pinnedEndpointStub) Host() string { return endpoint.host }
+
+func (endpoint pinnedEndpointStub) Verify(context.Context) error {
+	if endpoint.verified != nil {
+		*endpoint.verified++
+	}
+	return endpoint.verifyErr
+}
+
+func (endpoint pinnedEndpointStub) DockerArguments(arguments ...string) []string {
+	return append([]string{"--host", endpoint.host}, arguments...)
+}
+
+func (endpoint pinnedEndpointStub) Environment(environment []string) []string {
+	result := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		name, _, present := strings.Cut(entry, "=")
+		if present && slices.Contains([]string{"DOCKER_CONTEXT", "DOCKER_HOST", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"}, name) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, "DOCKER_HOST="+endpoint.host)
+}
+
+func TestPinnedDockerEndpointReachesEveryControllerProcess(t *testing.T) {
+	t.Setenv("DOCKER_CONTEXT", "remote")
+	t.Setenv("DOCKER_HOST", "tcp://remote.example:2375")
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, deploymentEnvName),
+		[]byte("COMPOSE_PROJECT_NAME=pinned-test\nCOMPOSE_HTTPS=0\n"),
+		0o600,
+	))
+	var requests []qualificationCommandRequest
+	executor := qualificationExecutorFunc(func(_ context.Context, request qualificationCommandRequest) ([]byte, error) {
+		requests = append(requests, request)
+		if slices.Contains(request.Arguments, "run") {
+			return []byte("container-id\n"), nil
+		}
+		return []byte("ok\n"), nil
+	})
+	var verified int
+	endpoint := pinnedEndpointStub{host: "unix:///run/user/1000/docker.sock", verified: &verified}
+	controller, err := New(Options{
+		Root: root, DockerBin: "docker-probe", DockerEndpoint: endpoint,
+		qualificationExecutor: executor,
+	})
+	require.NoError(t, err)
+
+	_, err = controller.qualificationDocker(t.Context(), nil, "version")
+	require.NoError(t, err)
+	_, err = controller.qualificationCompose(t.Context(), root, "config")
+	require.NoError(t, err)
+	_, err = controller.qualificationContainers.Start(t.Context(), qualificationContainerRequest{
+		Name: "pinned-container", Image: "example.invalid/image@sha256:test",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, requests, 3)
+	require.Equal(t, 3, verified)
+	for _, request := range requests {
+		require.GreaterOrEqual(t, len(request.Arguments), 3)
+		require.Equal(t, []string{"--host", endpoint.host}, request.Arguments[:2])
+		values := environmentValues(strings.Join(request.Environment, "\n"))
+		require.Equal(t, endpoint.host, values["DOCKER_HOST"])
+		require.NotContains(t, values, "DOCKER_CONTEXT")
+		require.NotEqual(t, "tcp://remote.example:2375", values["DOCKER_HOST"])
+	}
+
+	scoped, err := controller.scoped(t.TempDir(), os.Stdout)
+	require.NoError(t, err)
+	require.Equal(t, endpoint.host, scoped.dockerEndpoint.Host())
+}
+
+func TestChangedPinnedDaemonFailsBeforeControllerExecution(t *testing.T) {
+	var requests int
+	controller, err := New(Options{
+		Root: t.TempDir(), DockerEndpoint: pinnedEndpointStub{
+			host: "unix:///run/docker.sock", verifyErr: errors.New("daemon identity changed"),
+		},
+		qualificationExecutor: qualificationExecutorFunc(func(context.Context, qualificationCommandRequest) ([]byte, error) {
+			requests++
+			return nil, nil
+		}),
+	})
+	require.NoError(t, err)
+	_, err = controller.qualificationDocker(t.Context(), nil, "pull", "example.invalid/image")
+	require.ErrorContains(t, err, "daemon identity changed")
+	require.Zero(t, requests)
+}
+
+func TestPinnedDockerEndpointMustHaveAHost(t *testing.T) {
+	_, err := New(Options{Root: t.TempDir(), DockerEndpoint: pinnedEndpointStub{}})
+	require.ErrorContains(t, err, "endpoint host")
+}

--- a/internal/app/cli/composectl/qualification_authoring.go
+++ b/internal/app/cli/composectl/qualification_authoring.go
@@ -280,13 +280,19 @@ func (c *Controller) runQualificationAuthoring(
 			ctx, browser, "install authoring browser dependencies", err,
 		)
 	}
+	browserWorkerArguments := c.dockerArguments(
+		"exec", "-i", browserContainer,
+		"node", "/work/authoring-worker.mjs",
+	)
+	if err := c.verifyDockerEndpoint(rootContext); err != nil {
+		return report, err
+	}
 	browserWorker, err := startQualificationJSONWorker(
 		rootContext,
 		c.root,
-		os.Environ(),
+		c.dockerEnvironment(os.Environ()),
 		c.dockerBin,
-		"exec", "-i", browserContainer,
-		"node", "/work/authoring-worker.mjs",
+		browserWorkerArguments...,
 	)
 	if err != nil {
 		return report, fmt.Errorf("start qualification browser worker: %w", err)
@@ -379,11 +385,7 @@ func (c *Controller) runQualificationAuthoring(
 		os.Environ(),
 		"QUALIFICATION_KEYRING_PASSWORD="+keyringPassword,
 	)
-	clientWorker, err := startQualificationJSONWorker(
-		rootContext,
-		c.root,
-		clientEnvironment,
-		c.dockerBin,
+	clientWorkerArguments := c.dockerArguments(
 		"run", "--rm", "-i",
 		"--name", clientContainer,
 		"--network", "host",
@@ -398,6 +400,16 @@ func (c *Controller) runQualificationAuthoring(
 		"--source-root", options.SourceRoot,
 		"--project-id", options.ProjectID,
 		"--source-revision", options.SourceRevision,
+	)
+	if err := c.verifyDockerEndpoint(rootContext); err != nil {
+		return report, err
+	}
+	clientWorker, err := startQualificationJSONWorker(
+		rootContext,
+		c.root,
+		c.dockerEnvironment(clientEnvironment),
+		c.dockerBin,
+		clientWorkerArguments...,
 	)
 	if err != nil {
 		return report, fmt.Errorf("start qualification CLI worker: %w", err)

--- a/internal/app/cli/composectl/qualification_process.go
+++ b/internal/app/cli/composectl/qualification_process.go
@@ -92,11 +92,14 @@ func (c *Controller) qualificationDocker(
 	stdin io.Reader,
 	args ...string,
 ) ([]byte, error) {
+	if err := c.verifyDockerEndpoint(ctx); err != nil {
+		return nil, err
+	}
 	return qualificationProcess{
 		dir:         c.root,
 		executable:  c.dockerBin,
-		environment: os.Environ(),
-	}.Run(ctx, stdin, c.qualificationExecutor, args...)
+		environment: c.dockerEnvironment(os.Environ()),
+	}.Run(ctx, stdin, c.qualificationExecutor, c.dockerArguments(args...)...)
 }
 
 func composeArguments(root string, args ...string) ([]string, error) {
@@ -129,6 +132,9 @@ func (c *Controller) qualificationCompose(
 	root string,
 	args ...string,
 ) ([]byte, error) {
+	if err := c.verifyDockerEndpoint(ctx); err != nil {
+		return nil, err
+	}
 	commandArgs, err := composeArguments(root, args...)
 	if err != nil {
 		return nil, err
@@ -138,8 +144,8 @@ func (c *Controller) qualificationCompose(
 		return nil, err
 	}
 	return qualificationProcess{
-		dir: c.root, executable: c.dockerBin, environment: processEnvironment,
-	}.Run(ctx, nil, c.qualificationExecutor, commandArgs...)
+		dir: c.root, executable: c.dockerBin, environment: c.dockerEnvironment(processEnvironment),
+	}.Run(ctx, nil, c.qualificationExecutor, c.dockerArguments(commandArgs...)...)
 }
 
 // qualificationComposeEnvironment supplies operation-only credentials to the
@@ -152,6 +158,9 @@ func (c *Controller) qualificationComposeEnvironment(
 	environment map[string]string,
 	args ...string,
 ) ([]byte, error) {
+	if err := c.verifyDockerEndpoint(ctx); err != nil {
+		return nil, err
+	}
 	commandArgs, err := composeArguments(root, args...)
 	if err != nil {
 		return nil, err
@@ -169,8 +178,8 @@ func (c *Controller) qualificationComposeEnvironment(
 		return nil, err
 	}
 	return qualificationProcess{
-		dir: c.root, executable: c.dockerBin, environment: processEnvironment,
-	}.Run(ctx, nil, c.qualificationExecutor, commandArgs...)
+		dir: c.root, executable: c.dockerBin, environment: c.dockerEnvironment(processEnvironment),
+	}.Run(ctx, nil, c.qualificationExecutor, c.dockerArguments(commandArgs...)...)
 }
 
 // composeProcessEnvironment prevents host shell variables from

--- a/internal/app/cli/composectl/qualification_recovery.go
+++ b/internal/app/cli/composectl/qualification_recovery.go
@@ -1024,9 +1024,14 @@ func (c *Controller) startQualificationClientCommandWithEnv(
 		environment,
 		arguments...,
 	)
+	dockerArguments = c.dockerArguments(dockerArguments...)
+	if err := c.verifyDockerEndpoint(ctx); err != nil {
+		_ = output.Close()
+		return nil, err
+	}
 	command := exec.CommandContext(ctx, c.dockerBin, dockerArguments...)
 	command.Dir = c.root
-	command.Env = os.Environ()
+	command.Env = c.dockerEnvironment(os.Environ())
 	command.Stdout = output
 	command.Stderr = output
 	if err := command.Start(); err != nil {

--- a/internal/app/cli/composectl/qualification_runtime.go
+++ b/internal/app/cli/composectl/qualification_runtime.go
@@ -115,18 +115,29 @@ func qualificationContainerOperationError(
 type dockerCLIQualificationRuntime struct {
 	process  qualificationProcess
 	executor qualificationCommandExecutor
+	endpoint PinnedDockerEndpoint
 }
 
 func newDockerCLIQualificationRuntime(
 	root string,
 	dockerBin string,
 	executor qualificationCommandExecutor,
+	endpoints ...PinnedDockerEndpoint,
 ) *dockerCLIQualificationRuntime {
+	var endpoint PinnedDockerEndpoint
+	if len(endpoints) > 0 {
+		endpoint = endpoints[0]
+	}
+	environment := os.Environ()
+	if endpoint != nil {
+		environment = endpoint.Environment(environment)
+	}
 	return &dockerCLIQualificationRuntime{
 		process: qualificationProcess{
-			dir: root, executable: dockerBin, environment: os.Environ(),
+			dir: root, executable: dockerBin, environment: environment,
 		},
 		executor: executor,
+		endpoint: endpoint,
 	}
 }
 
@@ -217,6 +228,12 @@ func (runtime *dockerCLIQualificationRuntime) run(
 	stdin io.Reader,
 	arguments ...string,
 ) ([]byte, error) {
+	if runtime.endpoint != nil {
+		if err := runtime.endpoint.Verify(ctx); err != nil {
+			return nil, fmt.Errorf("verify pinned Docker endpoint: %w", err)
+		}
+		arguments = runtime.endpoint.DockerArguments(arguments...)
+	}
 	return runtime.process.Run(ctx, stdin, runtime.executor, arguments...)
 }
 

--- a/internal/app/cli/local_dev_dispatch_test.go
+++ b/internal/app/cli/local_dev_dispatch_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flidai/leapview/internal/app/cli/localdocker"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBareDevSelectsLocalBeforeAmbientTargetResolution(t *testing.T) {
+	t.Setenv("LEAPVIEW_TARGET", "production")
+	var remoteCalls, resolveCalls, localCalls int
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(&remoteCalls),
+		func(_ context.Context, options localdocker.Options) (localdocker.Endpoint, error) {
+			resolveCalls++
+			require.Empty(t, options.ExplicitContext)
+			require.Empty(t, options.ExplicitHost)
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error {
+			localCalls++
+			return nil
+		},
+	)
+	command.SetArgs(nil)
+	require.NoError(t, command.Execute())
+	require.Equal(t, 0, remoteCalls)
+	require.Equal(t, 1, resolveCalls)
+	require.Equal(t, 1, localCalls)
+}
+
+func TestExplicitTargetUsesRemoteWithoutDockerResolution(t *testing.T) {
+	var remoteCalls, resolveCalls, localCalls int
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(&remoteCalls),
+		func(context.Context, localdocker.Options) (localdocker.Endpoint, error) {
+			resolveCalls++
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error {
+			localCalls++
+			return nil
+		},
+	)
+	command.SetArgs([]string{"--target", "staging"})
+	require.NoError(t, command.Execute())
+	require.Equal(t, 1, remoteCalls)
+	require.Zero(t, resolveCalls)
+	require.Zero(t, localCalls)
+}
+
+func TestDevRejectsConflictingLocalAndRemoteSelectionBeforeEitherPath(t *testing.T) {
+	var remoteCalls, resolveCalls int
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(&remoteCalls),
+		func(context.Context, localdocker.Options) (localdocker.Endpoint, error) {
+			resolveCalls++
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error { return nil },
+	)
+	command.SetArgs([]string{"--target", "staging", "--docker-context", "desktop-linux"})
+	err := command.Execute()
+	require.ErrorContains(t, err, "cannot be combined")
+	require.Zero(t, remoteCalls)
+	require.Zero(t, resolveCalls)
+}
+
+func TestBareDevRejectsRemoteCredentialsBeforeDockerResolution(t *testing.T) {
+	var remoteCalls, resolveCalls int
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(&remoteCalls),
+		func(context.Context, localdocker.Options) (localdocker.Endpoint, error) {
+			resolveCalls++
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error { return nil },
+	)
+	command.SetArgs([]string{"--token", "secret"})
+	err := command.Execute()
+	require.ErrorContains(t, err, "requires an explicit remote --target")
+	require.NotContains(t, err.Error(), "secret")
+	require.Zero(t, remoteCalls)
+	require.Zero(t, resolveCalls)
+}
+
+func TestBareDevPassesExplicitDockerSelectionToResolver(t *testing.T) {
+	var got localdocker.Options
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(new(int)),
+		func(_ context.Context, options localdocker.Options) (localdocker.Endpoint, error) {
+			got = options
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error { return nil },
+	)
+	command.SetArgs([]string{"--docker-host", "unix:///var/run/docker.sock"})
+	require.NoError(t, command.Execute())
+	require.Equal(t, "unix:///var/run/docker.sock", got.ExplicitHost)
+	require.Empty(t, got.ExplicitContext)
+}
+
+func remoteDevCommandForDispatchTest(calls *int) *cobra.Command {
+	command := &cobra.Command{
+		Use:  "dev [source-root]",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(*cobra.Command, []string) error {
+			*calls++
+			return nil
+		},
+	}
+	command.Flags().String("target", "", "target")
+	command.Flags().String("token", "", "token")
+	command.Flags().String("project-id", "", "project")
+	command.Flags().String("source-root", "dashboards", "source")
+	command.Flags().Bool("bootstrap", false, "bootstrap")
+	return command
+}
+
+func TestExplicitEmptyRemoteTargetFailsClosed(t *testing.T) {
+	command := dispatchLocalDevCommand(
+		t.Context(), remoteDevCommandForDispatchTest(new(int)),
+		func(context.Context, localdocker.Options) (localdocker.Endpoint, error) {
+			t.Fatal("Docker resolution must not run")
+			return localdocker.Endpoint{}, nil
+		},
+		func(context.Context, localdocker.Endpoint, *cobra.Command, []string) error { return nil },
+	)
+	command.SetArgs([]string{"--target", strings.Repeat(" ", 2)})
+	require.ErrorContains(t, command.Execute(), "must not be empty")
+}

--- a/internal/app/cli/localdocker/endpoint.go
+++ b/internal/app/cli/localdocker/endpoint.go
@@ -1,0 +1,457 @@
+// Package localdocker resolves and verifies the Docker endpoint used by local
+// analytics development. It deliberately accepts only documented local Unix
+// sockets and returns an endpoint that can be pinned for every later command.
+package localdocker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const dockerInfoFormat = "{{json .}}"
+
+type Source string
+
+const (
+	SourceExplicitContext    Source = "explicit-context"
+	SourceExplicitHost       Source = "explicit-host"
+	SourceEnvironmentContext Source = "DOCKER_CONTEXT"
+	SourceEnvironmentHost    Source = "DOCKER_HOST"
+	SourceActiveContext      Source = "active-context"
+)
+
+type Kind string
+
+const (
+	KindEngine   Kind = "engine"
+	KindRootless Kind = "rootless-engine"
+	KindDesktop  Kind = "docker-desktop"
+)
+
+// Endpoint is the immutable result of local endpoint selection. Host is a
+// credential-free canonical Unix socket URI and ServerID identifies the daemon
+// reached through that trusted socket at selection time.
+type Endpoint struct {
+	context    string
+	host       string
+	socketPath string
+	serverID   string
+	source     Source
+	kind       Kind
+	verify     func(context.Context) error
+}
+
+func (endpoint Endpoint) Context() string  { return endpoint.context }
+func (endpoint Endpoint) Host() string     { return endpoint.host }
+func (endpoint Endpoint) ServerID() string { return endpoint.serverID }
+func (endpoint Endpoint) Source() Source   { return endpoint.source }
+func (endpoint Endpoint) Kind() Kind       { return endpoint.kind }
+
+func (endpoint Endpoint) Verify(ctx context.Context) error {
+	if endpoint.verify == nil {
+		return errors.New("Docker endpoint has no verification authority")
+	}
+	return endpoint.verify(ctx)
+}
+
+// Fingerprint is a credential-free resource-label identity for the selected
+// socket and daemon. It changes when either authority changes.
+func (endpoint Endpoint) Fingerprint() string {
+	identity := endpoint.host + "\x00" + endpoint.serverID + "\x00" + string(endpoint.kind)
+	return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(identity)))
+}
+
+// DockerArguments pins a Docker CLI invocation independently of later context
+// or environment changes.
+func (endpoint Endpoint) DockerArguments(arguments ...string) []string {
+	return append([]string{"--host", endpoint.host}, arguments...)
+}
+
+// Environment removes ambient endpoint and TLS selection, then pins the
+// verified Unix endpoint. DOCKER_CONFIG remains available for registry auth.
+func (endpoint Endpoint) Environment(base []string) []string {
+	result := make([]string, 0, len(base)+1)
+	for _, entry := range base {
+		name, _, present := strings.Cut(entry, "=")
+		if !present || slices.Contains([]string{
+			"DOCKER_CONTEXT", "DOCKER_HOST", "DOCKER_TLS", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH",
+		}, name) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, "DOCKER_HOST="+endpoint.host)
+}
+
+type commandRunner func(context.Context, []string, ...string) ([]byte, error)
+
+type Options struct {
+	DockerBin       string
+	Environment     []string
+	ExplicitContext string
+	ExplicitHost    string
+	Run             commandRunner
+	Platform        string
+	HomeDir         string
+
+	trustedSocketPaths []string
+	evaluateSymlinks   func(string) (string, error)
+	stat               func(string) (os.FileInfo, error)
+}
+
+type resolver struct {
+	environment        []string
+	explicitContext    string
+	explicitHost       string
+	run                commandRunner
+	platform           string
+	homeDir            string
+	uid                int
+	trustedSocketPaths []string
+	evaluateSymlinks   func(string) (string, error)
+	stat               func(string) (os.FileInfo, error)
+}
+
+type contextDescription struct {
+	Name        string              `json:"Name"`
+	TLSMaterial map[string][]string `json:"TLSMaterial"`
+	Endpoints   struct {
+		Docker struct {
+			Host          string `json:"Host"`
+			SkipTLSVerify bool   `json:"SkipTLSVerify"`
+		} `json:"docker"`
+	} `json:"Endpoints"`
+}
+
+type serverDescription struct {
+	ID string `json:"ID"`
+}
+
+func Resolve(ctx context.Context, options Options) (Endpoint, error) {
+	return newResolver(options).Resolve(ctx)
+}
+
+// Verify rechecks socket trust and exact daemon identity without falling back
+// to ambient Docker selection.
+func Verify(ctx context.Context, endpoint Endpoint, options Options) error {
+	return newResolver(options).Verify(ctx, endpoint)
+}
+
+func newResolver(options Options) *resolver {
+	dockerBin := strings.TrimSpace(options.DockerBin)
+	if dockerBin == "" {
+		dockerBin = "docker"
+	}
+	environment := append([]string(nil), options.Environment...)
+	if options.Environment == nil {
+		environment = os.Environ()
+	}
+	platform := strings.TrimSpace(options.Platform)
+	if platform == "" {
+		platform = runtime.GOOS
+	}
+	homeDir := strings.TrimSpace(options.HomeDir)
+	if homeDir == "" {
+		homeDir, _ = os.UserHomeDir()
+	}
+	run := options.Run
+	if run == nil {
+		run = func(ctx context.Context, environment []string, arguments ...string) ([]byte, error) {
+			command := exec.CommandContext(ctx, dockerBin, arguments...)
+			command.Env = environment
+			output, err := command.Output()
+			if err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					return nil, fmt.Errorf("Docker command failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+				}
+				return nil, fmt.Errorf("run Docker command: %w", err)
+			}
+			return output, nil
+		}
+	}
+	result := &resolver{
+		environment:     environment,
+		explicitContext: options.ExplicitContext, explicitHost: options.ExplicitHost, run: run,
+		platform: platform, homeDir: homeDir, uid: platformUID(),
+		trustedSocketPaths: append([]string(nil), options.trustedSocketPaths...),
+		evaluateSymlinks:   options.evaluateSymlinks,
+		stat:               options.stat,
+	}
+	if result.evaluateSymlinks == nil {
+		result.evaluateSymlinks = filepath.EvalSymlinks
+	}
+	if result.stat == nil {
+		result.stat = os.Stat
+	}
+	return result
+}
+
+func (resolver *resolver) Resolve(ctx context.Context) (Endpoint, error) {
+	if resolver.platform != "linux" && resolver.platform != "darwin" {
+		return Endpoint{}, fmt.Errorf("local Docker development is unsupported on %s", resolver.platform)
+	}
+	if resolver.explicitContext != "" && resolver.explicitHost != "" {
+		return Endpoint{}, errors.New("choose either an explicit Docker context or host, not both")
+	}
+	if resolver.explicitContext != "" {
+		if resolver.explicitContext != strings.TrimSpace(resolver.explicitContext) {
+			return Endpoint{}, errors.New("explicit Docker context contains surrounding whitespace")
+		}
+		return resolver.resolveContext(ctx, resolver.explicitContext, SourceExplicitContext)
+	}
+	if resolver.explicitHost != "" {
+		if resolver.explicitHost != strings.TrimSpace(resolver.explicitHost) {
+			return Endpoint{}, errors.New("explicit Docker host contains surrounding whitespace")
+		}
+		return resolver.resolveHost(ctx, resolver.explicitHost, "", SourceExplicitHost)
+	}
+	if raw := resolver.optionValue("DOCKER_CONTEXT"); raw != "" {
+		if raw != strings.TrimSpace(raw) {
+			return Endpoint{}, errors.New("DOCKER_CONTEXT contains surrounding whitespace")
+		}
+		return resolver.resolveContext(ctx, raw, SourceEnvironmentContext)
+	}
+	if raw := resolver.optionValue("DOCKER_HOST"); raw != "" {
+		if raw != strings.TrimSpace(raw) {
+			return Endpoint{}, errors.New("DOCKER_HOST contains surrounding whitespace")
+		}
+		return resolver.resolveHost(ctx, raw, "", SourceEnvironmentHost)
+	}
+	output, err := resolver.run(ctx, withoutDockerSelection(resolver.environment), "context", "show")
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("resolve active Docker context: %w", err)
+	}
+	name := strings.TrimSpace(string(output))
+	if name == "" || strings.ContainsAny(name, "\r\n") {
+		return Endpoint{}, errors.New("Docker returned an invalid active context")
+	}
+	return resolver.resolveContext(ctx, name, SourceActiveContext)
+}
+
+func (resolver *resolver) resolveContext(ctx context.Context, name string, source Source) (Endpoint, error) {
+	if name == "" || name != strings.TrimSpace(name) || strings.ContainsAny(name, "\r\n") {
+		return Endpoint{}, errors.New("Docker context selection is invalid")
+	}
+	output, err := resolver.run(
+		ctx, withoutDockerSelection(resolver.environment),
+		"context", "inspect", name, "--format", dockerInfoFormat,
+	)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("inspect Docker context %q: %w", name, err)
+	}
+	var description contextDescription
+	if err := decodeOneJSON(output, &description); err != nil {
+		return Endpoint{}, fmt.Errorf("inspect Docker context %q: %w", name, err)
+	}
+	if description.Name != name {
+		return Endpoint{}, fmt.Errorf("Docker context inspection returned %q instead of %q", description.Name, name)
+	}
+	if description.Endpoints.Docker.SkipTLSVerify {
+		return Endpoint{}, fmt.Errorf("Docker context %q uses unsupported TLS endpoint settings", name)
+	}
+	if len(description.TLSMaterial) != 0 {
+		return Endpoint{}, fmt.Errorf("Docker context %q contains unsupported TLS material", name)
+	}
+	return resolver.resolveHost(ctx, description.Endpoints.Docker.Host, name, source)
+}
+
+func (resolver *resolver) resolveHost(ctx context.Context, rawHost, contextName string, source Source) (Endpoint, error) {
+	host, socketPath, kind, err := resolver.verifyLocalSocket(rawHost)
+	if err != nil {
+		return Endpoint{}, err
+	}
+	endpoint := Endpoint{context: contextName, host: host, socketPath: socketPath, source: source, kind: kind}
+	serverID, err := resolver.probe(ctx, endpoint)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("inspect verified local Docker endpoint %s: %w", redactedEndpoint(host), err)
+	}
+	endpoint.serverID = serverID
+	endpoint.verify = func(verifyContext context.Context) error {
+		return resolver.Verify(verifyContext, endpoint)
+	}
+	return endpoint, nil
+}
+
+func (resolver *resolver) Verify(ctx context.Context, endpoint Endpoint) error {
+	host, socketPath, kind, err := resolver.verifyLocalSocket(endpoint.host)
+	if err != nil {
+		return err
+	}
+	if host != endpoint.host || socketPath != endpoint.socketPath || kind != endpoint.kind {
+		return errors.New("verified Docker endpoint no longer matches its recorded identity")
+	}
+	serverID, err := resolver.probe(ctx, endpoint)
+	if err != nil {
+		return fmt.Errorf("reverify local Docker endpoint: %w", err)
+	}
+	if serverID != endpoint.serverID {
+		return fmt.Errorf("Docker daemon identity changed from %q to %q", endpoint.serverID, serverID)
+	}
+	return nil
+}
+
+func (resolver *resolver) probe(ctx context.Context, endpoint Endpoint) (string, error) {
+	output, err := resolver.run(
+		ctx, endpoint.Environment(resolver.environment),
+		endpoint.DockerArguments("info", "--format", dockerInfoFormat)...,
+	)
+	if err != nil {
+		return "", err
+	}
+	var description serverDescription
+	if err := decodeOneJSON(output, &description); err != nil {
+		return "", err
+	}
+	if description.ID == "" || description.ID != strings.TrimSpace(description.ID) {
+		return "", errors.New("Docker daemon returned no stable server identity")
+	}
+	return description.ID, nil
+}
+
+func (resolver *resolver) verifyLocalSocket(rawHost string) (string, string, Kind, error) {
+	parsed, err := url.Parse(rawHost)
+	if err != nil {
+		return "", "", "", errors.New("Docker endpoint is malformed")
+	}
+	if parsed.User != nil {
+		return "", "", "", errors.New("Docker endpoint contains credentials and is not supported")
+	}
+	if parsed.Scheme != "unix" {
+		return "", "", "", fmt.Errorf("Docker endpoint %s uses an unsupported local-development transport", redactedEndpoint(rawHost))
+	}
+	if parsed.Host != "" || parsed.Opaque != "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" {
+		return "", "", "", fmt.Errorf("Docker endpoint %s is not a canonical Unix socket", redactedEndpoint(rawHost))
+	}
+	path := filepath.Clean(parsed.Path)
+	if path == "." || !filepath.IsAbs(path) {
+		return "", "", "", errors.New("Docker Unix socket path must be absolute")
+	}
+	kind, trusted := resolver.trustedPath(path)
+	if !trusted {
+		return "", "", "", fmt.Errorf("Docker endpoint %s is not a recognized local Engine or Docker Desktop socket", redactedEndpoint(rawHost))
+	}
+	resolved, err := resolver.evaluateSymlinks(path)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve Docker socket %q: %w", path, err)
+	}
+	resolved = filepath.Clean(resolved)
+	resolvedKind, resolvedTrusted := resolver.trustedPath(resolved)
+	if !resolvedTrusted || resolvedKind != kind {
+		return "", "", "", fmt.Errorf("Docker socket %q resolves outside recognized local runtime paths", path)
+	}
+	info, err := resolver.stat(resolved)
+	if err != nil {
+		return "", "", "", fmt.Errorf("inspect Docker socket %q: %w", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return "", "", "", fmt.Errorf("Docker endpoint %q is not a Unix socket", path)
+	}
+	owner, ownerKnown := fileOwnerUID(info)
+	if ownerKnown && !resolver.trustedOwner(kind, owner) {
+		return "", "", "", fmt.Errorf("Docker socket %q has unexpected owner uid %d", path, owner)
+	}
+	return "unix://" + resolved, resolved, resolvedKind, nil
+}
+
+func (resolver *resolver) trustedPath(path string) (Kind, bool) {
+	for _, trusted := range resolver.trustedSocketPaths {
+		if filepath.Clean(trusted) == path {
+			return KindRootless, true
+		}
+	}
+	if path == "/var/run/docker.sock" || path == "/run/docker.sock" {
+		if resolver.platform == "darwin" {
+			return KindDesktop, true
+		}
+		return KindEngine, true
+	}
+	if resolver.homeDir != "" {
+		if resolver.platform == "linux" && path == filepath.Join(resolver.homeDir, ".docker", "desktop", "docker.sock") {
+			return KindDesktop, true
+		}
+		if resolver.platform == "darwin" && path == filepath.Join(resolver.homeDir, ".docker", "run", "docker.sock") {
+			return KindDesktop, true
+		}
+	}
+	if resolver.platform == "linux" && resolver.uid >= 0 && path == filepath.Join("/run/user", strconv.Itoa(resolver.uid), "docker.sock") {
+		return KindRootless, true
+	}
+	return "", false
+}
+
+func (resolver *resolver) trustedOwner(kind Kind, owner int) bool {
+	if resolver.uid < 0 {
+		return false
+	}
+	if kind == KindEngine && resolver.platform == "linux" {
+		return owner == 0
+	}
+	return owner == resolver.uid || (resolver.platform == "darwin" && owner == 0)
+}
+
+func (resolver *resolver) optionValue(name string) string {
+	var value string
+	for _, entry := range resolver.environment {
+		entryName, entryValue, present := strings.Cut(entry, "=")
+		if present && entryName == name {
+			value = entryValue
+		}
+	}
+	return value
+}
+
+func withoutDockerSelection(environment []string) []string {
+	result := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		name, _, present := strings.Cut(entry, "=")
+		if present && slices.Contains([]string{
+			"DOCKER_CONTEXT", "DOCKER_HOST", "DOCKER_TLS", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH",
+		}, name) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func decodeOneJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode Docker response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); errors.Is(err, io.EOF) {
+		return nil
+	}
+	return errors.New("Docker response contains more than one JSON value")
+}
+
+func redactedEndpoint(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid>"
+	}
+	if parsed.Opaque != "" {
+		if parsed.Scheme == "" {
+			return "<redacted>"
+		}
+		return parsed.Scheme + ":<redacted>"
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/app/cli/localdocker/endpoint_test.go
+++ b/internal/app/cli/localdocker/endpoint_test.go
@@ -1,0 +1,369 @@
+package localdocker
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type recordedCommand struct {
+	environment []string
+	arguments   []string
+}
+
+type fakeDocker struct {
+	commands []recordedCommand
+	active   string
+	contexts map[string]string
+	serverID string
+}
+
+func (docker *fakeDocker) run(_ context.Context, environment []string, arguments ...string) ([]byte, error) {
+	docker.commands = append(docker.commands, recordedCommand{
+		environment: append([]string(nil), environment...),
+		arguments:   append([]string(nil), arguments...),
+	})
+	if slices.Equal(arguments, []string{"context", "show"}) {
+		return []byte(docker.active + "\n"), nil
+	}
+	if len(arguments) == 5 && arguments[0] == "context" && arguments[1] == "inspect" {
+		payload := map[string]any{
+			"Name": arguments[2],
+			"Endpoints": map[string]any{"docker": map[string]any{
+				"Host": docker.contexts[arguments[2]], "SkipTLSVerify": false,
+			}},
+		}
+		return json.Marshal(payload)
+	}
+	if len(arguments) == 5 && arguments[0] == "--host" && arguments[2] == "info" {
+		return json.Marshal(map[string]any{"ID": docker.serverID, "OperatingSystem": "Docker Engine"})
+	}
+	return nil, nil
+}
+
+func TestResolveUsesDockerPrecedenceAndPinsTheEndpoint(t *testing.T) {
+	socket := testSocket(t)
+	tests := []struct {
+		name            string
+		explicitContext string
+		explicitHost    string
+		environment     []string
+		active          string
+		contexts        map[string]string
+		wantContext     string
+		wantSource      Source
+		wantShow        bool
+	}{
+		{
+			name: "explicit context overrides environment", explicitContext: "explicit",
+			environment: []string{"DOCKER_CONTEXT=ambient", "DOCKER_HOST=tcp://remote:2375"},
+			contexts:    map[string]string{"explicit": "unix://" + socket},
+			wantContext: "explicit", wantSource: SourceExplicitContext,
+		},
+		{
+			name: "explicit host overrides environment", explicitHost: "unix://" + socket,
+			environment: []string{"DOCKER_CONTEXT=ambient", "DOCKER_HOST=tcp://remote:2375"},
+			wantSource:  SourceExplicitHost,
+		},
+		{
+			name: "DOCKER_CONTEXT overrides DOCKER_HOST", environment: []string{"DOCKER_CONTEXT=desktop", "DOCKER_HOST=tcp://remote:2375"},
+			contexts:    map[string]string{"desktop": "unix://" + socket},
+			wantContext: "desktop", wantSource: SourceEnvironmentContext,
+		},
+		{
+			name: "DOCKER_HOST overrides active context", environment: []string{"DOCKER_HOST=unix://" + socket},
+			active: "remote", contexts: map[string]string{"remote": "tcp://remote:2375"},
+			wantSource: SourceEnvironmentHost,
+		},
+		{
+			name: "active context is the fallback", active: "engine",
+			contexts:    map[string]string{"engine": "unix://" + socket},
+			wantContext: "engine", wantSource: SourceActiveContext, wantShow: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			docker := &fakeDocker{active: tc.active, contexts: tc.contexts, serverID: "engine-1"}
+			endpoint, err := Resolve(t.Context(), Options{
+				Environment: tc.environment, ExplicitContext: tc.explicitContext, ExplicitHost: tc.explicitHost,
+				Run: docker.run, trustedSocketPaths: []string{socket},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if endpoint.Context() != tc.wantContext || endpoint.Source() != tc.wantSource {
+				t.Fatalf("selection = context %q source %q", endpoint.Context(), endpoint.Source())
+			}
+			if endpoint.Host() != "unix://"+socket || endpoint.ServerID() != "engine-1" {
+				t.Fatalf("endpoint = %#v", endpoint)
+			}
+			var sawShow bool
+			for _, command := range docker.commands {
+				if slices.Equal(command.arguments, []string{"context", "show"}) {
+					sawShow = true
+				}
+			}
+			if sawShow != tc.wantShow {
+				t.Fatalf("context show called = %v, want %v", sawShow, tc.wantShow)
+			}
+			last := docker.commands[len(docker.commands)-1]
+			if !slices.Equal(last.arguments, []string{"--host", "unix://" + socket, "info", "--format", "{{json .}}"}) {
+				t.Fatalf("probe arguments = %q", last.arguments)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsUntrustedEndpointsBeforeContact(t *testing.T) {
+	tests := []string{
+		"tcp://127.0.0.1:2375",
+		"tcp://remote.example:2376",
+		"ssh://developer@remote.example",
+		"unix:///tmp/docker.sock",
+	}
+	for _, host := range tests {
+		t.Run(host, func(t *testing.T) {
+			docker := &fakeDocker{serverID: "must-not-be-contacted"}
+			_, err := Resolve(t.Context(), Options{
+				Environment: []string{"DOCKER_HOST=" + host}, Run: docker.run,
+			})
+			if err == nil {
+				t.Fatal("untrusted endpoint was accepted")
+			}
+			if len(docker.commands) != 0 {
+				t.Fatalf("untrusted endpoint contacted Docker: %#v", docker.commands)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsRemoteContextsBeforeDaemonContact(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment []string
+		active      string
+	}{
+		{name: "DOCKER_CONTEXT", environment: []string{"DOCKER_CONTEXT=default"}},
+		{name: "active context", active: "default"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			docker := &fakeDocker{
+				active: tc.active, contexts: map[string]string{"default": "tcp://127.0.0.1:2375"},
+				serverID: "must-not-be-contacted",
+			}
+			_, err := Resolve(t.Context(), Options{Environment: tc.environment, Run: docker.run})
+			if err == nil {
+				t.Fatal("loopback remote context was accepted")
+			}
+			for _, command := range docker.commands {
+				if slices.Contains(command.arguments, "info") {
+					t.Fatalf("rejected context contacted its daemon: %#v", docker.commands)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRedactsRejectedEndpointCredentials(t *testing.T) {
+	docker := &fakeDocker{}
+	_, err := Resolve(t.Context(), Options{
+		Environment: []string{"DOCKER_HOST=tcp://author:super-secret@remote.example:2376/path?token=also-secret"},
+		Run:         docker.run,
+	})
+	if err == nil {
+		t.Fatal("credential-bearing endpoint was accepted")
+	}
+	message := err.Error()
+	for _, secret := range []string{"author", "super-secret", "also-secret"} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("error leaked %q: %s", secret, message)
+		}
+	}
+}
+
+func TestResolveRedactsOpaqueEndpointText(t *testing.T) {
+	docker := &fakeDocker{}
+	_, err := Resolve(t.Context(), Options{
+		Environment: []string{"DOCKER_HOST=unix:author:super-secret"}, Run: docker.run,
+	})
+	if err == nil {
+		t.Fatal("opaque endpoint was accepted")
+	}
+	if strings.Contains(err.Error(), "author") || strings.Contains(err.Error(), "super-secret") {
+		t.Fatalf("opaque endpoint leaked through error: %v", err)
+	}
+	if len(docker.commands) != 0 {
+		t.Fatalf("opaque endpoint contacted Docker: %#v", docker.commands)
+	}
+}
+
+func TestEndpointEnvironmentRemovesAmbientSelection(t *testing.T) {
+	endpoint := Endpoint{host: "unix:///run/user/1000/docker.sock"}
+	got := endpoint.Environment([]string{
+		"PATH=/usr/bin", "DOCKER_CONTEXT=remote", "DOCKER_HOST=tcp://remote:2375",
+		"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=/secret", "DOCKER_CONFIG=/config",
+	})
+	values := environmentMap(got)
+	if values["DOCKER_HOST"] != endpoint.Host() {
+		t.Fatalf("DOCKER_HOST = %q", values["DOCKER_HOST"])
+	}
+	for _, name := range []string{"DOCKER_CONTEXT", "DOCKER_TLS", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"} {
+		if _, exists := values[name]; exists {
+			t.Fatalf("pinned environment retained %s", name)
+		}
+	}
+	if values["DOCKER_CONFIG"] != "/config" || values["PATH"] != "/usr/bin" {
+		t.Fatalf("unrelated environment was not retained: %#v", values)
+	}
+}
+
+func TestVerifyRejectsChangedDaemonIdentity(t *testing.T) {
+	socket := testSocket(t)
+	docker := &fakeDocker{serverID: "engine-1"}
+	resolver := newResolver(Options{Run: docker.run, trustedSocketPaths: []string{socket}})
+	endpoint, err := resolver.resolveHost(t.Context(), "unix://"+socket, "", SourceEnvironmentHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	docker.serverID = "engine-2"
+	if err := resolver.Verify(t.Context(), endpoint); err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+func TestResolveRejectsExplicitHostAndContextConflictBeforeDocker(t *testing.T) {
+	docker := &fakeDocker{}
+	_, err := Resolve(t.Context(), Options{
+		ExplicitContext: "desktop-linux", ExplicitHost: "unix:///var/run/docker.sock",
+		Run: docker.run,
+	})
+	if err == nil || !strings.Contains(err.Error(), "either") {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(docker.commands) != 0 {
+		t.Fatalf("conflicting selection contacted Docker: %#v", docker.commands)
+	}
+}
+
+func TestTrustedSocketPoliciesAreExact(t *testing.T) {
+	linux := newResolver(Options{Platform: "linux", HomeDir: "/home/author", Environment: []string{}})
+	for path, want := range map[string]Kind{
+		"/var/run/docker.sock":                     KindEngine,
+		"/run/docker.sock":                         KindEngine,
+		"/home/author/.docker/desktop/docker.sock": KindDesktop,
+		filepath.Join("/run/user", strconv.Itoa(linux.uid), "docker.sock"): KindRootless,
+	} {
+		kind, ok := linux.trustedPath(path)
+		if !ok || kind != want {
+			t.Errorf("trustedPath(%q) = %q, %v; want %q", path, kind, ok, want)
+		}
+	}
+	for _, path := range []string{"/tmp/docker.sock", "/home/author/docker.sock", "/var/run/other.sock"} {
+		if _, ok := linux.trustedPath(path); ok {
+			t.Errorf("trustedPath(%q) unexpectedly succeeded", path)
+		}
+	}
+
+	darwin := newResolver(Options{Platform: "darwin", HomeDir: "/Users/author", Environment: []string{}})
+	for _, path := range []string{"/var/run/docker.sock", "/Users/author/.docker/run/docker.sock"} {
+		if kind, ok := darwin.trustedPath(path); !ok || kind != KindDesktop {
+			t.Errorf("Darwin trustedPath(%q) = %q, %v", path, kind, ok)
+		}
+	}
+}
+
+func TestEndpointFingerprintChangesWithDaemonIdentity(t *testing.T) {
+	first := Endpoint{host: "unix:///run/docker.sock", serverID: "one", kind: KindEngine}
+	same := Endpoint{host: "unix:///run/docker.sock", serverID: "one", kind: KindEngine}
+	changed := Endpoint{host: "unix:///run/docker.sock", serverID: "two", kind: KindEngine}
+	if first.Fingerprint() != same.Fingerprint() || first.Fingerprint() == changed.Fingerprint() {
+		t.Fatal("endpoint fingerprint does not bind exact daemon identity")
+	}
+}
+
+func TestResolveLocalDockerIntegration(t *testing.T) {
+	if os.Getenv("LEAPVIEW_TEST_CONTAINERS") != "1" {
+		t.Skip("set LEAPVIEW_TEST_CONTAINERS=1 to exercise the installed Docker runtime")
+	}
+	endpoint, err := Resolve(t.Context(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpoint.Host() == "" || endpoint.ServerID() == "" || endpoint.Fingerprint() == "" {
+		t.Fatalf("incomplete endpoint identity: %#v", endpoint)
+	}
+	if err := Verify(t.Context(), endpoint, Options{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolvedSocketPathIsPinnedAcrossSymlinkChange(t *testing.T) {
+	directory := t.TempDir()
+	first := filepath.Join(directory, "first.sock")
+	second := filepath.Join(directory, "second.sock")
+	for _, path := range []string{first, second} {
+		listener, err := net.Listen("unix", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = listener.Close() })
+	}
+	link := filepath.Join(directory, "docker.sock")
+	if err := os.Symlink(first, link); err != nil {
+		t.Fatal(err)
+	}
+	docker := &fakeDocker{serverID: "engine-1"}
+	resolver := newResolver(Options{
+		Environment: []string{}, Run: docker.run,
+		trustedSocketPaths: []string{link, first, second},
+	})
+	endpoint, err := resolver.resolveHost(t.Context(), "unix://"+link, "", SourceExplicitHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpoint.Host() != "unix://"+first {
+		t.Fatalf("resolved host = %q", endpoint.Host())
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(second, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := resolver.Verify(t.Context(), endpoint); err != nil {
+		t.Fatalf("pinned endpoint followed changed symlink: %v", err)
+	}
+	last := docker.commands[len(docker.commands)-1]
+	if !slices.Equal(last.arguments[:2], []string{"--host", "unix://" + first}) {
+		t.Fatalf("verification was redirected: %q", last.arguments)
+	}
+}
+
+func testSocket(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "docker.sock")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return path
+}
+
+func environmentMap(environment []string) map[string]string {
+	values := make(map[string]string, len(environment))
+	for _, entry := range environment {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = value
+		}
+	}
+	return values
+}

--- a/internal/app/cli/localdocker/socket_owner_unix.go
+++ b/internal/app/cli/localdocker/socket_owner_unix.go
@@ -1,0 +1,20 @@
+//go:build linux || darwin
+
+package localdocker
+
+import (
+	"os"
+	"syscall"
+)
+
+func platformUID() int {
+	return os.Getuid()
+}
+
+func fileOwnerUID(info os.FileInfo) (int, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(stat.Uid), true
+}

--- a/internal/app/cli/localdocker/socket_owner_unsupported.go
+++ b/internal/app/cli/localdocker/socket_owner_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package localdocker
+
+import "os"
+
+func platformUID() int {
+	return -1
+}
+
+func fileOwnerUID(os.FileInfo) (int, bool) {
+	return 0, false
+}


### PR DESCRIPTION
## Summary

- route bare `leapview dev` to local selection before ambient or stored target resolution while preserving explicit `--target` remote development
- resolve Docker endpoints with documented context/host precedence and fail closed on remote, forwarded, ambiguous, unsupported, or untrusted sockets before daemon contact
- pin the canonical socket and daemon identity for Docker and Compose subprocess paths, then reverify the identity before each operation
- strip ambient Docker routing/TLS variables and redact credential-bearing endpoint diagnostics

## Scope

This is the FAI-779 endpoint and dispatch foundation. It intentionally does not claim a usable local runtime: FAI-778 and FAI-780 still own released runtime packaging and bootstrap, and the local starter remains unavailable until that wiring lands. FAI-779 should remain In Progress pending integration, platform, release-artifact, and clean-machine evidence.

## Validation

- `PATH=/home/codex/.bun/bin:$PATH task ci`
- targeted and race tests for `internal/app/cli/localdocker`, `internal/app/cli/composectl`, and local/remote dev dispatch
- installed Docker Engine integration test with `LEAPVIEW_TEST_CONTAINERS=1`
- required regression baselines for `internal/project/devloop`, `internal/analytics/environment`, and `internal/analytics/connectionbinding`
- Linux plus Darwin/Windows cross-compilation checks
- independent base-to-head review: no remaining P0-P2 findings

## Safety boundaries

- bare local development cannot inherit an ambient production target
- explicit remote development performs no local Docker resolution
- remote or unsupported Docker endpoints fail before image pulls or mutations
- all subsequent Docker/Compose operations use the verified pinned endpoint and exact daemon identity
- no global Docker configuration is modified