### PR TITLE
feat(release): add authoritative transition preflight resolution

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1300,6 +1300,19 @@ tasks:
         -run '^TestFAI520ManagedDataS3DRSeedQualification$'
         -count=1 -timeout=15m -v
 
+  qualify:ubdr:release-transition-preflight:
+    desc: Qualify authoritative PostgreSQL-era transition resolution without executing a transition
+    deps:
+      - db:generate
+    env:
+      LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED: "1"
+    cmds:
+      - >-
+        go test -race -tags='fai518qualification'
+        ./internal/recoveryset/postgres
+        -run '^TestFAI518'
+        -count=1 -timeout=10m -v
+
   test:go:
     desc: Run Go tests with bounded package parallelism and stable application shards
     cmds:

--- a/docs/articles/operate/upgrades.md
+++ b/docs/articles/operate/upgrades.md
@@ -84,10 +84,35 @@ The evaluator emits exactly one decision:
   path safely.
 
 This FAI-518 preflight is the eligibility boundary for the later FAI-519
-transition execution work. It is pure and read-only: it does not inspect live
-PostgreSQL, run Goose or River migrations, contact a provider, acquire a
-fence, select an image, or mutate persistent state. FAI-519 must revalidate the
-same immutable evidence at its execution boundary.
+transition execution work. The read-only Go entrypoint accepts exact owner
+references rather than a caller-assembled evaluator input. It resolves the
+predecessor and candidate from the immutable OCI-admission authority, the
+target identity and compatibility projections from their migration owners,
+the matching release policy from its policy owner, and an exact recovery-set
+identity from PostgreSQL. The PostgreSQL recovery-frontier adapter accepts only
+a published set whose exact passed validation attempt, result digest, evidence
+envelope, frontier digest, and target binding all agree. Missing, ambiguous,
+mutable, stale, or mismatched owner results fail before evaluation. The
+qualification supplies isolated owner adapters; production composition still
+requires deployed OCI-admission, release-policy, target, and migration
+projection authorities and must not replace them with caller values.
+
+The resolver then calls the existing pure evaluator and returns its canonical
+evidence bytes and domain-separated digest; it does not define another evidence
+format. Owner adapters must not substitute project release rows, serving
+artifact digests, mutable image tags, or the latest recovery set for the
+required OCI admission, release policy, and exact frontier authorities. Run the
+bounded PostgreSQL-backed resolver qualification with:
+
+```sh
+task qualify:ubdr:release-transition-preflight
+```
+
+The entrypoint remains read-only: it does not run Goose or River migrations,
+contact a recovery provider, acquire an execution fence, switch an image, or
+mutate release or recovery state. FAI-519 must revalidate the same immutable
+evidence at its execution boundary. Preflight evidence does not execute a
+release transition.
 
 The DuckLake compatibility value is the owner-produced verdict over the exact
 predecessor and candidate tuples recorded in the evidence. The preflight does

--- a/internal/app/releasetransitionpreflight/published_frontier.go
+++ b/internal/app/releasetransitionpreflight/published_frontier.go
@@ -1,0 +1,125 @@
+package releasetransitionpreflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/release/transitionpreflight"
+)
+
+// PublishedRecoveryFrontierReader is the read-only recovery-set projection
+// needed to resolve a published frontier. Implementations must read the exact
+// IDs supplied by the caller; no latest/current selector is part of this
+// boundary.
+type PublishedRecoveryFrontierReader interface {
+	ReadRecoveryFrontierSnapshot(context.Context, string) (recoveryset.RecoverySet, recoveryset.ValidationAttempt, recoveryset.ValidationResult, error)
+}
+
+// PublishedRecoveryFrontierAuthority adapts the recovery-set owner's
+// read-only API to the transition preflight resolver contract. It performs no
+// writes and deliberately retains no mutable/latest state.
+type PublishedRecoveryFrontierAuthority struct {
+	reader PublishedRecoveryFrontierReader
+}
+
+// NewPublishedRecoveryFrontierAuthority constructs an authority over a
+// read-only recovery-set owner. A nil reader is retained as an unusable
+// authority and fails closed from ResolveRecoveryFrontier.
+func NewPublishedRecoveryFrontierAuthority(reader PublishedRecoveryFrontierReader) *PublishedRecoveryFrontierAuthority {
+	return &PublishedRecoveryFrontierAuthority{reader: reader}
+}
+
+// ResolveRecoveryFrontier proves that setRef names one exact, currently
+// published recovery set and its exact passed validation evidence for target.
+// The returned reference is always freshly bound to the digest computed from
+// target; caller-provided target binding is never trusted without comparison.
+func (a *PublishedRecoveryFrontierAuthority) ResolveRecoveryFrontier(ctx context.Context, setRef transitionpreflight.RecoveryFrontierRef, target transitionpreflight.TargetIdentity) (transitionpreflight.RecoveryFrontierRef, error) {
+	if a == nil || a.reader == nil {
+		return transitionpreflight.RecoveryFrontierRef{}, fmt.Errorf("%w: recovery frontier reader is unavailable", transitionpreflight.ErrResolutionNotFound)
+	}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("target identity", err)
+	}
+	// A resolver caller may supply an unbound set reference. Validate its
+	// canonical set/digest identity after filling the binding that this
+	// authority computes from target, while retaining a supplied binding for
+	// the explicit mismatch check below.
+	refToValidate := setRef
+	refToValidate.TargetIdentityDigest = targetDigest
+	if err := refToValidate.Validate(); err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier reference", err)
+	}
+	set, attempt, result, err := a.reader.ReadRecoveryFrontierSnapshot(ctx, setRef.SetID)
+	if err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, mapFrontierReadError("recovery frontier", err)
+	}
+	if set.ID != setRef.SetID {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier set identity", nil)
+	}
+	if err := set.Validate(); err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier", err)
+	}
+	if set.Status != recoveryset.StatusPublished {
+		return transitionpreflight.RecoveryFrontierRef{}, fmt.Errorf("%w: recovery frontier is %s", transitionpreflight.ErrStaleFrontier, set.Status)
+	}
+	computedDigest, err := set.Digest()
+	if err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier digest", err)
+	}
+	if strings.TrimSpace(set.FrontierDigest) == "" || set.FrontierDigest != computedDigest {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier digest", nil)
+	}
+	if setRef.Digest != set.FrontierDigest {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier reference digest", nil)
+	}
+	if set.Delivery.TargetID != target.TargetID || set.Delivery.TargetRevision != target.TargetRevision {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier target", nil)
+	}
+	if setRef.TargetIdentityDigest != "" && setRef.TargetIdentityDigest != targetDigest {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("recovery frontier target digest", nil)
+	}
+
+	attemptID := set.PublishedValidationAttemptID
+	if attemptID == "" {
+		return transitionpreflight.RecoveryFrontierRef{}, fmt.Errorf("%w: published recovery frontier has no validation attempt", transitionpreflight.ErrResolutionMismatch)
+	}
+	if attempt.AttemptID != attemptID || attempt.SetID != set.ID || attempt.FenceEpoch != set.FenceEpoch {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("validation attempt identity", nil)
+	}
+	if attempt.Status != recoveryset.ValidationPassed || attempt.Validate() != nil || attempt.ResultDigest == "" {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("validation attempt", nil)
+	}
+
+	if result.AttemptID != attemptID || result.ResultDigest != attempt.ResultDigest || result.Validate() != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("validation result identity", nil)
+	}
+	envelope, err := recoveryset.ParseValidationEvidenceEnvelope(result.Evidence)
+	if err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("validation evidence", err)
+	}
+	if err := envelope.ValidateFor(set, attemptID); err != nil {
+		return transitionpreflight.RecoveryFrontierRef{}, resolutionMismatch("validation evidence binding", err)
+	}
+	return transitionpreflight.RecoveryFrontierRef{SetID: set.ID, Digest: computedDigest, TargetIdentityDigest: targetDigest}, nil
+}
+
+func resolutionMismatch(scope string, cause error) error {
+	if cause == nil {
+		return fmt.Errorf("%w: %s", transitionpreflight.ErrResolutionMismatch, scope)
+	}
+	return fmt.Errorf("%w: %s: %v", transitionpreflight.ErrResolutionMismatch, scope, cause)
+}
+
+func mapFrontierReadError(scope string, err error) error {
+	if errors.Is(err, recoveryset.ErrNotFound) {
+		return fmt.Errorf("%w: %s", transitionpreflight.ErrResolutionNotFound, scope)
+	}
+	if errors.Is(err, recoveryset.ErrInvalid) {
+		return resolutionMismatch(scope, err)
+	}
+	return fmt.Errorf("%s: %w", scope, err)
+}

--- a/internal/recoveryset/postgres/frontier_snapshot.go
+++ b/internal/recoveryset/postgres/frontier_snapshot.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/jackc/pgx/v5"
+)
+
+type repeatableReadBeginner interface {
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}
+
+// ReadRecoveryFrontierSnapshot reads a recovery set and its selected
+// validation evidence from one read-only repeatable-read snapshot. Non-
+// published sets are returned without attempt/result data so callers can
+// classify their lifecycle state without racing a later owner read.
+func (r *Repository) ReadRecoveryFrontierSnapshot(ctx context.Context, setID string) (recoveryset.RecoverySet, recoveryset.ValidationAttempt, recoveryset.ValidationResult, error) {
+	if r == nil || r.db == nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, recoveryset.ErrInvalid
+	}
+	beginner, ok := r.db.(repeatableReadBeginner)
+	if !ok {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, errors.New("recovery frontier snapshot requires a transaction-capable PostgreSQL pool")
+	}
+	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	snapshot := New(tx)
+	set, err := snapshot.ReadExact(ctx, setID)
+	if err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	if set.Status != recoveryset.StatusPublished {
+		if err := tx.Commit(ctx); err != nil {
+			return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+		}
+		return set, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, nil
+	}
+	attempt, err := snapshot.ValidationAttempt(ctx, set.PublishedValidationAttemptID)
+	if err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	result, err := snapshot.ValidationResult(ctx, set.PublishedValidationAttemptID)
+	if err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	return set, attempt, result, nil
+}

--- a/internal/recoveryset/postgres/published_frontier_qualification_test.go
+++ b/internal/recoveryset/postgres/published_frontier_qualification_test.go
@@ -1,0 +1,257 @@
+//go:build fai518qualification
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flidai/leapview/internal/analytics/physicalpool"
+	releasetransitionapp "github.com/flidai/leapview/internal/app/releasetransitionpreflight"
+	"github.com/flidai/leapview/internal/platform/compatibility"
+	"github.com/flidai/leapview/internal/recoveryset"
+	"github.com/flidai/leapview/internal/release/transitionpreflight"
+)
+
+func TestFAI518AuthoritativeTransitionPreflightQualification(t *testing.T) {
+	db := recoverySetDB(t)
+	repository := New(db)
+	set := recoverySetFixture(t)
+	created, err := repository.Create(t.Context(), set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Date(2026, 9, 13, 1, 0, 0, 0, time.UTC)
+	attempt := recoveryset.ValidationAttempt{
+		AttemptID: "018f3f83-7b2f-7b37-9f9e-000000000500",
+		SetID:     created.ID, OwnerID: "qualification-validator", FenceEpoch: created.FenceEpoch,
+		AuditIdentity: created.AuditIdentity, Status: recoveryset.ValidationRunning, StartedAt: started,
+	}
+	if _, err := repository.BeginValidation(t.Context(), attempt); err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := recoveryset.NewValidationEvidenceEnvelope(created, attempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := recoveryset.NewValidationResult(envelope, started.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.RecordValidationResult(t.Context(), result); err != nil {
+		t.Fatal(err)
+	}
+	attempt.Status, attempt.ResultDigest, attempt.CompletedAt = recoveryset.ValidationPassed, result.ResultDigest, started.Add(2*time.Second)
+	if err := repository.CompleteValidation(t.Context(), attempt); err != nil {
+		t.Fatal(err)
+	}
+	published, err := repository.Publish(t.Context(), created.ID, "qualification-publisher", created.FenceEpoch, attempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := transitionpreflight.TargetIdentity{TargetID: published.Delivery.TargetID, TargetRevision: published.Delivery.TargetRevision}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := transitionpreflight.RecoveryFrontierRef{SetID: published.ID, Digest: published.FrontierDigest}
+	authority := releasetransitionapp.NewPublishedRecoveryFrontierAuthority(repository)
+	resolved, err := authority.ResolveRecoveryFrontier(t.Context(), ref, target)
+	if err != nil {
+		t.Fatalf("resolve published frontier: %v", err)
+	}
+	if resolved.SetID != published.ID || resolved.Digest != published.FrontierDigest || resolved.TargetIdentityDigest != targetDigest {
+		t.Fatalf("resolved frontier = %#v, want set=%s digest=%s target=%s", resolved, published.ID, published.FrontierDigest, targetDigest)
+	}
+	resolver, request := qualificationTransitionResolver(t, target, ref, authority)
+	first, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatalf("authoritative preflight: %v", err)
+	}
+	second, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatalf("authoritative preflight replay: %v", err)
+	}
+	if first.Evidence.Decision != transitionpreflight.DecisionBinaryRollbackCompatible || first.EvidenceDigest != second.EvidenceDigest || string(first.CanonicalEvidence) != string(second.CanonicalEvidence) {
+		t.Fatalf("preflight replay differs: first=%#v second=%#v", first, second)
+	}
+
+	prepared := recoverySetFixture(t)
+	prepared.ID = "018f3f83-7b2f-7b37-9f9e-000000000501"
+	preparedCreated, err := repository.Create(t.Context(), prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparedTarget := transitionpreflight.TargetIdentity{TargetID: preparedCreated.Delivery.TargetID, TargetRevision: preparedCreated.Delivery.TargetRevision}
+	preparedTargetDigest, err := preparedTarget.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparedRef := transitionpreflight.RecoveryFrontierRef{SetID: preparedCreated.ID, Digest: preparedCreated.FrontierDigest, TargetIdentityDigest: preparedTargetDigest}
+	if _, err := authority.ResolveRecoveryFrontier(t.Context(), preparedRef, preparedTarget); !errors.Is(err, transitionpreflight.ErrStaleFrontier) {
+		t.Fatalf("prepared frontier error = %v, want ErrStaleFrontier", err)
+	}
+
+	if err := repository.Supersede(t.Context(), published.ID, published.FenceEpoch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := authority.ResolveRecoveryFrontier(t.Context(), ref, target); !errors.Is(err, transitionpreflight.ErrStaleFrontier) {
+		t.Fatalf("superseded frontier error = %v, want ErrStaleFrontier", err)
+	}
+}
+
+func TestFAI518PublishedRecoveryFrontierRejectsTargetAndTamperedValidation(t *testing.T) {
+	db := recoverySetDB(t)
+	repository := New(db)
+	set := recoverySetFixture(t)
+	created, attempt, result := qualificationPublishedFrontier(t, repository, set)
+	target := transitionpreflight.TargetIdentity{TargetID: created.Delivery.TargetID, TargetRevision: created.Delivery.TargetRevision}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := transitionpreflight.RecoveryFrontierRef{SetID: created.ID, Digest: created.FrontierDigest, TargetIdentityDigest: targetDigest}
+	authority := releasetransitionapp.NewPublishedRecoveryFrontierAuthority(repository)
+
+	wrongTarget := target
+	wrongTarget.TargetID = "other-target"
+	if _, err := authority.ResolveRecoveryFrontier(t.Context(), ref, wrongTarget); !errors.Is(err, transitionpreflight.ErrResolutionMismatch) {
+		t.Fatalf("target mismatch error = %v, want ErrResolutionMismatch", err)
+	}
+
+	tampered := result
+	tampered.Evidence = append([]byte(nil), tampered.Evidence...)
+	tampered.Evidence[len(tampered.Evidence)/2] = 'x'
+	reader := qualificationRecoveryFrontierReader{Repository: repository, tamperedResult: &tampered, attempt: attempt}
+	tamperedAuthority := releasetransitionapp.NewPublishedRecoveryFrontierAuthority(reader)
+	if _, err := tamperedAuthority.ResolveRecoveryFrontier(t.Context(), ref, target); !errors.Is(err, transitionpreflight.ErrResolutionMismatch) {
+		t.Fatalf("tampered validation error = %v, want ErrResolutionMismatch", err)
+	}
+}
+
+func qualificationPublishedFrontier(t *testing.T, repository *Repository, set recoveryset.RecoverySet) (recoveryset.RecoverySet, recoveryset.ValidationAttempt, recoveryset.ValidationResult) {
+	t.Helper()
+	created, err := repository.Create(t.Context(), set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Date(2026, 9, 13, 2, 0, 0, 0, time.UTC)
+	attempt := recoveryset.ValidationAttempt{
+		AttemptID: "018f3f83-7b2f-7b37-9f9e-000000000502", SetID: created.ID,
+		OwnerID: "qualification-validator", FenceEpoch: created.FenceEpoch, AuditIdentity: created.AuditIdentity,
+		Status: recoveryset.ValidationRunning, StartedAt: started,
+	}
+	if _, err := repository.BeginValidation(t.Context(), attempt); err != nil {
+		t.Fatal(err)
+	}
+	envelope, err := recoveryset.NewValidationEvidenceEnvelope(created, attempt.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := recoveryset.NewValidationResult(envelope, started.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.RecordValidationResult(t.Context(), result); err != nil {
+		t.Fatal(err)
+	}
+	attempt.Status, attempt.ResultDigest, attempt.CompletedAt = recoveryset.ValidationPassed, result.ResultDigest, started.Add(2*time.Second)
+	if err := repository.CompleteValidation(t.Context(), attempt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.Publish(t.Context(), created.ID, "qualification-publisher", created.FenceEpoch, attempt.AttemptID); err != nil {
+		t.Fatal(err)
+	}
+	return createdWithPublishedStatus(t, repository, created.ID), attempt, result
+}
+
+func createdWithPublishedStatus(t *testing.T, repository *Repository, setID string) recoveryset.RecoverySet {
+	t.Helper()
+	set, err := repository.ReadExact(t.Context(), setID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return set
+}
+
+type qualificationRecoveryFrontierReader struct {
+	*Repository
+	tamperedResult *recoveryset.ValidationResult
+	attempt        recoveryset.ValidationAttempt
+}
+
+func (r qualificationRecoveryFrontierReader) ReadRecoveryFrontierSnapshot(ctx context.Context, setID string) (recoveryset.RecoverySet, recoveryset.ValidationAttempt, recoveryset.ValidationResult, error) {
+	set, _, _, err := r.Repository.ReadRecoveryFrontierSnapshot(ctx, setID)
+	if err != nil {
+		return recoveryset.RecoverySet{}, recoveryset.ValidationAttempt{}, recoveryset.ValidationResult{}, err
+	}
+	return set, r.attempt, *r.tamperedResult, nil
+}
+
+func qualificationTransitionResolver(t *testing.T, target transitionpreflight.TargetIdentity, frontier transitionpreflight.RecoveryFrontierRef, frontierAuthority transitionpreflight.RecoveryFrontierAuthority) (*transitionpreflight.Resolver, transitionpreflight.ResolutionRequest) {
+	t.Helper()
+	pred := transitionpreflight.ArtifactIdentity{Release: compatibility.ReleaseIdentity{
+		ReleaseID: "v1.0.0", Version: "1.0.0", SourceRevision: strings.Repeat("1", 40),
+		Image: "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("a", 64), Distribution: "public", Platform: "linux/amd64",
+	}, ArchitectureMarker: transitionpreflight.ArchitecturePostgreSQL, ArtifactAdmissionDigest: "sha256:" + strings.Repeat("d", 64)}
+	candidate := transitionpreflight.ArtifactIdentity{Release: compatibility.ReleaseIdentity{
+		ReleaseID: "v1.1.0", Version: "1.1.0", SourceRevision: strings.Repeat("2", 40),
+		Image: "ghcr.io/flidai/leapview@sha256:" + strings.Repeat("b", 64), Distribution: "public", Platform: "linux/amd64",
+	}, ArchitectureMarker: transitionpreflight.ArchitecturePostgreSQL, ArtifactAdmissionDigest: "sha256:" + strings.Repeat("e", 64)}
+	predDigest, err := pred.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateDigest, err := candidate.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := transitionpreflight.ReleasePolicy{Version: transitionpreflight.ReleasePolicyVersion, Rules: []transitionpreflight.ReleasePolicyRule{{
+		PredecessorArtifactDigest: predDigest, CandidateArtifactDigest: candidateDigest,
+		RollbackFromArtifactDigest: candidateDigest, RollbackToArtifactDigest: predDigest,
+		Decision: transitionpreflight.DecisionBinaryRollbackCompatible,
+	}}}
+	policy.Digest, err = policy.ContentDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tuple := physicalpool.Compatibility{DuckDBRuntime: "duckdb:1.5.4", DuckLakeExtension: "ducklake:0.3.0", CatalogFormat: "ducklake-catalog:v1", StorageImplementation: "s3", ObjectNamingContract: "uuidv7:v1"}
+	artifacts := transitionpreflight.ArtifactAuthorityFunc(func(_ context.Context, ref string) (transitionpreflight.ArtifactIdentity, error) {
+		if ref == "predecessor" {
+			return pred, nil
+		}
+		if ref == "candidate" {
+			return candidate, nil
+		}
+		return transitionpreflight.ArtifactIdentity{}, transitionpreflight.ErrResolutionNotFound
+	})
+	targets := transitionpreflight.TargetAuthorityFunc(func(_ context.Context, ref string) (transitionpreflight.TargetIdentity, error) {
+		if ref != "target" {
+			return transitionpreflight.TargetIdentity{}, transitionpreflight.ErrResolutionNotFound
+		}
+		return target, nil
+	})
+	migrations := transitionpreflight.MigrationAuthorityFunc(func(context.Context, transitionpreflight.TargetIdentity, transitionpreflight.ArtifactIdentity, transitionpreflight.ArtifactIdentity) (transitionpreflight.MigrationResolution, error) {
+		return transitionpreflight.MigrationResolution{
+			PredecessorArtifactDigest: predDigest, CandidateArtifactDigest: candidateDigest,
+			Ownership: transitionpreflight.MigrationOwnership{GooseControlSchemaOwner: transitionpreflight.OwnerLeapView, RiverOperationalSchemaOwner: transitionpreflight.OwnerRiver, RiverJobHistoryOwner: transitionpreflight.OwnerLeapView}, DuckLakeOwner: transitionpreflight.OwnerLeapView,
+			Control:  transitionpreflight.PostgreSQLControlProjection{Compatibility: transitionpreflight.CompatibilityBackwardCompatible, PredecessorSchemaVersion: "goose/v12", CandidateSchemaVersion: "goose/v13", TargetIdentityDigest: targetDigest},
+			River:    transitionpreflight.RiverJobProjection{SchemaCompatibility: transitionpreflight.CompatibilityBackwardCompatible, JobHistoryCompatibility: transitionpreflight.CompatibilityBackwardCompatible, ExistingSchemaVersion: "river/v6", RequiredSchemaVersion: "river/v7", ExistingJobHistoryVersion: "jobs/v12", RequiredJobHistoryVersion: "jobs/v13", TargetIdentityDigest: targetDigest},
+			DuckLake: transitionpreflight.DuckLakeProjection{Compatibility: transitionpreflight.CompatibilityBackwardCompatible, Predecessor: tuple, Candidate: tuple, TargetIdentityDigest: targetDigest},
+		}, nil
+	})
+	policies := transitionpreflight.ReleasePolicyAuthorityFunc(func(context.Context, transitionpreflight.ArtifactIdentity, transitionpreflight.ArtifactIdentity) (transitionpreflight.ReleasePolicy, error) {
+		return policy, nil
+	})
+	resolver := transitionpreflight.NewResolver(artifacts, targets, migrations, policies, frontierAuthority)
+	request := transitionpreflight.ResolutionRequest{PredecessorRef: "predecessor", CandidateRef: "candidate", TargetRef: "target", RecoveryFrontier: frontier}
+	return resolver, request
+}

--- a/internal/release/transitionpreflight/resolver.go
+++ b/internal/release/transitionpreflight/resolver.go
@@ -1,0 +1,295 @@
+package transitionpreflight
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	platformdigest "github.com/flidai/leapview/internal/platform/digest"
+	"github.com/flidai/leapview/internal/platform/ociref"
+)
+
+const targetIdentityDomain = "leapview/release-transition-target/v1\n"
+
+var (
+	ErrResolution             = errors.New("transition preflight resolution failed")
+	ErrResolutionNotFound     = errors.New("authoritative transition input not found")
+	ErrResolutionConflict     = errors.New("authoritative transition input is ambiguous or conflicting")
+	ErrInvalidOwnerProjection = errors.New("authoritative transition projection is invalid")
+	ErrMutableArtifact        = errors.New("release artifact identity is mutable")
+	ErrStaleFrontier          = errors.New("recovery frontier is not currently published")
+	ErrResolutionMismatch     = errors.New("authoritative transition identities do not match")
+)
+
+// ResolutionRequest contains only exact lookup references. Resolved release,
+// policy, migration, target, and recovery data always comes from its owner.
+type ResolutionRequest struct {
+	PredecessorRef   string
+	CandidateRef     string
+	TargetRef        string
+	RecoveryFrontier RecoveryFrontierRef
+}
+
+// TargetIdentity is the immutable target projection owned by deployment.
+// Its digest binds the target in every migration and recovery projection.
+type TargetIdentity struct {
+	TargetID       string `json:"targetId"`
+	TargetRevision int64  `json:"targetRevision"`
+}
+
+func (t TargetIdentity) Digest() (string, error) {
+	if err := canonicalText(t.TargetID); err != nil {
+		return "", fmt.Errorf("targetId: %w", err)
+	}
+	if t.TargetRevision <= 0 {
+		return "", errors.New("targetRevision must be positive")
+	}
+	encoded, err := json.Marshal(t)
+	if err != nil {
+		return "", fmt.Errorf("encode target identity: %w", err)
+	}
+	sum := sha256.Sum256(append([]byte(targetIdentityDomain), encoded...))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// MigrationResolution is the single owner-produced comparison across all
+// PostgreSQL-era persistent domains. DuckLakeOwner is resolution metadata;
+// the existing evidence format retains the exact DuckLake tuple instead of a
+// fourth ownership string.
+type MigrationResolution struct {
+	PredecessorArtifactDigest string
+	CandidateArtifactDigest   string
+	Ownership                 MigrationOwnership
+	DuckLakeOwner             string
+	Control                   PostgreSQLControlProjection
+	River                     RiverJobProjection
+	DuckLake                  DuckLakeProjection
+}
+
+type ArtifactAuthority interface {
+	ResolveArtifact(context.Context, string) (ArtifactIdentity, error)
+}
+
+type TargetAuthority interface {
+	ResolveTarget(context.Context, string) (TargetIdentity, error)
+}
+
+type MigrationAuthority interface {
+	ResolveMigration(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error)
+}
+
+type ReleasePolicyAuthority interface {
+	ResolveReleasePolicy(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error)
+}
+
+type RecoveryFrontierAuthority interface {
+	ResolveRecoveryFrontier(context.Context, RecoveryFrontierRef, TargetIdentity) (RecoveryFrontierRef, error)
+}
+
+// Function adapters keep composition narrow without giving the resolver a
+// database, filesystem, registry, or migration execution dependency.
+type ArtifactAuthorityFunc func(context.Context, string) (ArtifactIdentity, error)
+
+func (f ArtifactAuthorityFunc) ResolveArtifact(ctx context.Context, ref string) (ArtifactIdentity, error) {
+	if f == nil {
+		return ArtifactIdentity{}, ErrResolutionNotFound
+	}
+	return f(ctx, ref)
+}
+
+type TargetAuthorityFunc func(context.Context, string) (TargetIdentity, error)
+
+func (f TargetAuthorityFunc) ResolveTarget(ctx context.Context, ref string) (TargetIdentity, error) {
+	if f == nil {
+		return TargetIdentity{}, ErrResolutionNotFound
+	}
+	return f(ctx, ref)
+}
+
+type MigrationAuthorityFunc func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error)
+
+func (f MigrationAuthorityFunc) ResolveMigration(ctx context.Context, target TargetIdentity, predecessor, candidate ArtifactIdentity) (MigrationResolution, error) {
+	if f == nil {
+		return MigrationResolution{}, ErrResolutionNotFound
+	}
+	return f(ctx, target, predecessor, candidate)
+}
+
+type ReleasePolicyAuthorityFunc func(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error)
+
+func (f ReleasePolicyAuthorityFunc) ResolveReleasePolicy(ctx context.Context, predecessor, candidate ArtifactIdentity) (ReleasePolicy, error) {
+	if f == nil {
+		return ReleasePolicy{}, ErrResolutionNotFound
+	}
+	return f(ctx, predecessor, candidate)
+}
+
+type RecoveryFrontierAuthorityFunc func(context.Context, RecoveryFrontierRef, TargetIdentity) (RecoveryFrontierRef, error)
+
+func (f RecoveryFrontierAuthorityFunc) ResolveRecoveryFrontier(ctx context.Context, ref RecoveryFrontierRef, target TargetIdentity) (RecoveryFrontierRef, error) {
+	if f == nil {
+		return RecoveryFrontierRef{}, ErrResolutionNotFound
+	}
+	return f(ctx, ref, target)
+}
+
+// Resolver owns the read-only authoritative resolution sequence.
+type Resolver struct {
+	artifacts  ArtifactAuthority
+	targets    TargetAuthority
+	migrations MigrationAuthority
+	policies   ReleasePolicyAuthority
+	frontiers  RecoveryFrontierAuthority
+}
+
+func NewResolver(artifacts ArtifactAuthority, targets TargetAuthority, migrations MigrationAuthority, policies ReleasePolicyAuthority, frontiers RecoveryFrontierAuthority) *Resolver {
+	return &Resolver{artifacts: artifacts, targets: targets, migrations: migrations, policies: policies, frontiers: frontiers}
+}
+
+// ResolutionResult is an in-memory result, not another evidence wire format.
+// CanonicalEvidence is exactly Evidence.CanonicalJSON.
+type ResolutionResult struct {
+	Evidence          Evidence
+	CanonicalEvidence []byte
+	EvidenceDigest    string
+}
+
+// ResolveAndEvaluate resolves every input from its authority, checks all
+// cross-owner bindings, and then delegates to the existing evaluator.
+func (r *Resolver) ResolveAndEvaluate(ctx context.Context, request ResolutionRequest) (ResolutionResult, error) {
+	if r == nil || r.artifacts == nil || r.targets == nil || r.migrations == nil || r.policies == nil || r.frontiers == nil {
+		return ResolutionResult{}, fmt.Errorf("%w: required authority is unavailable", ErrResolution)
+	}
+	for _, field := range []struct{ name, value string }{
+		{"predecessorRef", request.PredecessorRef}, {"candidateRef", request.CandidateRef},
+		{"targetRef", request.TargetRef}, {"recoverySetId", request.RecoveryFrontier.SetID},
+	} {
+		if err := canonicalText(field.value); err != nil {
+			return ResolutionResult{}, fmt.Errorf("%w: %s", ErrResolution, field.name)
+		}
+	}
+
+	predecessor, err := r.artifacts.ResolveArtifact(ctx, request.PredecessorRef)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("predecessor", err)
+	}
+	if err := validateResolvedArtifact(predecessor); err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: predecessor: %w", ErrInvalidOwnerProjection, err)
+	}
+	candidate, err := r.artifacts.ResolveArtifact(ctx, request.CandidateRef)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("candidate", err)
+	}
+	if err := validateResolvedArtifact(candidate); err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: candidate: %w", ErrInvalidOwnerProjection, err)
+	}
+
+	target, err := r.targets.ResolveTarget(ctx, request.TargetRef)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("target", err)
+	}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: target: %v", ErrInvalidOwnerProjection, err)
+	}
+	if request.RecoveryFrontier.TargetIdentityDigest != "" && request.RecoveryFrontier.TargetIdentityDigest != targetDigest {
+		return ResolutionResult{}, fmt.Errorf("%w: requested recovery frontier target", ErrResolutionMismatch)
+	}
+	migration, err := r.migrations.ResolveMigration(ctx, target, predecessor, candidate)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("migration", err)
+	}
+	predecessorDigest, _ := predecessor.Digest()
+	candidateDigest, _ := candidate.Digest()
+	if err := validateMigrationResolution(migration, targetDigest, predecessorDigest, candidateDigest); err != nil {
+		return ResolutionResult{}, err
+	}
+
+	policy, err := r.policies.ResolveReleasePolicy(ctx, predecessor, candidate)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("release policy", err)
+	}
+	if policy.Version != ReleasePolicyVersion {
+		return ResolutionResult{}, fmt.Errorf("%w: unsupported release policy version", ErrInvalidOwnerProjection)
+	}
+	policyDigest, err := policy.ContentDigest()
+	if err != nil || policy.Digest != policyDigest {
+		return ResolutionResult{}, fmt.Errorf("%w: release policy digest", ErrInvalidOwnerProjection)
+	}
+
+	frontier, err := r.frontiers.ResolveRecoveryFrontier(ctx, request.RecoveryFrontier, target)
+	if err != nil {
+		return ResolutionResult{}, ownerFailure("recovery frontier", err)
+	}
+	if err := frontier.Validate(); err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: recovery frontier: %v", ErrInvalidOwnerProjection, err)
+	}
+	if frontier.SetID != request.RecoveryFrontier.SetID || frontier.Digest != request.RecoveryFrontier.Digest || frontier.TargetIdentityDigest != targetDigest {
+		return ResolutionResult{}, fmt.Errorf("%w: recovery frontier", ErrResolutionMismatch)
+	}
+
+	evidence, err := Evaluate(Input{
+		SchemaVersion: SchemaVersion, TargetIdentityDigest: targetDigest,
+		Predecessor: predecessor, Candidate: candidate,
+		MigrationOwnership: migration.Ownership, Control: migration.Control,
+		River: migration.River, DuckLake: migration.DuckLake,
+		RecoveryFrontier: &frontier, ReleasePolicy: policy,
+	})
+	if err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: evaluate: %v", ErrInvalidOwnerProjection, err)
+	}
+	canonical, err := evidence.CanonicalJSON()
+	if err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: canonical evidence: %v", ErrInvalidOwnerProjection, err)
+	}
+	digest, err := evidence.Digest()
+	if err != nil || platformdigest.ValidateSHA256Identity(digest) != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: evidence digest", ErrInvalidOwnerProjection)
+	}
+	parsed, err := ParseEvidence(canonical)
+	if err != nil {
+		return ResolutionResult{}, fmt.Errorf("%w: evaluator emitted unreadable evidence: %v", ErrInvalidOwnerProjection, err)
+	}
+	parsedDigest, err := parsed.Digest()
+	if err != nil || parsedDigest != digest {
+		return ResolutionResult{}, fmt.Errorf("%w: evidence round trip", ErrResolutionMismatch)
+	}
+	return ResolutionResult{Evidence: evidence, CanonicalEvidence: append([]byte(nil), canonical...), EvidenceDigest: digest}, nil
+}
+
+func validateResolvedArtifact(artifact ArtifactIdentity) error {
+	if err := ociref.ValidateImmutable(artifact.Release.Image); err != nil {
+		return fmt.Errorf("%w: image", ErrMutableArtifact)
+	}
+	_, err := artifact.Digest()
+	return err
+}
+
+func validateMigrationResolution(m MigrationResolution, targetDigest, predecessorDigest, candidateDigest string) error {
+	if m.PredecessorArtifactDigest != predecessorDigest || m.CandidateArtifactDigest != candidateDigest {
+		return fmt.Errorf("%w: migration artifact pair", ErrResolutionMismatch)
+	}
+	if m.Ownership.GooseControlSchemaOwner == "" || m.Ownership.RiverOperationalSchemaOwner == "" || m.Ownership.RiverJobHistoryOwner == "" || strings.TrimSpace(m.DuckLakeOwner) == "" {
+		return fmt.Errorf("%w: migration ownership is incomplete", ErrInvalidOwnerProjection)
+	}
+	if m.Ownership.GooseControlSchemaOwner != GooseControlSchemaOwnerLeapView || m.Ownership.RiverOperationalSchemaOwner != RiverOperationalSchemaOwnerRiver || m.Ownership.RiverJobHistoryOwner != RiverJobHistoryOwnerLeapView || m.DuckLakeOwner != OwnerLeapView {
+		return fmt.Errorf("%w: migration ownership", ErrResolutionConflict)
+	}
+	for _, digest := range []string{m.Control.TargetIdentityDigest, m.River.TargetIdentityDigest, m.DuckLake.TargetIdentityDigest} {
+		if digest != targetDigest {
+			return fmt.Errorf("%w: migration target", ErrResolutionMismatch)
+		}
+	}
+	return nil
+}
+
+func ownerFailure(stage string, err error) error {
+	if err == nil {
+		return fmt.Errorf("%w: %s", ErrResolution, stage)
+	}
+	return fmt.Errorf("%w: %s: %w", ErrResolution, stage, err)
+}

--- a/internal/release/transitionpreflight/resolver_test.go
+++ b/internal/release/transitionpreflight/resolver_test.go
@@ -1,0 +1,245 @@
+package transitionpreflight
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAuthoritativeResolverEvaluatesOwnerProjectionsDeterministically(t *testing.T) {
+	resolver, request, _ := resolverFixture(t)
+	targetDigest, err := (TargetIdentity{TargetID: "target", TargetRevision: 1}).Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetDigest != "sha256:5054051d5bb2ded8859edfbe25d2afda75f25636bcb927bffaffb766f7f0eabf" {
+		t.Fatalf("target identity digest = %s", targetDigest)
+	}
+	first, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Evidence.Decision != DecisionBinaryRollbackCompatible {
+		t.Fatalf("decision = %q", first.Evidence.Decision)
+	}
+	if first.EvidenceDigest != second.EvidenceDigest || string(first.CanonicalEvidence) != string(second.CanonicalEvidence) {
+		t.Fatal("identical authoritative inputs produced different evidence")
+	}
+	parsed, err := ParseEvidence(first.CanonicalEvidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest, err := parsed.Digest(); err != nil || digest != first.EvidenceDigest {
+		t.Fatalf("round-trip digest = %q, %v", digest, err)
+	}
+}
+
+func TestAuthoritativeResolverPreservesProviderRecoveryDecision(t *testing.T) {
+	resolver, request, input := resolverFixture(t)
+	input.Control.Compatibility = CompatibilityIncompatible
+	input.ReleasePolicy.Rules[0].Decision = DecisionProviderRecoveryRequired
+	input.ReleasePolicy.Digest, _ = input.ReleasePolicy.ContentDigest()
+	resolver.migrations = MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+		return migrationFromInput(input), nil
+	})
+	resolver.policies = ReleasePolicyAuthorityFunc(func(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error) {
+		return input.ReleasePolicy, nil
+	})
+	result, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Evidence.Decision != DecisionProviderRecoveryRequired {
+		t.Fatalf("decision = %q", result.Evidence.Decision)
+	}
+}
+
+func TestAuthoritativeResolverRejectsOwnerFailuresBeforeEvaluation(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*Resolver, *ResolutionRequest, *Input)
+		want   error
+	}{
+		"missing predecessor": {func(r *Resolver, _ *ResolutionRequest, _ *Input) {
+			r.artifacts = ArtifactAuthorityFunc(func(_ context.Context, ref string) (ArtifactIdentity, error) {
+				if ref == "predecessor" {
+					return ArtifactIdentity{}, ErrResolutionNotFound
+				}
+				return testInput().Candidate, nil
+			})
+		}, ErrResolutionNotFound},
+		"missing candidate": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			r.artifacts = ArtifactAuthorityFunc(func(_ context.Context, ref string) (ArtifactIdentity, error) {
+				if ref == "candidate" {
+					return ArtifactIdentity{}, ErrResolutionNotFound
+				}
+				return in.Predecessor, nil
+			})
+		}, ErrResolutionNotFound},
+		"ambiguous candidate": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			r.artifacts = ArtifactAuthorityFunc(func(_ context.Context, ref string) (ArtifactIdentity, error) {
+				if ref == "candidate" {
+					return ArtifactIdentity{}, ErrResolutionConflict
+				}
+				return in.Predecessor, nil
+			})
+		}, ErrResolutionConflict},
+		"mutable candidate": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			r.artifacts = ArtifactAuthorityFunc(func(_ context.Context, ref string) (ArtifactIdentity, error) {
+				if ref == "predecessor" {
+					return in.Predecessor, nil
+				}
+				candidate := in.Candidate
+				candidate.Release.Image = "ghcr.io/flidai/leapview:latest"
+				return candidate, nil
+			})
+		}, ErrMutableArtifact},
+		"ownership conflict": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			m := migrationFromInput(*in)
+			m.Ownership.GooseControlSchemaOwner = OwnerRiver
+			r.migrations = MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+				return m, nil
+			})
+		}, ErrResolutionConflict},
+		"unknown ducklake authority": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			m := migrationFromInput(*in)
+			m.DuckLakeOwner = ""
+			r.migrations = MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+				return m, nil
+			})
+		}, ErrInvalidOwnerProjection},
+		"missing frontier": {func(r *Resolver, _ *ResolutionRequest, _ *Input) {
+			r.frontiers = RecoveryFrontierAuthorityFunc(func(context.Context, RecoveryFrontierRef, TargetIdentity) (RecoveryFrontierRef, error) {
+				return RecoveryFrontierRef{}, ErrResolutionNotFound
+			})
+		}, ErrResolutionNotFound},
+		"stale frontier": {func(r *Resolver, _ *ResolutionRequest, _ *Input) {
+			r.frontiers = RecoveryFrontierAuthorityFunc(func(context.Context, RecoveryFrontierRef, TargetIdentity) (RecoveryFrontierRef, error) {
+				return RecoveryFrontierRef{}, ErrStaleFrontier
+			})
+		}, ErrStaleFrontier},
+		"frontier target mismatch": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			r.frontiers = RecoveryFrontierAuthorityFunc(func(_ context.Context, ref RecoveryFrontierRef, _ TargetIdentity) (RecoveryFrontierRef, error) {
+				ref.TargetIdentityDigest = "sha256:" + strings.Repeat("9", 64)
+				return ref, nil
+			})
+			_ = in
+		}, ErrResolutionMismatch},
+		"requested frontier target mismatch": {func(_ *Resolver, request *ResolutionRequest, _ *Input) {
+			request.RecoveryFrontier.TargetIdentityDigest = "sha256:" + strings.Repeat("6", 64)
+		}, ErrResolutionMismatch},
+		"migration artifact mismatch": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			m := migrationFromInput(*in)
+			m.CandidateArtifactDigest = "sha256:" + strings.Repeat("7", 64)
+			r.migrations = MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+				return m, nil
+			})
+		}, ErrResolutionMismatch},
+		"unsupported policy": {func(r *Resolver, _ *ResolutionRequest, in *Input) {
+			policy := in.ReleasePolicy
+			policy.Version = "release-policy/v9"
+			r.policies = ReleasePolicyAuthorityFunc(func(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error) { return policy, nil })
+		}, ErrInvalidOwnerProjection},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			resolver, request, input := resolverFixture(t)
+			tc.mutate(resolver, &request, &input)
+			if _, err := resolver.ResolveAndEvaluate(t.Context(), request); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthoritativeResolverEmitsUnsupportedEvidenceForPolicyMismatch(t *testing.T) {
+	resolver, request, input := resolverFixture(t)
+	policy := input.ReleasePolicy
+	policy.Rules[0].CandidateArtifactDigest = "sha256:" + strings.Repeat("8", 64)
+	policy.Digest, _ = policy.ContentDigest()
+	resolver.policies = ReleasePolicyAuthorityFunc(func(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error) { return policy, nil })
+	result, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Evidence.Decision != DecisionUnsupported || !containsReason(result.Evidence.ReasonCodes, ReasonPolicyMismatch) {
+		t.Fatalf("evidence = %#v", result.Evidence)
+	}
+}
+
+func TestAuthoritativeResolverEmitsUnsupportedEvidenceForUnknownMigrationState(t *testing.T) {
+	resolver, request, input := resolverFixture(t)
+	migration := migrationFromInput(input)
+	migration.Control.Compatibility = CompatibilityUnknown
+	resolver.migrations = MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+		return migration, nil
+	})
+	result, err := resolver.ResolveAndEvaluate(t.Context(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Evidence.Decision != DecisionUnsupported || !containsReason(result.Evidence.ReasonCodes, ReasonUnknownControlCompatibility) {
+		t.Fatalf("evidence = %#v", result.Evidence)
+	}
+}
+
+func TestAuthoritativeResolverRejectsTypedNilAuthority(t *testing.T) {
+	resolver, request, _ := resolverFixture(t)
+	resolver.artifacts = ArtifactAuthorityFunc(nil)
+	if _, err := resolver.ResolveAndEvaluate(t.Context(), request); !errors.Is(err, ErrResolutionNotFound) {
+		t.Fatalf("error = %v, want ErrResolutionNotFound", err)
+	}
+}
+
+func resolverFixture(t *testing.T) (*Resolver, ResolutionRequest, Input) {
+	t.Helper()
+	input := testInput()
+	target := TargetIdentity{TargetID: "target", TargetRevision: 1}
+	targetDigest, err := target.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.TargetIdentityDigest = targetDigest
+	input.Control.TargetIdentityDigest = targetDigest
+	input.River.TargetIdentityDigest = targetDigest
+	input.DuckLake.TargetIdentityDigest = targetDigest
+	input.RecoveryFrontier.TargetIdentityDigest = targetDigest
+	request := ResolutionRequest{PredecessorRef: "predecessor", CandidateRef: "candidate", TargetRef: "target", RecoveryFrontier: *input.RecoveryFrontier}
+	artifacts := ArtifactAuthorityFunc(func(_ context.Context, ref string) (ArtifactIdentity, error) {
+		switch ref {
+		case "predecessor":
+			return input.Predecessor, nil
+		case "candidate":
+			return input.Candidate, nil
+		default:
+			return ArtifactIdentity{}, ErrResolutionNotFound
+		}
+	})
+	targets := TargetAuthorityFunc(func(_ context.Context, ref string) (TargetIdentity, error) {
+		if ref != "target" {
+			return TargetIdentity{}, ErrResolutionNotFound
+		}
+		return target, nil
+	})
+	migrations := MigrationAuthorityFunc(func(context.Context, TargetIdentity, ArtifactIdentity, ArtifactIdentity) (MigrationResolution, error) {
+		return migrationFromInput(input), nil
+	})
+	policies := ReleasePolicyAuthorityFunc(func(context.Context, ArtifactIdentity, ArtifactIdentity) (ReleasePolicy, error) {
+		return input.ReleasePolicy, nil
+	})
+	frontiers := RecoveryFrontierAuthorityFunc(func(_ context.Context, ref RecoveryFrontierRef, _ TargetIdentity) (RecoveryFrontierRef, error) {
+		ref.TargetIdentityDigest = targetDigest
+		return ref, nil
+	})
+	return NewResolver(artifacts, targets, migrations, policies, frontiers), request, input
+}
+
+func migrationFromInput(input Input) MigrationResolution {
+	predDigest, _ := input.Predecessor.Digest()
+	candidateDigest, _ := input.Candidate.Digest()
+	return MigrationResolution{PredecessorArtifactDigest: predDigest, CandidateArtifactDigest: candidateDigest, Ownership: input.MigrationOwnership, DuckLakeOwner: OwnerLeapView, Control: input.Control, River: input.River, DuckLake: input.DuckLake}
+}


### PR DESCRIPTION
## Problem

The PostgreSQL-era transition preflight evaluator accepted caller-assembled inputs. It did not authoritatively resolve immutable predecessor/candidate artifacts, migration ownership, release policy, or the exact published RecoverySet frontier.

## Root cause

The evaluator intentionally remained pure and read-only, but no owner-backed orchestration boundary existed to construct its input from authoritative sources.

## Solution

- Add a bounded resolver over explicit artifact, target, migration, policy, and recovery-frontier authorities.
- Require immutable OCI artifact identities and exact target/migration bindings.
- Resolve the published RecoverySet frontier in a read-only, repeatable-read PostgreSQL snapshot and validate publication, selected attempt, evidence envelope, frontier digest, and target identity.
- Invoke the existing evaluator and return its existing canonical evidence bytes and domain-separated digest; no new evidence format is introduced.
- Add `task qualify:ubdr:release-transition-preflight` and document the authoritative-resolution boundary.

## Evidence output

The entrypoint emits the existing canonical transition-preflight evidence containing the resolved predecessor/candidate, migration ownership, recovery frontier, evaluator decision, and deterministic digest. It reparses the generated evidence before return to preserve consumer compatibility.

## Tests added and verification

Passed on the exact pre-delivery diff:

- `go test -race ./internal/release/transitionpreflight -count=2`
- `LEAPVIEW_POSTGRES_CONFORMANCE_REQUIRED=1 go test -race -tags=fai518qualification ./internal/recoveryset/postgres -run '^TestFAI518' -count=2 -timeout=10m`
- RecoverySet tests
- `go test ./internal/platform/architecture -count=1`
- focused `go vet`
- `task generated:check`
- `task docs:check`
- `git diff --check`
- full `task ci` (exit 0)

The qualification covers successful authoritative resolution, deterministic replay, prepared/superseded or tampered frontier rejection, target mismatch, missing or mutable artifacts, ownership conflicts, unsupported policy versions, and fail-closed adapter behavior.

## Remaining limitations

Production composition still requires deployed immutable OCI-admission, release-policy, target, and migration-projection authorities. Transition execution, migration fencing, candidate restart verification, rollback/provider-recovery execution, and FAI-519 interruption qualification remain outside this slice.

**Preflight evidence does not execute a release transition.**
